### PR TITLE
Archive manual EAS activations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ tracks releases under the 2.1.x series.
 - Added a CLI helper (`tools/generate_sample_audio.py`) to create demonstration SAME audio
   clips without ingesting a live CAP product.
 - Delivered an in-app Manual Broadcast Builder on the EAS Output tab so operators can generate SAME headers, attention tones (EAS dual-tone or 1050 Hz), optional narration, and composite audio without leaving the browser.
+- Archived every manual EAS activation automatically, writing audio and summary
+  assets to disk, logging them in the database, and exposing a printable/exportable
+  history table within the admin console.
 - Unlocked an in-app first-run experience so the Admin panel exposes an
   "First-Time Administrator Setup" wizard when no accounts exist.
 - Introduced optional Azure AI speech synthesis to append narrated voiceovers when the
@@ -38,6 +41,9 @@ tracks releases under the 2.1.x series.
 - Updated the Quick Weekly Test preset to omit the attention signal by default and added a
   “No attention signal (omit)” option so manual packages can exclude the dual-tone or 1050 Hz
   alert when regulations allow.
+### Fixed
+- Corrected the Quick Weekly Test preset so the sample Required Weekly Test script
+  populates the message body as expected.
 - Standardised the manual and automated encoder timing so each SAME section includes a one-second
   guard interval and the End Of Message burst transmits the canonical `NNNN` payload per 47 CFR §11.31.
 - Replaced the free-form originator/call-sign fields with a guarded originator dropdown listing the four FCC originator codes (EAS, CIV, WXR, PEP) and a station identifier input, filtered the event selector to remove placeholder `??*` codes, and enforced the 31-location SAME limit in the UI.

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from flask import current_app, has_app_context
 from geoalchemy2 import Geometry
@@ -182,6 +182,65 @@ class EASMessage(db.Model):
             "text_filename": self.text_filename,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "metadata": dict(self.metadata_payload or {}),
+        }
+
+
+class ManualEASActivation(db.Model):
+    __tablename__ = "manual_eas_activations"
+
+    id = db.Column(db.Integer, primary_key=True)
+    identifier = db.Column(db.String(120), nullable=False)
+    event_code = db.Column(db.String(8), nullable=False)
+    event_name = db.Column(db.String(255), nullable=False)
+    status = db.Column(db.String(32), nullable=False)
+    message_type = db.Column(db.String(32), nullable=False)
+    same_header = db.Column(db.String(255), nullable=False)
+    same_locations = db.Column(db.JSON, nullable=False, default=list)
+    tone_profile = db.Column(db.String(32), nullable=False)
+    tone_seconds = db.Column(db.Float)
+    sample_rate = db.Column(db.Integer)
+    includes_tts = db.Column(db.Boolean, default=False)
+    tts_warning = db.Column(db.String(255))
+    sent_at = db.Column(db.DateTime(timezone=True))
+    expires_at = db.Column(db.DateTime(timezone=True))
+    headline = db.Column(db.String(240))
+    message_text = db.Column(db.Text)
+    instruction_text = db.Column(db.Text)
+    duration_minutes = db.Column(db.Float)
+    storage_path = db.Column(db.String(255), nullable=False)
+    summary_filename = db.Column(db.String(255))
+    components_payload = db.Column(db.JSON, nullable=False, default=dict)
+    metadata_payload = db.Column(db.JSON, nullable=False, default=dict)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now)
+    archived_at = db.Column(db.DateTime(timezone=True))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "identifier": self.identifier,
+            "event_code": self.event_code,
+            "event_name": self.event_name,
+            "status": self.status,
+            "message_type": self.message_type,
+            "same_header": self.same_header,
+            "same_locations": list(self.same_locations or []),
+            "tone_profile": self.tone_profile,
+            "tone_seconds": self.tone_seconds,
+            "sample_rate": self.sample_rate,
+            "includes_tts": bool(self.includes_tts),
+            "tts_warning": self.tts_warning,
+            "sent_at": self.sent_at.isoformat() if self.sent_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "headline": self.headline,
+            "message_text": self.message_text,
+            "instruction_text": self.instruction_text,
+            "duration_minutes": self.duration_minutes,
+            "storage_path": self.storage_path,
+            "summary_filename": self.summary_filename,
+            "components": dict(self.components_payload or {}),
+            "metadata": dict(self.metadata_payload or {}),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "archived_at": self.archived_at.isoformat() if self.archived_at else None,
         }
 
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1171,6 +1171,37 @@
                                     <p class="text-muted mb-0">Fill out the form to generate SAME/EAS audio assets.</p>
                                 </div>
                             </div>
