### PR TITLE
Use Docker database defaults for containerized deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ EXPOSE 5000
 # Default environment variables
 ENV FLASK_APP=app.py \
     FLASK_RUN_HOST=0.0.0.0 \
-    FLASK_RUN_PORT=5000
+    FLASK_RUN_PORT=5000 \
+    DATABASE_URL=postgresql+psycopg2://casaos:casaos@postgresql:5432/casaos
 
 # Use Gunicorn for production-ready serving
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -121,12 +121,15 @@ environment variable. If you do not already have a database running, you can
 start a disposable PostgreSQL container for local testing:
 
 ```bash
-docker run --name noaa-db -e POSTGRES_DB=noaa_alerts \
-    -e POSTGRES_USER=noaa_user -e POSTGRES_PASSWORD=change_me \
+docker run --name noaa-db -e POSTGRES_DB=casaos \
+    -e POSTGRES_USER=casaos -e POSTGRES_PASSWORD=casaos \
     -p 5432:5432 -d postgres:15
 ```
 
-Update the credentials and port as needed for your environment.
+Update the credentials and port as needed for your environment. If you are
+running the application and database in Docker, use the service/container name
+(`postgresql` in the provided compose file) as the hostname in
+`DATABASE_URL`.
 
 ### 3. Start the NOAA Alerts container
 
@@ -135,16 +138,16 @@ connection string and any other configuration you require:
 
 ```bash
 docker run --name noaa-alerts --rm -p 5000:5000 \
-    -e DATABASE_URL=postgresql://noaa_user:change_me@host.docker.internal:5432/noaa_alerts \
+    -e DATABASE_URL=postgresql+psycopg2://casaos:casaos@postgresql:5432/casaos \
     -e SECRET_KEY=replace-this-with-a-secret-value \
     -e LED_SIGN_IP=192.168.1.100 \
     -e LED_SIGN_PORT=10001 \
     noaa-alerts:latest
 ```
 
-* Use `host.docker.internal` if the PostgreSQL instance is running on your host
-  machine. Replace it with the appropriate hostname/IP when running in other
-  environments.
+* Replace the `DATABASE_URL` hostname (`postgresql`) if your database is hosted
+  elsewhere. Avoid using `localhost` inside containers; use the appropriate
+  Docker service name or network alias instead.
 * Remove or adjust the `LED_SIGN_*` variables if you do not have the hardware
   attached.
 

--- a/app.py
+++ b/app.py
@@ -50,7 +50,10 @@ app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-key-change-in-production')
 
 # Database configuration
-DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://noaa_user:rkhkeq@localhost:5432/noaa_alerts')
+DATABASE_URL = os.getenv(
+    'DATABASE_URL',
+    'postgresql+psycopg2://casaos:casaos@postgresql:5432/casaos'
+)
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 

--- a/configure.py
+++ b/configure.py
@@ -17,8 +17,10 @@ class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-key-change-in-production')
 
     # Database settings
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL',
-                                             'postgresql://noaa_user:your_secure_password@localhost/noaa_alerts')
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        'DATABASE_URL',
+        'postgresql+psycopg2://casaos:casaos@postgresql:5432/casaos'
+    )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ENGINE_OPTIONS = {
         'pool_pre_ping': True,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,18 +11,18 @@ services:
     environment:
       FLASK_ENV: production
       SECRET_KEY: change-me
-      DATABASE_URL: postgresql://noaa_user:change_me@db:5432/noaa_alerts
+      DATABASE_URL: postgresql+psycopg2://casaos:casaos@postgresql:5432/casaos
       LED_SIGN_IP: 192.168.1.100
       LED_SIGN_PORT: 10001
     depends_on:
-      - db
+      - postgresql
 
-  db:
+  postgresql:
     image: postgres:15
     environment:
-      POSTGRES_DB: noaa_alerts
-      POSTGRES_USER: noaa_user
-      POSTGRES_PASSWORD: change_me
+      POSTGRES_DB: casaos
+      POSTGRES_USER: casaos
+      POSTGRES_PASSWORD: casaos
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary
- update Flask configuration defaults to use the Docker Postgres service connection string
- align docker-compose, Dockerfile, and documentation with the casaos Postgres credentials and service name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd07552ebc8320a175f90b950756c4