### PR TITLE
Include manual EAS activations in the audio archive view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ tracks releases under the 2.1.x series.
   “No attention signal (omit)” option so manual packages can exclude the dual-tone or 1050 Hz
   alert when regulations allow.
 ### Fixed
+- Count manual EAS activations when calculating Audio Archive totals and show them
+  alongside automated captures so archived transmissions are visible in the history
+  table.
+- Moved the Manual Broadcast Archive card to span the full EAS console width,
+  matching the builder/output layout and preventing it from being tucked under the
+  preview panel on large displays.
 - Corrected the Quick Weekly Test preset so the sample Required Weekly Test script
   populates the message body as expected.
 - Standardised the manual and automated encoder timing so each SAME section includes a one-second

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1171,36 +1171,37 @@
                                     <p class="text-muted mb-0">Fill out the form to generate SAME/EAS audio assets.</p>
                                 </div>
                             </div>
-                            <div class="admin-card mt-4">
-                                <div class="card-header-custom d-flex align-items-center justify-content-between">
-                                    <div>
-                                        <h5 class="mb-1"><i class="fas fa-archive me-2"></i>Manual Broadcast Archive</h5>
-                                        <small class="text-muted">Saved activations are archived for printing and export.</small>
-                                    </div>
-                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="refreshManualEasEvents">
-                                        <i class="fas fa-sync-alt"></i> Refresh
-                                    </button>
-                                </div>
-                                <div class="p-3">
-                                    <div id="manualEasStatus" class="text-muted small mb-2"></div>
-                                    <div class="table-responsive">
-                                        <table class="table table-sm align-middle mb-0">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="col" class="text-nowrap">Created</th>
-                                                    <th scope="col">Event</th>
-                                                    <th scope="col" class="text-nowrap">SAME Header</th>
-                                                    <th scope="col" class="text-nowrap text-center">Actions</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody id="manualEasEventsBody">
-                                                <tr>
-                                                    <td colspan="4" class="text-center text-muted py-3">No manual activations recorded yet.</td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
+                        </div>
+                    </div>
+
+                    <div class="admin-card mt-4">
+                        <div class="card-header-custom d-flex align-items-center justify-content-between">
+                            <div>
+                                <h5 class="mb-1"><i class="fas fa-archive me-2"></i>Manual Broadcast Archive</h5>
+                                <small class="text-muted">Saved activations are archived for printing and export.</small>
+                            </div>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" id="refreshManualEasEvents">
+                                <i class="fas fa-sync-alt"></i> Refresh
+                            </button>
+                        </div>
+                        <div class="p-3">
+                            <div id="manualEasStatus" class="text-muted small mb-2"></div>
+                            <div class="table-responsive">
+                                <table class="table table-sm align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col" class="text-nowrap">Created</th>
+                                            <th scope="col">Event</th>
+                                            <th scope="col" class="text-nowrap">SAME Header</th>
+                                            <th scope="col" class="text-nowrap text-center">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="manualEasEventsBody">
+                                        <tr>
+                                            <td colspan="4" class="text-center text-muted py-3">No manual activations recorded yet.</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
                             </div>
                         </div>
                     </div>

--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -144,6 +144,9 @@
                                     </td>
                                     <td>
                                         <strong>{{ message.event }}</strong>
+                                        {% if message.source == 'manual' %}
+                                        <span class="badge bg-info text-dark ms-2">Manual</span>
+                                        {% endif %}
                                         {% if message.alert_identifier %}
                                         <div class="small text-muted">{{ message.alert_identifier }}</div>
                                         {% endif %}
@@ -177,10 +180,10 @@
                                     <td>
                                         {% if message.alert_url %}
                                         <a href="{{ message.alert_url }}" class="btn btn-sm btn-outline-primary">
-                                            <i class="fas fa-eye"></i> View Alert
+                                            <i class="fas fa-eye"></i> {{ message.alert_label or 'View Alert' }}
                                         </a>
                                         {% else %}
-                                        <span class="text-muted">Manual or unknown source</span>
+                                        <span class="text-muted">No linked alert</span>
                                         {% endif %}
                                     </td>
                                     <td class="text-center">


### PR DESCRIPTION
## Summary
- combine manual EAS activation records with automated captures in the audio archive route, including pagination and filter metadata updates
- surface manual identifiers and download links in the archive table while counting both record types in the dashboard totals
- move the manual broadcast archive card to its own full-width section and document the fixes in the changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6901ae1421848320bf25debf030d6fb4