### PR TITLE
Replace deprecated Flask before_first_request hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -3390,7 +3390,10 @@ def after_request(response):
     return response
 
 
-@app.before_first_request
+# Flask 3 removed the ``before_first_request`` hook, so we run our
+# initialization using ``before_serving`` which executes once when the
+# server starts handling requests.
+@app.before_serving
 def initialize_database():
     """Ensure all database tables exist when the app starts."""
     try:


### PR DESCRIPTION
## Summary
- replace the removed Flask `before_first_request` decorator with `before_serving`
- document the change to clarify why the hook was updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe21621e148320acb9a68c505540b2