### PR TITLE
Add admin UI for editing and deleting alerts

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -550,45 +550,20 @@
                                 </div>
                             </div>
                             <div class="row g-2 mt-2">
-                                <div class="col-md-3">
-                                    <label class="form-label">Area (State)</label>
-                                    <input type="text" class="form-control" id="manualAlertArea" value="OH" placeholder="OH" maxlength="2">
+                                <div class="col-md-4">
+                                    <label class="form-label">State (2-letter)</label>
+                                    <input type="text" class="form-control" id="manualAlertArea" value="OH" placeholder="e.g. OH" maxlength="2">
                                 </div>
-                                <div class="col-md-3">
-                                    <label class="form-label">Zone (UGC)</label>
-                                    <input type="text" class="form-control" id="manualAlertZone" value="OHC137" placeholder="OHC137">
-                                </div>
-                                <div class="col-md-3">
-                                    <label class="form-label">Status</label>
-                                    <select class="form-select" id="manualAlertStatus">
-                                        <option value="actual" selected>Actual</option>
-                                        <option value="any">Any</option>
-                                        <option value="test">Test</option>
-                                        <option value="exercise">Exercise</option>
-                                        <option value="system">System</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-3">
-                                    <label class="form-label">Message Type</label>
-                                    <select class="form-select" id="manualAlertMessageType">
-                                        <option value="alert" selected>Alert</option>
-                                        <option value="any">Any</option>
-                                        <option value="update">Update</option>
-                                        <option value="cancel">Cancel</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="row g-2 mt-2">
-                                <div class="col-md-6">
-                                    <label class="form-label">Event Filter</label>
+                                <div class="col-md-4">
+                                    <label class="form-label">Event Filter (optional)</label>
                                     <input type="text" class="form-control" id="manualAlertEvent" placeholder="e.g. Tornado Warning">
                                 </div>
-                                <div class="col-md-6">
+                                <div class="col-md-4">
                                     <label class="form-label">Result Limit</label>
                                     <input type="number" class="form-control" id="manualAlertLimit" min="1" max="50" value="5">
                                 </div>
                             </div>
-                            <div class="form-text mt-2">Provide an identifier for the fastest lookup, or specify a start and end range (with optional state area or UGC zone) to search the NOAA archive.</div>
+                            <div class="form-text mt-2">Provide an identifier for the fastest lookup, or specify a start and end range with the two-letter state code. NOAA manual imports require state-level queries.</div>
                             <button onclick="manualImportAlert()" class="btn btn-custom btn-secondary w-100 mt-3">
                                 <i class="fas fa-cloud-download-alt"></i> Fetch &amp; Save
                             </button>
@@ -628,6 +603,40 @@
                 <div class="tab-pane fade" id="alerts-mgmt" role="tabpanel">
                     <h4><i class="fas fa-exclamation-triangle text-danger"></i> Alert Management</h4>
                     <p class="text-muted">Manage expired alerts and data preservation.</p>
+
+                    <div class="operation-card mb-4">
+                        <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3 mb-3">
+                            <div>
+                                <h6 class="mb-1">Stored Alerts</h6>
+                                <div class="text-muted small">Edit or remove alerts directly from the database.</div>
+                            </div>
+                            <div class="d-flex align-items-center gap-3 flex-wrap">
+                                <div class="form-check form-switch mb-0">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="includeExpiredAlertsToggle">
+                                    <label class="form-check-label small" for="includeExpiredAlertsToggle">Include expired alerts</label>
+                                </div>
+                                <button type="button" class="btn btn-custom btn-outline-primary" id="refreshAlertListButton">
+                                    <i class="fas fa-sync"></i> Refresh
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <input type="text" class="form-control" id="alertSearchInput" placeholder="Search by identifier, event, or headline...">
+                            </div>
+                            <div class="col-md-6 text-md-end">
+                                <small id="adminAlertListMeta" class="text-muted"></small>
+                            </div>
+                        </div>
+
+                        <div id="adminAlertList" class="table-responsive">
+                            <div class="text-center py-4">
+                                <div class="loading-spinner"></div>
+                                <span class="ms-2">Loading alerts...</span>
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="row">
                         <div class="col-md-6">
@@ -695,6 +704,122 @@
         </div>
     </div>
 
