### PR TITLE
Document single-line Experimental install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ tracks releases under the 2.1.x series.
 - Exposed in-app About and Help pages so operators can read the mission overview and operations guide directly from the dashboard navigation.
 ### Changed
 - Clarified in the README and dependency notes that PostgreSQL with PostGIS must run in a dedicated container separate from the application services.
+- Documented a single-line command for cloning the Experimental branch and launching the Docker Compose stack so operators can bootstrap quickly.
 - Updated the GPIO relay control so it remains engaged for the full alert audio playback,
   using `EAS_GPIO_HOLD_SECONDS` as the minimum release delay once audio finishes.
 - Automatically generate and play an End-Of-Message (EOM) data burst sequence after each alert
@@ -36,6 +37,8 @@ tracks releases under the 2.1.x series.
   selected code names in CLI output and audit trails while the broadcaster consumes
   the resolved identifiers for header generation.
 ### Fixed
+- Restored the `.env.example` template and documented the startup error shown when the
+  file is missing so Docker Compose deployments no longer fail with "env file not found".
 - Skip PostGIS-specific geometry checks when running against SQLite and store geometry
   fields as plain text on non-PostgreSQL databases so local development can initialize
   without spatial extensions.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,18 @@
 ### One-Command Installation
 
 ```bash
-git clone https://github.com/KR8MER/noaa_alerts_systems.git
+bash -c "git clone -b Experimental https://github.com/KR8MER/noaa_alerts_systems.git && cd noaa_alerts_systems && cp .env.example .env && docker compose up -d --build"
+```
+
+> ⚠️ **Important:** The command above copies the example configuration and launches the
+> containers with placeholder credentials. Immediately edit `.env` to set a strong
+> `SECRET_KEY`, update `POSTGRES_PASSWORD`, and restart the stack so your changes take
+> effect.
+
+If you prefer to run each step manually, the equivalent sequence is:
+
+```bash
+git clone -b Experimental https://github.com/KR8MER/noaa_alerts_systems.git
 cd noaa_alerts_systems
 cp .env.example .env
 # IMPORTANT: Edit .env and set SECRET_KEY and POSTGRES_PASSWORD!
@@ -76,6 +87,10 @@ docker compose up -d --build
    ```bash
    cp .env.example .env
    ```
+
+   > **Heads up:** Docker Compose will refuse to start if `.env` is missing and will
+   > print an error similar to `env file .../.env not found`. Always create this file
+   > before launching the stack.
 
 2. **Generate a secure SECRET_KEY:**
    ```bash


### PR DESCRIPTION
## Summary
- document a single-line command that clones the Experimental branch, copies the example env file, and starts the Docker stack
- record the installation shortcut in the changelog

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_6901250aab608320b8ba711a6e363951