### PR TITLE
Handle LED init disconnection

### DIFF
--- a/app_core/led.py
+++ b/app_core/led.py
@@ -83,6 +83,15 @@ else:
             led_controller = None
             return None
 
+        if not getattr(led_controller, "connected", False):
+            logger.warning(
+                "LED controller reported as disconnected after initialization; "
+                "marking LED integration as unavailable"
+            )
+            LED_AVAILABLE = False
+            led_controller = None
+            return None
+
         LED_AVAILABLE = True
         logger.info(
             "LED controller initialized successfully for %s:%s",


### PR DESCRIPTION
## Summary
- ensure the LED controller is only marked available when the connection succeeds

## Testing
- DATABASE_URL=sqlite:///test.db python - <<'PY'
import importlib
import app
from pprint import pprint
print('imported app')
app._db_initialized = False
with app.app.app_context():
    app.initialize_database()
print('LED available?', app.LED_AVAILABLE)
PY


------
https://chatgpt.com/codex/tasks/task_e_6900e93b31788320a967a3012a2f809a