### PR TITLE
Add 0xAB preamble to generated EOM burst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ tracks releases under the 2.1.x series.
   the resolved identifiers for header generation.
 ### Fixed
 - Corrected SAME/RTTY generation to follow 47 CFR §11.31 framing (seven LSB-first ASCII bits, trailing null bit, and precise 520 5⁄6 baud timing) so the AFSK bursts decode at the proper pitch and speed.
+- Corrected the generated End Of Message burst to prepend the sixteen 0xAB preamble bytes so decoders reliably synchronise with the termination header.
 - Trimmed the manual and UI event selector to the authorised 47 CFR §11.31(d–e) code tables and removed placeholder `??*` entries.
 - Eliminated `service "app" depends on undefined service "alerts-db"` errors by removing the optional compose overlay, deleting the unused service definition, and updating documentation to assume an external database.
 - Ensured the Manual Broadcast Builder always renders the SAME event code list so operators can


### PR DESCRIPTION
## Summary
- prepend the standard 0xAB SAME preamble bytes before encoding generated EOM bursts
- allow the SAME bit encoder to optionally prefix preamble bytes for termination bursts
- document the decoder-facing change in the Unreleased changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901a5eb46e48320a680c321bf7d0379