### PR TITLE
Add audio archive views and integrate alert audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ tracks releases under the 2.1.x series.
 
 ## [Unreleased]
 ### Added
+- Introduced a dedicated Audio Archive history view with filtering, playback,
+  printing, and Excel export support for every generated SAME package.
+- Surfaced archived audio links throughout the alert history and detail pages so
+  operators can quickly review transmissions tied to a CAP product.
 - Added a `manual_eas_event.py` utility that ingests raw CAP XML (e.g., RWT/RMT tests),
   validates the targeted SAME/FIPS codes, and drives the broadcaster so operators can
   trigger manual transmissions with full auditing.
@@ -31,6 +35,7 @@ tracks releases under the 2.1.x series.
   can either rely on the bundled `alerts-db` PostGIS container or connect to an
   existing deployment without editing the primary compose file.
 ### Changed
+- Suppressed automatic EAS generation for Special Weather Statements and Dense Fog Advisories to align with standard activation practices.
 - Clarified in the README and dependency notes that PostgreSQL with PostGIS must run in a dedicated container separate from the application services.
 - Documented a single-line command for cloning the Experimental branch and launching the Docker Compose stack so operators can bootstrap quickly.
 - Clarified the update instructions to explicitly pull the Experimental branch when refreshing deployments.

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -976,11 +976,22 @@ class EASBroadcaster:
 
         status = (getattr(alert, 'status', '') or '').lower()
         message_type = (payload.get('message_type') or getattr(alert, 'message_type', '') or '').lower()
+        event_name = (getattr(alert, 'event', '') or payload.get('event') or '').strip().lower()
+
+        suppressed_events = {
+            'special weather statement',
+            'dense fog advisory',
+        }
+
         if status not in {'actual', 'test'}:
             self.logger.debug('Skipping EAS generation for status %s', status)
             return
         if message_type not in {'alert', 'update', 'test'}:
             self.logger.debug('Skipping EAS generation for message type %s', message_type)
+            return
+        if event_name in suppressed_events:
+            pretty_event = getattr(alert, 'event', '') or payload.get('event') or event_name
+            self.logger.info('Skipping EAS generation for event %s', pretty_event)
             return
 
         header, location_codes, event_code = build_same_header(alert, payload, self.config, self.location_settings)

--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -841,6 +841,97 @@
                         </div>
                     </div>
 
+                    {% if audio_entries %}
+                    <div class="card mt-4">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">
+                                <i class="fas fa-headphones"></i> Broadcast Audio Archive
+                            </h5>
+                            <a href="{{ url_for('audio_history') }}" class="btn btn-sm btn-outline-secondary">
+                                <i class="fas fa-folder-open"></i> View All Audio
+                            </a>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table table-sm align-middle mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th scope="col" class="text-nowrap">Generated</th>
+                                            <th scope="col">Details</th>
+                                            <th scope="col" class="text-nowrap">SAME Header</th>
+                                            <th scope="col" class="text-nowrap text-center">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for entry in audio_entries %}
+                                        {% set meta = entry.metadata or {} %}
+                                        <tr>
+                                            <td class="text-nowrap">
+                                                {{ entry.created_at | format_local_datetime(false) if entry.created_at else 'Unknown' }}
+                                                <br>
+                                                <small class="text-muted">
+                                                    {{ entry.created_at | format_local_time if entry.created_at else '' }}
+                                                </small>
+                                            </td>
+                                            <td>
+                                                <strong>{{ meta.get('event', alert.event) or 'Unknown Event' }}</strong>
+                                                {% if meta.get('severity') or alert.severity %}
+                                                    <span class="badge bg-danger ms-1">{{ meta.get('severity', alert.severity) }}</span>
+                                                {% endif %}
+                                                {% if meta.get('status') or alert.status %}
+                                                    <span class="badge bg-secondary ms-1">{{ meta.get('status', alert.status) }}</span>
+                                                {% endif %}
+                                                {% if meta.get('event_code') %}
+                                                    <span class="badge bg-info ms-1">{{ meta.get('event_code') }}</span>
+                                                {% endif %}
+                                                {% set locations_meta = meta.get('locations') %}
+                                                {% if locations_meta %}
+                                                    <div class="small text-muted mt-1">
+                                                        <i class="fas fa-map-pin"></i>
+                                                        {% if locations_meta is string %}
+                                                            {{ locations_meta }}
+                                                        {% elif locations_meta is iterable %}
+                                                            {{ locations_meta | join(', ') }}
+                                                        {% else %}
+                                                            {{ locations_meta }}
+                                                        {% endif %}
+                                                    </div>
+                                                {% endif %}
+                                            </td>
+                                            <td class="text-break">
+                                                <code>{{ entry.same_header }}</code>
+                                            </td>
+                                            <td class="text-center">
+                                                <div class="btn-group btn-group-sm" role="group">
+                                                    {% if entry.audio_url %}
+                                                    <a class="btn btn-outline-primary" href="{{ entry.audio_url }}" target="_blank" rel="noopener">
+                                                        <i class="fas fa-play"></i>
+                                                    </a>
+                                                    {% endif %}
+                                                    {% if entry.text_url %}
+                                                    <a class="btn btn-outline-info" href="{{ entry.text_url }}" target="_blank" rel="noopener" title="Download summary">
+                                                        <i class="fas fa-file-alt"></i>
+                                                    </a>
+                                                    {% endif %}
+                                                    <a class="btn btn-outline-secondary" href="{{ entry.detail_url }}" title="View detail">
+                                                        <i class="fas fa-headphones"></i>
+                                                    </a>
+                                                    {% if entry.eom_url %}
+                                                    <a class="btn btn-outline-warning" href="{{ entry.eom_url }}" target="_blank" rel="noopener" title="EOM Burst">
+                                                        <i class="fas fa-broadcast-tower"></i>
+                                                    </a>
+                                                    {% endif %}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    {% endif %}
+
                     <!-- Actions -->
                     <div class="card mt-4 alert-actions">
                         <div class="card-header">

