### PR TITLE
Ensure SAME bursts comply with CFR 11.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ tracks releases under the 2.1.x series.
 - Manual CAP broadcasts enforce configurable SAME event allow-lists and display the
   selected code names in CLI output and audit trails while the broadcaster consumes
   the resolved identifiers for header generation.
+- Ensured automated and manual SAME headers include the sixteen 0xAB preamble bytes
+  before each burst so the transmitted RTTY data fully complies with 47 CFR §11.31.
+- Restricted automatic EAS activations to CAP products whose SAME event codes match
+  the authorised 47 CFR §11.31(d–f) tables, preventing unintended broadcasts for
+  unclassified alerts.
 ### Fixed
 - Corrected SAME/RTTY generation to follow 47 CFR §11.31 framing (seven LSB-first ASCII bits, trailing null bit, and precise 520 5⁄6 baud timing) so the AFSK bursts decode at the proper pitch and speed.
 - Corrected the generated End Of Message burst to prepend the sixteen 0xAB preamble bytes so decoders reliably synchronise with the termination header.

--- a/app_utils/event_codes.py
+++ b/app_utils/event_codes.py
@@ -110,7 +110,7 @@ def resolve_event_code_from_name(name: str) -> Optional[str]:
     return EVENT_NAME_LOOKUP.get(_normalise_name(name))
 
 
-def resolve_event_code(event_name: str, candidates: Sequence[str]) -> str:
+def resolve_event_code(event_name: str, candidates: Sequence[str]) -> Optional[str]:
     for candidate in candidates:
         normalised = normalise_event_code(candidate)
         if normalised and normalised in EVENT_CODE_REGISTRY:
@@ -120,7 +120,7 @@ def resolve_event_code(event_name: str, candidates: Sequence[str]) -> str:
     if by_name:
         return by_name
 
-    return 'CEM'
+    return None
 
 
 def describe_event_code(code: str) -> str:


### PR DESCRIPTION
## Summary
- include the 0xAB preamble when rendering automated and manual SAME header bursts to satisfy 47 CFR §11.31
- skip EAS playback when CAP alerts do not resolve to an authorised SAME event code
- document the compliance updates in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901abcbc73c8320aca41848b8adf692