+    <!-- Edit Alert Modal -->
+    <div class="modal fade" id="editAlertModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <i class="fas fa-edit"></i> Edit Alert
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <form id="editAlertForm">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label fw-bold">Identifier</label>
+                            <div class="form-control-plaintext" id="editAlertIdentifier"></div>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="editAlertEvent" class="form-label">Event <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control" id="editAlertEvent" required>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="editAlertStatus" class="form-label">Status <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control" id="editAlertStatus" list="alertStatusOptions" required>
+                                    <datalist id="alertStatusOptions">
+                                        <option value="Actual"></option>
+                                        <option value="Test"></option>
+                                        <option value="Exercise"></option>
+                                        <option value="System"></option>
+                                        <option value="Draft"></option>
+                                        <option value="Expired"></option>
+                                    </datalist>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="editAlertSeverity" class="form-label">Severity</label>
+                                    <input type="text" class="form-control" id="editAlertSeverity" list="alertSeverityOptions">
+                                    <datalist id="alertSeverityOptions">
+                                        <option value="Extreme"></option>
+                                        <option value="Severe"></option>
+                                        <option value="Moderate"></option>
+                                        <option value="Minor"></option>
+                                        <option value="Unknown"></option>
+                                    </datalist>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="editAlertUrgency" class="form-label">Urgency</label>
+                                    <input type="text" class="form-control" id="editAlertUrgency" list="alertUrgencyOptions">
+                                    <datalist id="alertUrgencyOptions">
+                                        <option value="Immediate"></option>
+                                        <option value="Expected"></option>
+                                        <option value="Future"></option>
+                                        <option value="Past"></option>
+                                        <option value="Unknown"></option>
+                                    </datalist>
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="mb-3">
+                                    <label for="editAlertCertainty" class="form-label">Certainty</label>
+                                    <input type="text" class="form-control" id="editAlertCertainty" list="alertCertaintyOptions">
+                                    <datalist id="alertCertaintyOptions">
+                                        <option value="Observed"></option>
+                                        <option value="Likely"></option>
+                                        <option value="Possible"></option>
+                                        <option value="Unlikely"></option>
+                                        <option value="Unknown"></option>
+                                    </datalist>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertCategory" class="form-label">Category</label>
+                            <input type="text" class="form-control" id="editAlertCategory">
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertHeadline" class="form-label">Headline</label>
+                            <textarea class="form-control" id="editAlertHeadline" rows="2"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertDescription" class="form-label">Description</label>
+                            <textarea class="form-control" id="editAlertDescription" rows="4"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertInstruction" class="form-label">Instruction</label>
+                            <textarea class="form-control" id="editAlertInstruction" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertAreaDesc" class="form-label">Area Description</label>
+                            <textarea class="form-control" id="editAlertAreaDesc" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAlertExpires" class="form-label">Expiration</label>
+                            <input type="datetime-local" class="form-control" id="editAlertExpires">
+                            <div class="form-text">Leave blank to clear the expiration time.</div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> Save Changes
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <!-- Keyboard Shortcuts Info -->
     <div class="keyboard-shortcuts">
         <i class="fas fa-keyboard"></i> Alt+1-6: Switch Tabs | Alt+R: Refresh | Alt+H: Help
@@ -707,13 +832,23 @@
         // Global variables
         let confirmationModal;
         let currentOperation = null;
+        let editAlertModal;
+        let adminAlerts = [];
+        let adminAlertFilters = { includeExpired: false, search: '' };
+        let alertSearchTimeout = null;
+        let editingAlertId = null;
 
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', function() {
             confirmationModal = new bootstrap.Modal(document.getElementById('confirmationModal'));
+            const editAlertModalElement = document.getElementById('editAlertModal');
+            if (editAlertModalElement) {
+                editAlertModal = new bootstrap.Modal(editAlertModalElement);
+            }
             loadBoundaries();
             loadSystemHealth();
             setupKeyboardShortcuts();