--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <div class="container-fluid">
+    {% set audio_map = audio_map or {} %}
     <div class="row">
         <div class="col-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
@@ -160,6 +161,7 @@
                                     <th>Expires</th>
                                     <th>Headline</th>
                                     <th>Area</th>
+                                    <th>Audio</th>
                                     <th>Actions</th>
                                 </tr>
                             </thead>
@@ -212,6 +214,34 @@
                                         </div>
                                         {% else %}
                                         <span class="text-muted">No area description</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% set audio_entries = audio_map.get(alert.id, []) %}
+                                        {% if audio_entries %}
+                                        <div class="d-flex flex-column gap-1">
+                                            {% set primary_audio = audio_entries[0] %}
+                                            <div class="btn-group btn-group-sm" role="group">
+                                                {% if primary_audio.audio_url %}
+                                                <a class="btn btn-outline-primary" href="{{ primary_audio.audio_url }}" target="_blank" rel="noopener">
+                                                    <i class="fas fa-play"></i> Play
+                                                </a>
+                                                {% endif %}
+                                                <a class="btn btn-outline-info" href="{{ primary_audio.detail_url }}">
+                                                    <i class="fas fa-headphones"></i> Details
+                                                </a>
+                                            </div>
+                                            {% if primary_audio.text_url %}
+                                            <a class="small" href="{{ primary_audio.text_url }}" target="_blank" rel="noopener">
+                                                <i class="fas fa-file-alt"></i> Summary file
+                                            </a>
+                                            {% endif %}
+                                            {% if audio_entries|length > 1 %}
+                                            <small class="text-muted">{{ audio_entries|length }} recordings archived</small>
+                                            {% endif %}
+                                        </div>
+                                        {% else %}
+                                        <span class="text-muted">None</span>
                                         {% endif %}
                                     </td>
                                     <td>