+                            <div class="admin-card mt-4">
+                                <div class="card-header-custom d-flex align-items-center justify-content-between">
+                                    <div>
+                                        <h5 class="mb-1"><i class="fas fa-archive me-2"></i>Manual Broadcast Archive</h5>
+                                        <small class="text-muted">Saved activations are archived for printing and export.</small>
+                                    </div>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="refreshManualEasEvents">
+                                        <i class="fas fa-sync-alt"></i> Refresh
+                                    </button>
+                                </div>
+                                <div class="p-3">
+                                    <div id="manualEasStatus" class="text-muted small mb-2"></div>
+                                    <div class="table-responsive">
+                                        <table class="table table-sm align-middle mb-0">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col" class="text-nowrap">Created</th>
+                                                    <th scope="col">Event</th>
+                                                    <th scope="col" class="text-nowrap">SAME Header</th>
+                                                    <th scope="col" class="text-nowrap text-center">Actions</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="manualEasEventsBody">
+                                                <tr>
+                                                    <td colspan="4" class="text-center text-muted py-3">No manual activations recorded yet.</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -1891,9 +1922,122 @@
         function initializeEasPanel() {
             initializeEasGenerator();
             loadEasMessages();
+            loadManualEasEvents();
             const refreshButton = document.getElementById('refreshEasMessages');
             if (refreshButton) {
                 refreshButton.addEventListener('click', () => loadEasMessages());
+            }
+            const manualRefresh = document.getElementById('refreshManualEasEvents');
+            if (manualRefresh) {
+                manualRefresh.addEventListener('click', () => loadManualEasEvents());
+            }
+        }
+
+        async function loadManualEasEvents() {
+            const tableBody = document.getElementById('manualEasEventsBody');
+            const status = document.getElementById('manualEasStatus');
+            if (!tableBody) {
+                return;
+            }
+
+            tableBody.innerHTML = `
+                <tr>
+                    <td colspan="4" class="text-center text-muted py-3">
+                        <div class="loading-spinner"></div>
+                        <span class="ms-2">Loading manual activations…</span>
+                    </td>
+                </tr>
+            `;
+
+            try {
+                const response = await fetch('/admin/eas/manual_events?limit=50', {
+                    headers: { 'Accept': 'application/json' }
+                });
+
+                if (response.status === 401) {
+                    window.location.href = '/login';
+                    return;
+                }
+
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    tableBody.innerHTML = `
+                        <tr>
+                            <td colspan="4" class="text-center text-danger py-3">
+                                ${escapeHtml(data.error || 'Unable to load manual activations.')}
+                            </td>
+                        </tr>
+                    `;
+                    if (status) {
+                        status.textContent = data.error || 'Unable to load manual activations.';
+                    }
+                    return;
+                }
+
+                const events = Array.isArray(data.events) ? data.events : [];
+                const total = typeof data.total === 'number' ? data.total : events.length;
+
+                if (!events.length) {
+                    tableBody.innerHTML = `
+                        <tr>
+                            <td colspan="4" class="text-center text-muted py-3">
+                                No manual activations recorded yet.
+                            </td>
+                        </tr>
+                    `;
+                } else {
+                    tableBody.innerHTML = '';
+                    events.forEach((item) => {
+                        const createdLabel = item.created_at ? new Date(item.created_at).toLocaleString() : 'Unknown';
+                        const eventLabel = item.event_code
+                            ? `<strong>${escapeHtml(item.event_code)}</strong>${item.event_name ? ` — ${escapeHtml(item.event_name)}` : ''}`
+                            : escapeHtml(item.event_name || 'Manual Activation');
+                        const sameHeader = item.same_header
+                            ? `<code>${escapeHtml(item.same_header)}</code>`
+                            : '<span class="text-muted">—</span>';
+                        const actions = [];
+                        const composite = item.components && item.components.composite;
+                        if (composite && composite.download_url) {
+                            actions.push(`<a class="btn btn-sm btn-outline-primary" href="${escapeHtml(composite.download_url)}" target="_blank" rel="noopener"><i class="fas fa-play"></i> Composite</a>`);
+                        }
+                        if (item.print_url) {
+                            actions.push(`<a class="btn btn-sm btn-outline-secondary" href="${escapeHtml(item.print_url)}" target="_blank" rel="noopener"><i class="fas fa-print"></i> Print</a>`);
+                        }
+                        if (item.export_url) {
+                            actions.push(`<a class="btn btn-sm btn-outline-info" href="${escapeHtml(item.export_url)}" target="_blank" rel="noopener"><i class="fas fa-file-export"></i> Export</a>`);
+                        }
+                        const actionGroup = actions.length
+                            ? actions.join(' ')
+                            : '<span class="text-muted">No files</span>';
+
+                        const row = document.createElement('tr');
+                        row.innerHTML = `
+                            <td class="text-nowrap">${escapeHtml(createdLabel)}</td>
+                            <td>${eventLabel}</td>
+                            <td class="text-break">${sameHeader}</td>
+                            <td class="text-center">${actionGroup}</td>
+                        `;
+                        tableBody.appendChild(row);
+                    });
+                }
+
+                if (status) {
+                    status.textContent = events.length
+                        ? `Showing ${events.length} of ${total} archived manual activations.`
+                        : 'No manual activations have been archived yet.';
+                }
+            } catch (error) {
+                console.error('Failed to load manual EAS activations', error);
+                tableBody.innerHTML = `
+                    <tr>
+                        <td colspan="4" class="text-center text-danger py-3">
+                            Unexpected error while loading manual activations.
+                        </td>
+                    </tr>
+                `;
+                if (status) {
+                    status.textContent = 'Unexpected error while loading manual activations.';
+                }
             }
         }
 
