### PR TITLE
Add client-side export helper and robust LED controller fallback

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -378,6 +378,52 @@
             });
         }
 
+        // Simple CSV export utility so "Export" buttons work consistently
+        function exportToExcel(data, baseFilename = 'export') {
+            if (!Array.isArray(data) || data.length === 0) {
+                showToast('No data available to export.', 'warning');
+                return;
+            }
+
+            const headers = Object.keys(data[0]);
+            if (headers.length === 0) {
+                showToast('Export failed: no columns detected.', 'error');
+                return;
+            }
+
+            const escapeCell = (value) => {
+                if (value === null || value === undefined) {
+                    return '""';
+                }
+
+                const stringValue = String(value).replace(/"/g, '""');
+                return `"${stringValue}"`;
+            };
+
+            const csvRows = [headers.map(escapeCell).join(',')];
+
+            data.forEach((row) => {
+                const rowValues = headers.map((header) => escapeCell(row[header] ?? ''));
+                csvRows.push(rowValues.join(','));
+            });
+
+            const csvContent = '\ufeff' + csvRows.join('\n');
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+
+            const timestamp = new Date().toISOString().split('T')[0];
+            const filename = `${baseFilename}_${timestamp}.csv`;
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', filename);
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+
+            URL.revokeObjectURL(url);
+        }
+
         // System health check
         async function checkSystemHealth() {
             try {
@@ -431,6 +477,7 @@
         // Make functions available globally
         window.showToast = showToast;
         window.toggleTheme = toggleTheme;
+        window.exportToExcel = exportToExcel;
     </script>
 
     <!-- 3. Page-specific scripts -->


### PR DESCRIPTION
## Summary
- add a reusable CSV export helper to the base template so alert exports work in the browser
- streamline LED controller initialization with a shared fallback MessagePriority implementation when the hardware module is missing or fails to start

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68fe109a99c08320b00a36c34bac61d0