--- a/templates/audio_detail.html
+++ b/templates/audio_detail.html
@@ -1,0 +1,190 @@
+{% extends "base.html" %}
+
+{% block title %}Audio Detail - {{ event_name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-12 d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <h1 class="h3 text-primary mb-0">
+                <i class="fas fa-headphones"></i> Broadcast Audio Detail
+            </h1>
+            <div class="d-flex gap-2 flex-wrap">
+                <button type="button" class="btn btn-info" onclick="window.print()">
+                    <i class="fas fa-print"></i> Print
+                </button>
+                {% if audio_url %}
+                <a class="btn btn-primary" href="{{ audio_url }}" target="_blank" rel="noopener">
+                    <i class="fas fa-download"></i> Download Audio
+                </a>
+                {% endif %}
+                {% if text_url %}
+                <a class="btn btn-outline-info" href="{{ text_url }}" target="_blank" rel="noopener">
+                    <i class="fas fa-file-alt"></i> Download Summary
+                </a>
+                {% endif %}
+                {% if eom_url %}
+                <a class="btn btn-outline-warning" href="{{ eom_url }}" target="_blank" rel="noopener">
+                    <i class="fas fa-broadcast-tower"></i> Download EOM
+                </a>
+                {% endif %}
+                <a class="btn btn-outline-secondary" href="{{ url_for('audio_history') }}">
+                    <i class="fas fa-list"></i> Back to Archive
+                </a>
+                {% if alert %}
+                <a class="btn btn-outline-primary" href="{{ url_for('alert_detail', alert_id=alert.id) }}">
+                    <i class="fas fa-bullhorn"></i> View Alert
+                </a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-8">
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <div>
+                        <h5 class="mb-0">
+                            <i class="fas fa-wave-square"></i> Audio Playback
+                        </h5>
+                        <small class="text-muted">Generated {{ message.created_at | format_local_datetime(false) if message.created_at else 'Unknown time' }}</small>
+                    </div>
+                    {% if message.same_header %}
+                    <span class="badge bg-secondary">SAME</span>
+                    {% endif %}
+                </div>
+                <div class="card-body">
+                    {% if audio_url %}
+                    <audio controls class="w-100 mb-3">
+                        <source src="{{ audio_url }}" type="audio/wav">
+                        Your browser does not support the audio element.
+                    </audio>
+                    {% else %}
+                    <div class="alert alert-warning">
+                        <i class="fas fa-exclamation-circle"></i> Audio file is not available for download.
+                    </div>
+                    {% endif %}
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Event</dt>
+                        <dd class="col-sm-8">{{ event_name }}</dd>
+                        <dt class="col-sm-4">SAME Header</dt>
+                        <dd class="col-sm-8"><code>{{ message.same_header }}</code></dd>
+                        {% if severity %}
+                        <dt class="col-sm-4">Severity</dt>
+                        <dd class="col-sm-8">{{ severity }}</dd>
+                        {% endif %}
+                        {% if status %}
+                        <dt class="col-sm-4">Status</dt>
+                        <dd class="col-sm-8">{{ status }}</dd>
+                        {% endif %}
+                        {% if metadata.get('event_code') %}
+                        <dt class="col-sm-4">Event Code</dt>
+                        <dd class="col-sm-8">{{ metadata.get('event_code') }}</dd>
+                        {% endif %}
+                        {% if locations %}
+                        <dt class="col-sm-4">Locations</dt>
+                        <dd class="col-sm-8">{{ locations | join(', ') }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+            </div>
+
+            {% if summary_data %}
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-file-alt"></i> Narration Summary
+                    </h5>
+                </div>
+                <div class="card-body">
+                    {% if summary_data.message_text %}
+                    <h6>Message Text</h6>
+                    <p class="alert-content">{{ summary_data.message_text | replace('\n', '<br>') | safe }}</p>
+                    {% endif %}
+                    <dl class="row mb-0">
+                        {% if summary_data.headline %}
+                        <dt class="col-sm-4">Headline</dt>
+                        <dd class="col-sm-8">{{ summary_data.headline }}</dd>
+                        {% endif %}
+                        {% if summary_data.instruction %}
+                        <dt class="col-sm-4">Instruction</dt>
+                        <dd class="col-sm-8">{{ summary_data.instruction }}</dd>
+                        {% endif %}
+                        {% if summary_data.location_codes %}
+                        <dt class="col-sm-4">Location Codes</dt>
+                        <dd class="col-sm-8">{{ summary_data.location_codes | join(', ') }}</dd>
+                        {% endif %}
+                        {% if summary_data.voiceover_provider %}
+                        <dt class="col-sm-4">Voice Provider</dt>
+                        <dd class="col-sm-8">{{ summary_data.voiceover_provider }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+            </div>
+            {% endif %}
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-database"></i> Raw Metadata
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <pre class="bg-light p-3 rounded small">{{ metadata | tojson(indent=2) }}</pre>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-info-circle"></i> Transmission Info
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-5">Message ID</dt>
+                        <dd class="col-sm-7">#{{ message.id }}</dd>
+                        <dt class="col-sm-5">Created</dt>
+                        <dd class="col-sm-7">{{ message.created_at | format_local_datetime(false) if message.created_at else 'Unknown' }}</dd>
+                        {% if metadata.get('eom_filename') %}
+                        <dt class="col-sm-5">EOM File</dt>
+                        <dd class="col-sm-7">{{ metadata.get('eom_filename') }}</dd>
+                        {% endif %}
+                        {% if message.text_filename %}
+                        <dt class="col-sm-5">Summary File</dt>
+                        <dd class="col-sm-7">{{ message.text_filename }}</dd>
+                        {% endif %}
+                        {% if message.audio_filename %}
+                        <dt class="col-sm-5">Audio File</dt>
+                        <dd class="col-sm-7">{{ message.audio_filename }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+            </div>
+
+            {% if alert %}
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-bullhorn"></i> Source Alert
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <p class="mb-1"><strong>{{ alert.event }}</strong></p>
+                    <p class="text-muted small mb-3">Identifier: {{ alert.identifier }}</p>
+                    {% if alert.headline %}
+                    <p class="mb-2">{{ alert.headline }}</p>
+                    {% endif %}
+                    {% if alert.expires %}
+                    <p class="small text-muted mb-0">Expires {{ alert.expires | format_local_datetime(false) }}</p>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -1,0 +1,304 @@
+{% extends "base.html" %}
+
+{% block title %}Audio Archive - NOAA CAP Alerts{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1 class="h3 text-primary mb-0">
+                    <i class="fas fa-headphones"></i> Audio Archive
+                </h1>
+                <div class="d-flex gap-2 flex-wrap">
+                    <button type="button" class="btn btn-success" onclick="exportAudioArchive()" title="Export visible audio records">
+                        <i class="fas fa-file-export"></i> Export
+                    </button>
+                    <button type="button" class="btn btn-info" onclick="window.print()" title="Print this page">
+                        <i class="fas fa-print"></i> Print
+                    </button>
+                    <a href="/" class="btn btn-outline-secondary">
+                        <i class="fas fa-map"></i> Back to Map
+                    </a>
+                    <a href="/admin" class="btn btn-outline-primary">
+                        <i class="fas fa-cog"></i> Admin
+                    </a>
+                </div>
+            </div>
+
+            {% if not eas_enabled %}
+            <div class="alert alert-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                Automatic EAS audio generation is currently disabled. Historical records remain available below.
+            </div>
+            {% endif %}
+
+            <div class="row mb-4">
+                <div class="col-md-4">
+                    <div class="card bg-dark text-white">
+                        <div class="card-body text-center">
+                            <h3 class="mb-0">{{ total_messages }}</h3>
+                            <small>Archived Recordings</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-8">
+                    <div class="card bg-light h-100">
+                        <div class="card-body d-flex align-items-center justify-content-center text-muted">
+                            <div class="text-center">
+                                <i class="fas fa-wave-square fa-2x mb-2"></i>
+                                <div>Audio records include SAME headers, attention tones, and narration packages.</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-filter"></i> Filters
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <form method="GET" class="row g-3 align-items-end">
+                        <div class="col-md-3">
+                            <label for="search" class="form-label">Search</label>
+                            <input type="text" class="form-control" id="search" name="search" value="{{ current_filters.search or '' }}" placeholder="Search event, header, or identifier">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="event" class="form-label">Event Type</label>
+                            <select class="form-select" id="event" name="event">
+                                <option value="">All Events</option>
+                                {% for event in events %}
+                                <option value="{{ event }}" {% if current_filters.event == event %}selected{% endif %}>{{ event }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="severity" class="form-label">Severity</label>
+                            <select class="form-select" id="severity" name="severity">
+                                <option value="">All Severities</option>
+                                {% for severity in severities %}
+                                <option value="{{ severity }}" {% if current_filters.severity == severity %}selected{% endif %}>{{ severity }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="status" class="form-label">Status</label>
+                            <select class="form-select" id="status" name="status">
+                                <option value="">All Statuses</option>
+                                {% for status in statuses %}
+                                <option value="{{ status }}" {% if current_filters.status == status %}selected{% endif %}>{{ status }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-1">
+                            <label for="per_page" class="form-label">Per Page</label>
+                            <select class="form-select" id="per_page" name="per_page">
+                                <option value="25" {% if current_filters.per_page == 25 %}selected{% endif %}>25</option>
+                                <option value="50" {% if current_filters.per_page == 50 %}selected{% endif %}>50</option>
+                                <option value="100" {% if current_filters.per_page == 100 %}selected{% endif %}>100</option>
+                            </select>
+                        </div>
+                        <div class="col-md-1">
+                            <button type="submit" class="btn btn-primary w-100">
+                                <i class="fas fa-search"></i>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">
+                        <i class="fas fa-wave-square"></i> Archived Audio
+                        {% if pagination.total %}
+                        <span class="badge bg-secondary">{{ pagination.total }} total</span>
+                        {% endif %}
+                    </h5>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0" id="audioArchiveTable">
+                            <thead class="table-light">
+                                <tr>
+                                    <th scope="col" class="text-nowrap">Generated</th>
+                                    <th scope="col">Event</th>
+                                    <th scope="col" class="text-nowrap">Severity</th>
+                                    <th scope="col" class="text-nowrap">Status</th>
+                                    <th scope="col" class="text-nowrap">SAME Header</th>
+                                    <th scope="col">Alert</th>
+                                    <th scope="col" class="text-center text-nowrap">Audio</th>
+                                    <th scope="col" class="text-center text-nowrap">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% if messages %}
+                                {% for message in messages %}
+                                <tr>
+                                    <td class="text-nowrap">
+                                        {{ message.created_at | format_local_datetime(false) if message.created_at else 'Unknown' }}<br>
+                                        <small class="text-muted">{{ message.created_at | format_local_time if message.created_at else '' }}</small>
+                                    </td>
+                                    <td>
+                                        <strong>{{ message.event }}</strong>
+                                        {% if message.alert_identifier %}
+                                        <div class="small text-muted">{{ message.alert_identifier }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if message.severity %}
+                                            {% set severity = message.severity %}
+                                            {% set severity_class = 'bg-secondary' %}
+                                            {% if severity == 'Extreme' %}
+                                                {% set severity_class = 'bg-danger' %}
+                                            {% elif severity == 'Severe' %}
+                                                {% set severity_class = 'bg-warning text-dark' %}
+                                            {% elif severity == 'Moderate' %}
+                                                {% set severity_class = 'bg-info text-dark' %}
+                                            {% endif %}
+                                            <span class="badge {{ severity_class }}">{{ severity }}</span>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if message.status %}
+                                        <span class="badge bg-secondary">{{ message.status }}</span>
+                                        {% else %}
+                                        <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-break">
+                                        <code>{{ message.same_header }}</code>
+                                    </td>
+                                    <td>
+                                        {% if message.alert_url %}
+                                        <a href="{{ message.alert_url }}" class="btn btn-sm btn-outline-primary">
+                                            <i class="fas fa-eye"></i> View Alert
+                                        </a>
+                                        {% else %}
+                                        <span class="text-muted">Manual or unknown source</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-center">
+                                        {% if message.audio_url %}
+                                        <a class="btn btn-sm btn-outline-primary" href="{{ message.audio_url }}" target="_blank" rel="noopener">
+                                            <i class="fas fa-play"></i> Play
+                                        </a>
+                                        {% else %}
+                                        <span class="text-muted">Unavailable</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-center">
+                                        <div class="btn-group btn-group-sm" role="group">
+                                            {% if message.text_url %}
+                                            <a class="btn btn-outline-info" href="{{ message.text_url }}" target="_blank" rel="noopener" title="Download summary">
+                                                <i class="fas fa-file-alt"></i>
+                                            </a>
+                                            {% endif %}
+                                            <a class="btn btn-outline-secondary" href="{{ message.detail_url }}" title="View details">
+                                                <i class="fas fa-headphones"></i>
+                                            </a>
+                                            {% if message.eom_url %}
+                                            <a class="btn btn-outline-warning" href="{{ message.eom_url }}" target="_blank" rel="noopener" title="EOM Burst">
+                                                <i class="fas fa-broadcast-tower"></i>
+                                            </a>
+                                            {% endif %}
+                                        </div>
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                                {% else %}
+                                <tr data-empty="true">
+                                    <td colspan="8" class="text-center text-muted py-4">
+                                        <i class="fas fa-headphones-slash fa-2x mb-2"></i>
+                                        <div>No audio records found. Adjust your filters or check back later.</div>
+                                    </td>
+                                </tr>
+                                {% endif %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            {% if pagination.pages > 1 %}
+            <nav aria-label="Audio archive pagination" class="mt-4">
+                <ul class="pagination justify-content-center">
+                    {% if pagination.has_prev %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('audio_history', page=pagination.prev_num, **current_filters) }}">
+                            <i class="fas fa-chevron-left"></i> Previous
+                        </a>
+                    </li>
+                    {% endif %}
+                    {% for page_num in pagination.iter_pages() %}
+                        {% if page_num %}
+                            {% if page_num == pagination.page %}
+                            <li class="page-item active"><span class="page-link">{{ page_num }}</span></li>
+                            {% else %}
+                            <li class="page-item"><a class="page-link" href="{{ url_for('audio_history', page=page_num, **current_filters) }}">{{ page_num }}</a></li>
+                            {% endif %}
+                        {% else %}
+                        <li class="page-item disabled"><span class="page-link">…</span></li>
+                        {% endif %}
+                    {% endfor %}
+                    {% if pagination.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('audio_history', page=pagination.next_num, **current_filters) }}">
+                            Next <i class="fas fa-chevron-right"></i>
+                        </a>
+                    </li>
+                    {% endif %}
+                </ul>
+            </nav>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<script>
+function exportAudioArchive() {
+    try {
+        const table = document.getElementById('audioArchiveTable');
+        if (!table) {
+            showToast('Audio table not available', 'warning');
+            return;
+        }
+        const rows = table.querySelectorAll('tbody tr');
+        const dataset = [];
+        rows.forEach(row => {
+            if (row.dataset.empty === 'true') {
+                return;
+            }
+            const cells = row.querySelectorAll('td');
+            if (cells.length < 6) {
+                return;
+            }
+            dataset.push({
+                'Generated': cells[0].innerText.trim(),
+                'Event': cells[1].innerText.trim(),
+                'Severity': cells[2].innerText.trim(),
+                'Status': cells[3].innerText.trim(),
+                'SAME Header': cells[4].innerText.trim(),
+                'Alert': cells[5].innerText.trim(),
+            });
+        });
+
+        if (!dataset.length) {
+            showToast('No audio records to export', 'warning');
+            return;
+        }
+
+        exportToExcel(dataset, 'Audio_Archive');
+        showToast(`Exported ${dataset.length} audio records`, 'success');
+    } catch (error) {
+        console.error('Audio export failed:', error);
+        showToast('Failed to export audio history', 'danger');
+    }
+}
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -249,6 +249,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('audio_history') }}">
+                            <i class="fas fa-headphones"></i> Audio Archive
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/stats">
                             <i class="fas fa-chart-bar"></i> Statistics
                         </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -369,6 +369,9 @@
                     <a href="/alerts" class="btn btn-outline-primary btn-sm">
                         <i class="fas fa-history"></i> View History
                     </a>
+                    <a href="{{ url_for('audio_history') }}" class="btn btn-outline-warning btn-sm">
+                        <i class="fas fa-headphones"></i> Audio Archive
+                    </a>
                     <a href="/stats" class="btn btn-outline-info btn-sm">
                         <i class="fas fa-chart-bar"></i> Statistics
                     </a>


### PR DESCRIPTION
## Summary
- add a dedicated audio archive page with playback, filtering, and export controls
- surface generated audio links on alert history/detail views and navigation
- skip EAS generation for special weather statements and dense fog advisories

## Testing
- python -m compileall app.py app_utils/eas.py

------
https://chatgpt.com/codex/tasks/task_e_6901a7a9ef68832092e9a18bbfa6ff12