@@ -2236,7 +2380,7 @@
                 headlineInput.value = 'This is a Required Weekly Test.';
             }
 
-            const messageInput = document.getElementById('easMessage');
+            const messageInput = document.getElementById('easMessageBody');
             if (messageInput) {
                 messageInput.value = 'This is a test of the Emergency Alert System. No action is required.';
             }
@@ -2977,7 +3121,8 @@
 
                 easLastResponse = data;
                 renderEasGeneratorResults(data);
-                setEasGeneratorStatus('Manual EAS package generated. Review each component below.', 'success');
+                setEasGeneratorStatus('Manual EAS package generated and archived. Review each component below.', 'success');
+                loadManualEasEvents();
             } catch (error) {
                 console.error('Failed to generate manual EAS package', error);
                 setEasGeneratorStatus('Unexpected error while generating EAS audio.', 'danger');
@@ -3102,6 +3247,34 @@
             html += buildEasAudioCard('End of Message (EOM)', components.eom, 'Completes the activation with three end-of-message bursts.');
             html += buildEasAudioCard('Composite Package', components.composite, 'Full playback including header, tone, narration, and EOM.');
 
+            if (data.activation) {
+                const activation = data.activation;
+                const actions = [];
+                const archivedAt = activation.created_at
+                    ? new Date(activation.created_at).toLocaleString()
+                    : 'just now';
+                if (activation.print_url) {
+                    actions.push(`<a class="btn btn-sm btn-outline-primary" href="${escapeHtml(activation.print_url)}" target="_blank" rel="noopener"><i class="fas fa-print"></i> Print Sheet</a>`);
+                }
+                if (activation.export_url) {
+                    actions.push(`<a class="btn btn-sm btn-outline-secondary" href="${escapeHtml(activation.export_url)}" target="_blank" rel="noopener"><i class="fas fa-file-export"></i> Export JSON</a>`);
+                }
+                const actionButtons = actions.length
+                    ? actions.join('\n')
+                    : '<span class="text-muted small">Archive links unavailable.</span>';
+                html += `
+                    <div class="alert alert-info-custom d-flex flex-wrap justify-content-between align-items-center gap-2">
+                        <div>
+                            <strong>Archived activation #${escapeHtml(String(activation.id || ''))}</strong>
+                            <span class="small text-muted ms-2">Saved at ${escapeHtml(archivedAt)}.</span>
+                        </div>
+                        <div class="btn-group d-print-none">
+                            ${actionButtons}
+                        </div>
+                    </div>
+                `;
+            }
+
             container.innerHTML = html;
             if (copyButton) {
                 copyButton.disabled = !sameHeader;
@@ -3126,13 +3299,20 @@
         }
 
         function buildEasAudioCard(title, component, description) {
-            if (!component || !component.data_url) {
+            if (!component) {
                 return '';
             }
             const duration = Number(component.duration_seconds || 0);
             const durationLabel = duration ? `${duration.toFixed(duration >= 10 ? 0 : 2)} seconds` : '—';
             const sizeLabel = component.size_bytes ? formatBytes(Number(component.size_bytes)) : null;
             const filename = component.filename || `${title.replace(/\s+/g, '_').toLowerCase()}.wav`;
+            const downloadUrl = component.download_url || component.data_url || '';
+            const audioSource = component.data_url || component.download_url || '';
+            const downloadButton = downloadUrl
+                ? `<a class="btn btn-sm btn-outline-primary" href="${escapeHtml(downloadUrl)}" download="${escapeHtml(filename)}" target="_blank" rel="noopener">
+                        <i class="fas fa-download"></i> Download
+                   </a>`
+                : '<span class="btn btn-sm btn-outline-secondary disabled"><i class="fas fa-download"></i></span>';
 
             return `
                 <div class="border rounded-3 p-3 mb-3">
@@ -3141,11 +3321,9 @@
                             <h6 class="mb-1">${escapeHtml(title)}</h6>
                             <small class="text-muted">${escapeHtml(description || '')}${sizeLabel ? ` · ${escapeHtml(sizeLabel)}` : ''} · ${escapeHtml(durationLabel)}</small>
                         </div>
-                        <a class="btn btn-sm btn-outline-primary" href="${escapeHtml(component.data_url)}" download="${escapeHtml(filename)}">
-                            <i class="fas fa-download"></i> Download
-                        </a>
+                        ${downloadButton}
                     </div>
-                    <audio controls class="w-100 mt-3" src="${escapeHtml(component.data_url)}"></audio>
+                    ${audioSource ? `<audio controls class="w-100 mt-3" src="${escapeHtml(audioSource)}"></audio>` : '<p class="text-muted small mb-0 mt-3">Audio preview unavailable for this component.</p>'}
                 </div>
             `;
         }

--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -1,0 +1,147 @@
+{% extends "base.html" %}
+{% block title %}Manual EAS Activation — {{ event.identifier }}{% endblock %}
+{% block content %}
+<div class="container py-4 manual-eas-print">
+    <div class="d-flex justify-content-between align-items-start mb-4">
+        <div>
+            <h1 class="h3 mb-2">{{ event.event_code }} — {{ event.event_name }}</h1>
+            <p class="mb-1 text-muted">Identifier: <strong>{{ event.identifier }}</strong></p>
+            <p class="mb-0 text-muted">
+                Generated {{ event.created_at.isoformat() if event.created_at else 'Unknown time' }}
+            </p>
+        </div>
+        <div class="d-print-none">
+            {% if summary_url %}
+            <a class="btn btn-outline-primary btn-sm" href="{{ summary_url }}" target="_blank" rel="noopener">
+                <i class="fas fa-file-export"></i> Export JSON
+            </a>
+            {% endif %}
+            <button type="button" class="btn btn-primary btn-sm ms-2" onclick="window.print();">
+                <i class="fas fa-print"></i> Print
+            </button>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-7">
+            <div class="card shadow-sm">
+                <div class="card-header bg-dark text-white">
+                    <strong>SAME Header</strong>
+                </div>
+                <div class="card-body">
+                    <p class="mb-2"><code class="text-break">{{ event.same_header }}</code></p>
+                    {% set tone_profile_label = event.tone_profile or 'unknown' %}
+                    {% set tone_seconds_value = event.tone_seconds if event.tone_seconds is not none else 0 %}
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Status</dt>
+                        <dd class="col-sm-8">{{ event.status }} · {{ event.message_type }}</dd>
+                        <dt class="col-sm-4">Sent</dt>
+                        <dd class="col-sm-8">{{ event.sent_at.isoformat() if event.sent_at else '—' }}</dd>
+                        <dt class="col-sm-4">Expires</dt>
+                        <dd class="col-sm-8">{{ event.expires_at.isoformat() if event.expires_at else '—' }}</dd>
+                        <dt class="col-sm-4">Tone Profile</dt>
+                        <dd class="col-sm-8">{{ tone_profile_label|capitalize }} ({{ '%.1f'|format(tone_seconds_value) }} seconds)</dd>
+                        <dt class="col-sm-4">Sample Rate</dt>
+                        <dd class="col-sm-8">{{ event.sample_rate or '—' }} Hz</dd>
+                    </dl>
+                </div>
+            </div>
+
+            {% if header_detail.locations %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-header bg-light">
+                    <strong>Targeted Locations</strong>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Code</th>
+                                    <th scope="col">Area</th>
+                                    <th scope="col">Portion</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for loc in header_detail.locations %}
+                                <tr>
+                                    <td><code>{{ loc.code }}</code></td>
+                                    <td>{{ loc.description }}<br><small class="text-muted">{{ loc.state_name }}</small></td>
+                                    <td>{{ loc.p_meaning or 'Entire area' }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if event.headline %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-header bg-light">
+                    <strong>Headline</strong>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">{{ event.headline }}</p>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if event.message_text %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-header bg-light">
+                    <strong>Public Message</strong>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">{{ event.message_text.replace('\n', '<br>')|safe }}</p>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if event.instruction_text %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-header bg-light">
+                    <strong>Instructions</strong>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">{{ event.instruction_text.replace('\n', '<br>')|safe }}</p>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        <div class="col-lg-5">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light d-flex justify-content-between align-items-center">
+                    <strong>Audio Components</strong>
+                    <span class="badge bg-secondary">{{ components|length }} files</span>
+                </div>
+                <div class="card-body">
+                    {% if components %}
+                        {% for key, comp in components.items() %}
+                        <div class="mb-3">
+                            <div class="d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h6 class="mb-1 text-uppercase">{{ key }}</h6>
+                                    <small class="text-muted">{{ comp.duration_seconds|default(0)|round(2) }} s · {{ comp.size_bytes|default(0) }} bytes</small>
+                                </div>
+                                {% if comp.download_url %}
+                                <a class="btn btn-sm btn-outline-primary d-print-none" href="{{ comp.download_url }}" target="_blank" rel="noopener">
+                                    <i class="fas fa-download"></i>
+                                </a>
+                                {% endif %}
+                            </div>
+                            {% if comp.download_url %}
+                            <audio class="w-100 mt-2" controls src="{{ comp.download_url }}"></audio>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                    {% else %}
+                        <p class="text-muted mb-0">No audio assets were stored for this activation.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- persist manual EAS packages from the admin console to disk and the database while archiving previous entries
- expose manual activation history APIs plus a printable/exportable history view in the admin console
- fix the Quick Weekly Test preset so the sample message body populates correctly and surface archive links after generation

## Testing
- python -m compileall app.py app_core manual_eas_event.py

------
https://chatgpt.com/codex/tasks/task_e_6901a1bef5748320b7bebde39521981b