+            initializeAlertManagement();
 
             // Auto-refresh every 30 seconds
             setInterval(() => {
@@ -835,6 +970,439 @@
                 setTimeout(() => {
                     statusDiv.style.display = 'none';
                 }, duration);
+            }
+        }
+
+        function initializeAlertManagement() {
+            loadAdminAlerts();
+
+            const searchInput = document.getElementById('alertSearchInput');
+            if (searchInput) {
+                searchInput.addEventListener('input', onAlertSearchChanged);
+            }
+
+            const includeExpiredToggle = document.getElementById('includeExpiredAlertsToggle');
+            if (includeExpiredToggle) {
+                includeExpiredToggle.addEventListener('change', (event) => {
+                    adminAlertFilters.includeExpired = !!event.target.checked;
+                    loadAdminAlerts();
+                });
+            }
+
+            const refreshButton = document.getElementById('refreshAlertListButton');
+            if (refreshButton) {
+                refreshButton.addEventListener('click', () => loadAdminAlerts(true));
+            }
+
+            const editForm = document.getElementById('editAlertForm');
+            if (editForm) {
+                editForm.addEventListener('submit', submitAlertEdit);
+            }
+
+            const editModalElement = document.getElementById('editAlertModal');
+            if (editModalElement) {
+                editModalElement.addEventListener('hidden.bs.modal', resetAlertEditForm);
+            }
+        }
+
+        function onAlertSearchChanged(event) {
+            const value = event.target ? event.target.value.trim() : '';
+            adminAlertFilters.search = value;
+            if (alertSearchTimeout) {
+                clearTimeout(alertSearchTimeout);
+            }
+            alertSearchTimeout = setTimeout(() => {
+                loadAdminAlerts();
+            }, 400);
+        }
+
+        async function loadAdminAlerts(showRefreshNotice = false) {
+            const listContainer = document.getElementById('adminAlertList');
+            const metaContainer = document.getElementById('adminAlertListMeta');
+
+            if (listContainer) {
+                listContainer.innerHTML = `
+                    <div class="text-center py-4">
+                        <div class="loading-spinner"></div>
+                        <span class="ms-2">Loading alerts...</span>
+                    </div>
+                `;
+            }
+            if (metaContainer) {
+                metaContainer.textContent = '';
+            }
+
+            const params = new URLSearchParams();
+            if (adminAlertFilters.includeExpired) {
+                params.set('include_expired', 'true');
+            }
+            if (adminAlertFilters.search) {
+                params.set('search', adminAlertFilters.search);
+            }
+
+            const queryString = params.toString();
+            const url = queryString ? `/admin/alerts?${queryString}` : '/admin/alerts';
+
+            try {
+                const response = await fetch(url);
+                const result = await response.json();
+
+                if (!response.ok || (result && result.error)) {
+                    throw new Error((result && result.error) || 'Failed to load alerts.');
+                }
+
+                adminAlerts = Array.isArray(result.alerts) ? result.alerts : [];
+                renderAdminAlertList(result);
+
+                if (showRefreshNotice) {
+                    showStatus('✅ Alert list refreshed.', 'success', 2500);
+                }
+            } catch (error) {
+                if (listContainer) {
+                    listContainer.innerHTML = `<div class="alert alert-danger-custom">Failed to load alerts: ${escapeHtml(error.message)}</div>`;
+                }
+                if (metaContainer) {
+                    metaContainer.textContent = '';
+                }
+                showStatus(`❌ Failed to load alerts: ${error.message}`, 'danger');
+            }
+        }
+
+        function renderAdminAlertList(payload) {
+            const listContainer = document.getElementById('adminAlertList');
+            const metaContainer = document.getElementById('adminAlertListMeta');
+
+            if (!listContainer) {
+                return;
+            }
+
+            const alerts = Array.isArray(adminAlerts) ? adminAlerts : [];
+            if (metaContainer) {
+                const total = typeof payload.total === 'number' ? payload.total : alerts.length;
+                const returned = typeof payload.returned === 'number' ? payload.returned : alerts.length;
+                const descriptor = payload.include_expired ? 'including expired alerts' : 'active alerts only';
+                const countText = total !== returned ? `${returned} of ${total}` : `${returned}`;
+                metaContainer.textContent = alerts.length ? `${countText} displayed (${descriptor})` : '';
+            }
+
+            if (!alerts.length) {
+                listContainer.innerHTML = '<div class="alert alert-info-custom">No alerts found for the selected filters.</div>';
+                return;
+            }
+
+            const rows = alerts.map(renderAdminAlertRow).join('');
+            listContainer.innerHTML = `
+                <div class="table-responsive">
+                    <table class="table table-sm table-striped align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Event</th>
+                                <th class="text-nowrap">Issued</th>
+                                <th class="text-nowrap">Expires</th>
+                                <th class="text-nowrap">Status</th>
+                                <th class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>${rows}</tbody>
+                    </table>
+                </div>
+            `;
+        }
+
+        function renderAdminAlertRow(alert) {
+            const eventLabel = escapeHtml(alert.event || 'Unknown');
+            const identifier = escapeHtml(alert.identifier || '');
+            const headline = alert.headline ? `<div class="small text-muted">${escapeHtml(alert.headline)}</div>` : '';
+            const areaDesc = alert.area_desc
+                ? `<div class="small text-muted" title="${escapeHtml(alert.area_desc)}">${escapeHtml(alert.area_desc.length > 140 ? `${alert.area_desc.slice(0, 137)}…` : alert.area_desc)}</div>`
+                : '';
+            const metadataBadges = [
+                renderSeverityBadge(alert.severity),
+                renderUrgencyBadge(alert.urgency),
+                renderCertaintyBadge(alert.certainty)
+            ].filter(Boolean).join(' ');
+
+            return `
+                <tr>
+                    <td>
+                        <div class="fw-semibold">${eventLabel}</div>
+                        ${headline}
+                        <div class="small text-muted">ID: <code>${identifier}</code></div>
+                        ${areaDesc}
+                        ${metadataBadges ? `<div class="small mt-1">${metadataBadges}</div>` : ''}
+                    </td>
+                    <td class="text-nowrap">${formatDateTimeDisplay(alert.sent)}</td>
+                    <td class="text-nowrap">${formatDateTimeDisplay(alert.expires)}</td>
+                    <td class="text-nowrap">${renderStatusBadge(alert.status)}</td>
+                    <td class="text-end text-nowrap">
+                        <button class="btn btn-sm btn-outline-primary me-2" type="button" onclick="openEditAlert(${alert.id})">
+                            <i class="fas fa-edit"></i> Edit
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger" type="button" onclick="promptDeleteAlert(${alert.id})">
+                            <i class="fas fa-trash-alt"></i>
+                        </button>
+                    </td>
+                </tr>
+            `;
+        }
+
+        function renderSeverityBadge(severity) {
+            if (!severity) {
+                return '';
+            }
+            const normalized = severity.toLowerCase();
+            let badgeClass = 'bg-secondary';
+            if (normalized === 'extreme') {
+                badgeClass = 'bg-danger';
+            } else if (normalized === 'severe') {
+                badgeClass = 'bg-warning text-dark';
+            } else if (normalized === 'moderate') {
+                badgeClass = 'bg-info text-dark';
+            } else if (normalized === 'minor') {
+                badgeClass = 'bg-success';
+            }
+            return `<span class="badge ${badgeClass} me-1">${escapeHtml(severity)}</span>`;
+        }
+
+        function renderUrgencyBadge(urgency) {
+            if (!urgency) {
+                return '';
+            }
+            const normalized = urgency.toLowerCase();
+            let badgeClass = 'bg-secondary';
+            if (normalized === 'immediate') {
+                badgeClass = 'bg-danger';
+            } else if (normalized === 'expected') {
+                badgeClass = 'bg-warning text-dark';
+            } else if (normalized === 'future') {
+                badgeClass = 'bg-info text-dark';
+            }
+            return `<span class="badge ${badgeClass} me-1">${escapeHtml(urgency)}</span>`;
+        }
+
+        function renderCertaintyBadge(certainty) {
+            if (!certainty) {
+                return '';
+            }
+            const normalized = certainty.toLowerCase();
+            let badgeClass = 'bg-secondary';
+            if (normalized === 'observed') {
+                badgeClass = 'bg-primary';
+            } else if (normalized === 'likely') {
+                badgeClass = 'bg-success';
+            } else if (normalized === 'possible') {
+                badgeClass = 'bg-warning text-dark';
+            }
+            return `<span class="badge ${badgeClass}">${escapeHtml(certainty)}</span>`;
+        }
+
+        function renderStatusBadge(status) {
+            if (!status) {
+                return '<span class="badge bg-secondary">Unknown</span>';
+            }
+            const normalized = status.toLowerCase();
+            let badgeClass = 'bg-secondary';
+            if (normalized === 'expired') {
+                badgeClass = 'bg-dark';
+            } else if (normalized === 'actual' || normalized === 'active') {
+                badgeClass = 'bg-success';
+            } else if (normalized === 'test') {
+                badgeClass = 'bg-info text-dark';
+            }
+            return `<span class="badge ${badgeClass}">${escapeHtml(status)}</span>`;
+        }
+
+        function formatDateTimeDisplay(value) {
+            if (!value) {
+                return '<span class="text-muted">—</span>';
+            }
+            const parsed = new Date(value);
+            if (Number.isNaN(parsed.getTime())) {
+                return escapeHtml(String(value));
+            }
+            return escapeHtml(parsed.toLocaleString());
+        }
+
+        function isoToLocalInputValue(value) {
+            if (!value) {
+                return '';
+            }
+            const parsed = new Date(value);
+            if (Number.isNaN(parsed.getTime())) {
+                return '';
+            }
+            const offsetMinutes = parsed.getTimezoneOffset();
+            const localTime = new Date(parsed.getTime() - offsetMinutes * 60000);
+            return localTime.toISOString().slice(0, 16);
+        }
+
+        function localInputToIso(value) {
+            if (!value) {
+                return null;
+            }
+            const parsed = new Date(value);
+            if (Number.isNaN(parsed.getTime())) {
+                return null;
+            }
+            const offsetMinutes = parsed.getTimezoneOffset();
+            const utcTime = new Date(parsed.getTime() - offsetMinutes * 60000);
+            return utcTime.toISOString();
+        }
+
+        function setInputValue(id, value) {
+            const element = document.getElementById(id);
+            if (element) {
+                element.value = value || '';
+            }
+        }
+
+        function openEditAlert(alertId) {
+            const target = adminAlerts.find(alert => alert.id === alertId);
+            if (!target) {
+                showStatus('Selected alert could not be found. Refresh the list and try again.', 'warning');
+                return;
+            }
+
+            editingAlertId = alertId;
+
+            const identifierLabel = document.getElementById('editAlertIdentifier');
+            if (identifierLabel) {
+                identifierLabel.textContent = target.identifier || '';
+            }
+
+            setInputValue('editAlertEvent', target.event);
+            setInputValue('editAlertStatus', target.status);
+            setInputValue('editAlertSeverity', target.severity);
+            setInputValue('editAlertUrgency', target.urgency);
+            setInputValue('editAlertCertainty', target.certainty);
+            setInputValue('editAlertCategory', target.category);
+            setInputValue('editAlertHeadline', target.headline);
+            setInputValue('editAlertDescription', target.description);
+            setInputValue('editAlertInstruction', target.instruction);
+            setInputValue('editAlertAreaDesc', target.area_desc);
+
+            const expiresInput = document.getElementById('editAlertExpires');
+            if (expiresInput) {
+                expiresInput.value = isoToLocalInputValue(target.expires);
+            }
+
+            if (editAlertModal) {
+                editAlertModal.show();
+            }
+        }
+
+        function resetAlertEditForm() {
+            editingAlertId = null;
+            const form = document.getElementById('editAlertForm');
+            if (form) {
+                form.reset();
+            }
+            const identifierLabel = document.getElementById('editAlertIdentifier');
+            if (identifierLabel) {
+                identifierLabel.textContent = '';
+            }
+        }
+
+        function promptDeleteAlert(alertId) {
+            const target = adminAlerts.find(alert => alert.id === alertId);
+            if (!target) {
+                showStatus('Selected alert could not be found. Refresh the list and try again.', 'warning');
+                return;
+            }
+
+            const identifierLabel = target.identifier ? `"${target.identifier}"` : `ID ${alertId}`;
+
+            showConfirmation({
+                title: 'Delete Alert',
+                message: `Delete alert ${escapeHtml(identifierLabel)}?`,
+                warning: 'This will permanently remove the alert, its intersections, and related LED messages.',
+                type: 'danger',
+                confirmText: 'Delete Alert',
+                onConfirm: () => deleteAlert(alertId)
+            });
+        }
+
+        async function deleteAlert(alertId) {
+            try {
+                const response = await fetch(`/admin/alerts/${alertId}`, { method: 'DELETE' });
+                const result = await response.json();
+
+                if (!response.ok || (result && result.error)) {
+                    throw new Error((result && result.error) || 'Failed to delete alert.');
+                }
+
+                showStatus(result.message || 'Alert deleted.', 'success');
+                await loadAdminAlerts();
+            } catch (error) {
+                showStatus(`❌ Failed to delete alert: ${error.message}`, 'danger');
+            }
+        }
+
+        async function submitAlertEdit(event) {
+            event.preventDefault();
+
+            if (!editingAlertId) {
+                showStatus('No alert selected for editing.', 'warning');
+                return;
+            }
+
+            const eventValue = (document.getElementById('editAlertEvent')?.value || '').trim();
+            const statusValue = (document.getElementById('editAlertStatus')?.value || '').trim();
+
+            if (!eventValue) {
+                showStatus('Event name is required.', 'warning');
+                return;
+            }
+
+            if (!statusValue) {
+                showStatus('Status is required.', 'warning');
+                return;
+            }
+
+            const payload = {
+                event: eventValue,
+                status: statusValue,
+                severity: (document.getElementById('editAlertSeverity')?.value || '').trim() || null,
+                urgency: (document.getElementById('editAlertUrgency')?.value || '').trim() || null,
+                certainty: (document.getElementById('editAlertCertainty')?.value || '').trim() || null,
+                category: (document.getElementById('editAlertCategory')?.value || '').trim() || null,
+                headline: (document.getElementById('editAlertHeadline')?.value || '').trim() || null,
+                description: (document.getElementById('editAlertDescription')?.value || '').trim() || null,
+                instruction: (document.getElementById('editAlertInstruction')?.value || '').trim() || null,
+                area_desc: (document.getElementById('editAlertAreaDesc')?.value || '').trim() || null,
+            };
+
+            const expiresValue = document.getElementById('editAlertExpires')?.value || '';
+            if (expiresValue) {
+                const isoValue = localInputToIso(expiresValue);
+                if (!isoValue) {
+                    showStatus('Expiration time could not be parsed. Please provide a valid date and time.', 'warning');
+                    return;
+                }
+                payload.expires = isoValue;
+            } else {
+                payload.expires = null;
+            }
+
+            try {
+                const response = await fetch(`/admin/alerts/${editingAlertId}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const result = await response.json();
+
+                if (!response.ok || (result && result.error)) {
+                    throw new Error((result && result.error) || 'Failed to update alert.');
+                }
+
+                showStatus(result.message || 'Alert updated successfully.', 'success');
+                if (editAlertModal) {
+                    editAlertModal.hide();
+                }
+                await loadAdminAlerts();
+            } catch (error) {
+                showStatus(`❌ Failed to update alert: ${error.message}`, 'danger');
             }
         }
 
@@ -1226,14 +1794,72 @@
             }
         }
 
+        const escapeHtml = (value) => {
+            if (typeof value !== 'string') {
+                return value;
+            }
+            return value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
+
+        const renderQueryDetails = (container, queryUrl, params) => {
+            if (!container || !queryUrl) {
+                return;
+            }
+
+            const detailsContainer = document.createElement('div');
+            detailsContainer.className = 'mt-3 alert alert-light border manual-import-query-details';
+
+            const heading = document.createElement('div');
+            heading.className = 'small fw-semibold text-uppercase text-muted';
+            heading.textContent = 'NOAA API Query';
+            detailsContainer.appendChild(heading);
+
+            const urlWrapper = document.createElement('div');
+            urlWrapper.className = 'small text-break';
+            const urlCode = document.createElement('code');
+            urlCode.textContent = queryUrl;
+            urlWrapper.appendChild(urlCode);
+            detailsContainer.appendChild(urlWrapper);
+
+            const paramEntries = params && typeof params === 'object' ? Object.entries(params) : [];
+            if (paramEntries.length > 0) {
+                const list = document.createElement('dl');
+                list.className = 'row small mb-0 mt-2';
+                paramEntries.forEach(([key, value]) => {
+                    const dt = document.createElement('dt');
+                    dt.className = 'col-sm-4';
+                    dt.textContent = key;
+
+                    const dd = document.createElement('dd');
+                    dd.className = 'col-sm-8 text-break';
+                    const codeEl = document.createElement('code');
+                    codeEl.textContent = String(value);
+                    dd.appendChild(codeEl);
+
+                    list.appendChild(dt);
+                    list.appendChild(dd);
+                });
+                detailsContainer.appendChild(list);
+            } else {
+                const noParams = document.createElement('div');
+                noParams.className = 'small text-muted mt-2 mb-0';
+                noParams.textContent = 'No additional query parameters were sent.';
+                detailsContainer.appendChild(noParams);
+            }
+
+            container.appendChild(detailsContainer);
+        };
+
         async function manualImportAlert() {
             const identifierInput = document.getElementById('manualAlertIdentifier');
             const startInput = document.getElementById('manualAlertStart');
             const endInput = document.getElementById('manualAlertEnd');
             const areaInput = document.getElementById('manualAlertArea');
-            const zoneInput = document.getElementById('manualAlertZone');
-            const statusSelect = document.getElementById('manualAlertStatus');
-            const messageTypeSelect = document.getElementById('manualAlertMessageType');
             const eventInput = document.getElementById('manualAlertEvent');
             const limitInput = document.getElementById('manualAlertLimit');
             const resultsDiv = document.getElementById('manualImportResults');
@@ -1245,10 +1871,8 @@
             const identifier = identifierInput ? identifierInput.value.trim() : '';
             const startValue = startInput ? startInput.value : '';
             const endValue = endInput ? endInput.value : '';
-            const area = areaInput ? areaInput.value.trim() : '';
-            const zone = zoneInput ? zoneInput.value.trim() : '';
-            const status = statusSelect ? statusSelect.value : 'actual';
-            const messageType = messageTypeSelect ? messageTypeSelect.value : 'alert';
+            const rawState = areaInput ? areaInput.value.trim().toUpperCase() : '';
+            const sanitizedState = rawState.replace(/[^A-Z]/g, '').slice(0, 2);
             const eventFilter = eventInput ? eventInput.value.trim() : '';
             const limit = limitInput ? parseInt(limitInput.value, 10) : 5;
 
@@ -1271,15 +1895,25 @@
                 return;
             }
 
+            if (!identifier) {
+                if (!sanitizedState || sanitizedState.length !== 2) {
+                    showStatus('Provide the two-letter state code when searching without an identifier.', 'warning');
+                    return;
+                }
+            } else if (sanitizedState && sanitizedState.length !== 2) {
+                showStatus('State filters must use the two-letter postal abbreviation.', 'warning');
+                return;
+            }
+
             const payload = {
                 identifier,
-                area,
-                zone,
                 event: eventFilter,
                 limit: Number.isNaN(limit) ? 5 : limit,
-                status,
-                message_type: messageType,
             };
+
+            if (sanitizedState && sanitizedState.length === 2) {
+                payload.area = sanitizedState;
+            }
 
             if (startIso) {
                 payload.start = startIso;
@@ -1321,7 +1955,7 @@
                         summaryParts.push(`${result.skipped} skipped`);
                     }
 
-                    const identifiers = (result.identifiers || []).map(id => `<code>${id}</code>`).join(', ');
+                    const identifiers = (result.identifiers || []).map(id => `<code>${escapeHtml(id)}</code>`).join(', ');
 
                     showStatus(`✅ ${result.message || 'Alert import completed successfully.'}`, 'success');
 
@@ -1330,6 +1964,14 @@
                             ${summaryParts.length ? `<div>${summaryParts.join(' • ')}</div>` : ''}
                             ${identifiers ? `<div class="mt-1">Identifiers: ${identifiers}</div>` : ''}
                         `;
+                        renderQueryDetails(resultsDiv, result.query_url, result.params);
+                    }
+
+                    if (result.query_url) {
+                        console.info('Manual NOAA import executed', {
+                            url: result.query_url,
+                            params: result.params,
+                        });
                     }
                 } else {
                     const fallbackMessage = rawBody && rawBody.trim() ? rawBody.trim() : 'Manual alert import failed.';
@@ -1337,6 +1979,9 @@
                     showStatus(`❌ ${message}`, response.status === 404 ? 'warning' : 'danger');
                     if (resultsDiv) {
                         resultsDiv.textContent = '';
+                        if (result && result.query_url) {
+                            renderQueryDetails(resultsDiv, result.query_url, result.params);
+                        }
                     }
                 }
             } catch (error) {

--- a/templates/stats/_scripts.html
+++ b/templates/stats/_scripts.html
@@ -1,12 +1,175 @@
 <!-- Load Highcharts and modules -->
-<script src="https://code.highcharts.com/11.4.1/stock/highstock.js"></script>
-<script src="https://code.highcharts.com/11.4.1/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/heatmap.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/solid-gauge.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/drilldown.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/exporting.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/export-data.js"></script>
-<script src="https://code.highcharts.com/11.4.1/modules/accessibility.js"></script>
+<script>
+(function setupHighchartsLoader() {
+    const HIGHCHARTS_VERSION = '12.4.0';
+    const HIGHCHARTS_VERSION_MINOR = '12.4';
+    const CDN_SOURCES = [
+        {
+            name: 'Highcharts Official (latest)',
+            resolve: (path) => `https://code.highcharts.com${path}`
+        },
+        {
+            name: `Highcharts Official v${HIGHCHARTS_VERSION}`,
+            resolve: (path) => path.startsWith('/stock/')
+                ? `https://code.highcharts.com/stock/${HIGHCHARTS_VERSION}${path.substring('/stock'.length)}`
+                : `https://code.highcharts.com/${HIGHCHARTS_VERSION}${path}`
+        },
+        {
+            name: `Highcharts Official ${HIGHCHARTS_VERSION_MINOR}.x`,
+            resolve: (path) => path.startsWith('/stock/')
+                ? `https://code.highcharts.com/stock/${HIGHCHARTS_VERSION_MINOR}${path.substring('/stock'.length)}`
+                : `https://code.highcharts.com/${HIGHCHARTS_VERSION_MINOR}${path}`
+        },
+        {
+            name: 'jsDelivr',
+            resolve: (path) => `https://cdn.jsdelivr.net/npm/highcharts@${HIGHCHARTS_VERSION}${path}`
+        },
+        {
+            name: 'unpkg',
+            resolve: (path) => `https://unpkg.com/highcharts@${HIGHCHARTS_VERSION}/dist${path}`
+        }
+    ];
+    const REQUIRED_SCRIPTS = [
+        '/stock/highstock.js',
+        '/highcharts-more.js',
+        '/modules/heatmap.js',
+        '/modules/solid-gauge.js',
+        '/modules/xrange.js',
+        '/modules/drilldown.js',
+        '/modules/exporting.js',
+        '/modules/export-data.js',
+        '/modules/accessibility.js'
+    ];
+
+    if (window.__highchartsLoadPromise) {
+        return;
+    }
+
+    function loadScript(src) {
+        return new Promise((resolve, reject) => {
+            const scripts = Array.from(document.getElementsByTagName('script'));
+            const existing = scripts.find((script) => script.src === src && script.dataset.highchartsLoader !== 'stats-dashboard-failed');
+
+            const cleanupListeners = (scriptElement, onLoad, onError) => {
+                if (!scriptElement) {
+                    return;
+                }
+                scriptElement.removeEventListener('load', onLoad);
+                scriptElement.removeEventListener('error', onError);
+            };
+
+            const resolveSuccess = (scriptElement) => {
+                if (scriptElement) {
+                    scriptElement.dataset.highchartsLoaded = 'true';
+                }
+                resolve();
+            };
+
+            const rejectFailure = (scriptElement) => {
+                if (scriptElement) {
+                    scriptElement.dataset.highchartsLoader = 'stats-dashboard-failed';
+                    if (scriptElement.parentNode) {
+                        scriptElement.parentNode.removeChild(scriptElement);
+                    }
+                }
+                reject(new Error(`Failed to load Highcharts resource: ${src}`));
+            };
+
+            if (existing) {
+                const managedByLoader = existing.dataset.highchartsLoader === 'stats-dashboard';
+                const alreadyLoaded = existing.dataset.highchartsLoaded === 'true'
+                    || !managedByLoader
+                    || existing.readyState === 'complete'
+                    || existing.readyState === 'loaded';
+                if (alreadyLoaded) {
+                    resolve();
+                    return;
+                }
+
+                const onLoad = () => {
+                    cleanupListeners(existing, onLoad, onError);
+                    resolveSuccess(existing);
+                };
+                const onError = () => {
+                    cleanupListeners(existing, onLoad, onError);
+                    rejectFailure(existing);
+                };
+
+                existing.addEventListener('load', onLoad, { once: true });
+                existing.addEventListener('error', onError, { once: true });
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = src;
+            script.async = false;
+            script.dataset.highchartsLoader = 'stats-dashboard';
+
+            const onLoad = () => {
+                cleanupListeners(script, onLoad, onError);
+                resolveSuccess(script);
+            };
+            const onError = () => {
+                cleanupListeners(script, onLoad, onError);
+                rejectFailure(script);
+            };
+
+            script.addEventListener('load', onLoad, { once: true });
+            script.addEventListener('error', onError, { once: true });
+            document.head.appendChild(script);
+        });
+    }
+
+    function tryLoadFromCdn(cdn) {
+        console.log(`[Highcharts loader] 📦 Attempting to load Highcharts from ${cdn.name}...`);
+        return REQUIRED_SCRIPTS.reduce(
+            (chain, path) => chain.then(() => loadScript(cdn.resolve(path))),
+            Promise.resolve()
+        );
+    }
+
+    function attemptFromIndex(index) {
+        if (index >= CDN_SOURCES.length) {
+            return Promise.reject(new Error('Failed to load Highcharts from all available sources.'));
+        }
+        const cdn = CDN_SOURCES[index];
+        return tryLoadFromCdn(cdn)
+            .then(() => cdn)
+            .catch((error) => {
+                console.warn(`[Highcharts loader] ⚠️ ${cdn.name} failed: ${error.message}`);
+                return attemptFromIndex(index + 1);
+            });
+    }
+
+    if (window.Highcharts) {
+        window.__highchartsLoadPromise = Promise.resolve(window.Highcharts);
+        Promise.resolve().then(() => document.dispatchEvent(new Event('highcharts:loaded')));
+        return;
+    }
+
+    const loadPromise = attemptFromIndex(0)
+        .then((cdn) => {
+            if (!window.Highcharts) {
+                throw new Error('Highcharts did not initialize as expected.');
+            }
+            delete window.__highchartsLoadError;
+            console.log(`[Highcharts loader] ✅ Highcharts loaded successfully from ${cdn.name}.`);
+            return window.Highcharts;
+        });
+
+    window.__highchartsLoadPromise = loadPromise
+        .then((highcharts) => {
+            document.dispatchEvent(new Event('highcharts:loaded'));
+            return highcharts;
+        })
+        .catch((error) => {
+            window.__highchartsLoadError = error;
+            document.dispatchEvent(new CustomEvent('highcharts:failed', { detail: error }));
+            delete window.__highchartsLoadPromise;
+            throw error;
+        });
+})();
+</script>
 
 <script>
 console.log('🚀 Statistics dashboard initializing...');
@@ -61,15 +224,26 @@ const state = {
     staticChartsInitialized: false
 };
 
-Highcharts.setOptions({
-    colors: ['#007bff', '#28a745', '#ffc107', '#dc3545', '#17a2b8', '#6f42c1', '#fd7e14', '#20c997', '#6c757d'],
-    chart: {
-        backgroundColor: 'transparent',
-        style: { fontFamily: 'Segoe UI, sans-serif' }
-    },
-    credits: { enabled: false },
-    title: { style: { color: '#212529', fontSize: '16px' } }
-});
+let highchartsDefaultsConfigured = false;
+
+function configureHighchartsDefaults() {
+    if (highchartsDefaultsConfigured) {
+        return;
+    }
+    if (!window.Highcharts) {
+        throw new Error('Highcharts is not available.');
+    }
+    Highcharts.setOptions({
+        colors: ['#007bff', '#28a745', '#ffc107', '#dc3545', '#17a2b8', '#6f42c1', '#fd7e14', '#20c997', '#6c757d'],
+        chart: {
+            backgroundColor: 'transparent',
+            style: { fontFamily: 'Segoe UI, sans-serif' }
+        },
+        credits: { enabled: false },
+        title: { style: { color: '#212529', fontSize: '16px' } }
+    });
+    highchartsDefaultsConfigured = true;
+}
 
 function populateFilterSelect(id, options) {
     const select = document.getElementById(id);
@@ -1305,21 +1479,60 @@ function initializeFilters() {
     updateDateInputs();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    try {
-        updateSystemInfo();
-        initializeFilters();
-        updateDashboard();
-        console.log('📊 Dashboard ready');
-    } catch (error) {
-        console.error('❌ Statistics dashboard failed to initialize', error);
-        const root = document.getElementById('statisticsDashboardRoot');
-        if (root) {
-            const alert = document.createElement('div');
-            alert.className = 'alert alert-danger mt-3';
-            alert.innerHTML = '<strong>Statistics failed to load.</strong> Please check the browser console for details.';
+function initializeDashboard() {
+    if (window.__statsDashboardInitialized) {
+        console.warn('Statistics dashboard initialization skipped because it already ran.');
+        return;
+    }
+
+    window.__statsDashboardInitialized = true;
+    configureHighchartsDefaults();
+    initializeFilters();
+    updateDashboard();
+    console.log('📊 Dashboard ready');
+}
+
+function renderInitializationFailure(message) {
+    const root = document.getElementById('statisticsDashboardRoot');
+    if (root) {
+        let alert = root.querySelector('.stats-init-error');
+        if (!alert) {
+            alert = document.createElement('div');
+            alert.className = 'alert alert-danger mt-3 stats-init-error';
             root.prepend(alert);
         }
+        alert.innerHTML = `<strong>${message}</strong> Please check the browser console for details.`;
     }
+    if (typeof showToast === 'function') {
+        showToast(message, 'error', 8000);
+    }
+}
+
+function handleInitializationError(error, message) {
+    console.error('❌ Statistics dashboard failed to initialize', error);
+    window.__statsDashboardInitialized = false;
+    renderInitializationFailure(message || 'Statistics failed to load.');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    updateSystemInfo();
+    const highchartsPromise = window.__highchartsLoadPromise;
+
+    if (!highchartsPromise) {
+        handleInitializationError(new Error('Highcharts loader was not initialized.'), 'Statistics failed to load because the charting library was not requested.');
+        return;
+    }
+
+    highchartsPromise
+        .then(() => {
+            try {
+                initializeDashboard();
+            } catch (error) {
+                handleInitializationError(error, 'Statistics failed to load.');
+            }
+        })
+        .catch((error) => {
+            handleInitializationError(error, 'Statistics failed to load because the charting library could not be loaded.');
+        });
 });
 </script>


### PR DESCRIPTION
## Summary
- add admin endpoints to list, update, and delete CAP alerts while logging actions and bumping the app build version
- surface a stored alerts management card in the admin interface with search, filters, and actions that call the new APIs
- provide an edit modal with validation plus delete confirmation so operators can revise or remove individual alerts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ffe4bddad88320b777cd42fc739ec0