### PR TITLE
Enable SAME portion selection and nationwide code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ tracks releases under the 2.1.x series.
 
 ## [Unreleased]
 ### Added
+- Enabled the manual broadcast builder to target county subdivisions and the
+  nationwide 000000 SAME code by exposing P-digit selection alongside the
+  existing state and county pickers.
 - Introduced a dedicated Audio Archive history view with filtering, playback,
   printing, and Excel export support for every generated SAME package.
 - Surfaced archived audio links throughout the alert history and detail pages so

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -97,15 +97,15 @@ def load_eas_config(base_path: Optional[str] = None) -> Dict[str, object]:
 
 P_DIGIT_MEANINGS = {
     '0': 'Entire area',
-    '1': 'North portion',
-    '2': 'East portion',
-    '3': 'South portion',
-    '4': 'West portion',
+    '1': 'Northwest portion',
+    '2': 'North central portion',
+    '3': 'Northeast portion',
+    '4': 'West central portion',
     '5': 'Central portion',
-    '6': 'Northeast portion',
-    '7': 'Southeast portion',
-    '8': 'Southwest portion',
-    '9': 'Northwest portion',
+    '6': 'East central portion',
+    '7': 'Southwest portion',
+    '8': 'South central portion',
+    '9': 'Southeast portion',
 }
 
 ORIGINATOR_DESCRIPTIONS = {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -979,17 +979,21 @@
                                         <div class="mb-3 mt-3">
                                             <label class="form-label fw-bold">Location Codes (PSSCCC)</label>
                                             <div class="row g-2 align-items-end">
-                                                <div class="col-md-6">
+                                                <div class="col-md-5 col-lg-4">
                                                     <label for="easStateSelect" class="form-label text-uppercase small fw-bold text-muted mb-1">State / Territory</label>
                                                     <select class="form-select" id="easStateSelect">
                                                         <option value="">Select state or territory…</option>
                                                     </select>
                                                 </div>
-                                                <div class="col-md-6">
+                                                <div class="col-md-4 col-lg-5">
                                                     <label for="easCountySelect" class="form-label text-uppercase small fw-bold text-muted mb-1">County / Parish</label>
                                                     <select class="form-select" id="easCountySelect" disabled>
                                                         <option value="">Select a state first…</option>
                                                     </select>
+                                                </div>
+                                                <div class="col-md-3 col-lg-3">
+                                                    <label for="easPortionSelect" class="form-label text-uppercase small fw-bold text-muted mb-1">Portion (P digit)</label>
+                                                    <select class="form-select" id="easPortionSelect"></select>
                                                 </div>
                                             </div>
                                             <div class="d-flex flex-wrap gap-2 mt-2">
@@ -1020,7 +1024,7 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="form-text">Select PSSCCC entries by state and county or parish. The leading P digit marks the portion of the area (0 = entire jurisdiction).</div>
+                                            <div class="form-text">Select PSSCCC entries by state and county or parish. Choose a portion with the P digit (0 = entire jurisdiction).</div>
                                         </div>
 
                                         <div class="mb-3">
@@ -2489,6 +2493,28 @@
             };
         }
 
+        function populatePortionOptions() {
+            const portionSelect = document.getElementById('easPortionSelect');
+            if (!portionSelect) {
+                return;
+            }
+            portionSelect.innerHTML = '';
+
+            const digits = Object.keys(EAS_P_DIGIT_MEANINGS || {}).sort((a, b) => Number(a) - Number(b));
+            digits.forEach((digit) => {
+                const option = document.createElement('option');
+                option.value = digit;
+                const meaning = EAS_P_DIGIT_MEANINGS?.[digit];
+                option.textContent = meaning ? `${digit} — ${meaning}` : digit;
+                portionSelect.appendChild(option);
+            });
+
+            if (!portionSelect.value) {
+                portionSelect.value = '0';
+            }
+            portionSelect.disabled = true;
+        }
+
         function populateStateOptions() {
             const stateSelect = document.getElementById('easStateSelect');
             if (!stateSelect) {
@@ -2502,7 +2528,11 @@
                 }
                 const option = document.createElement('option');
                 option.value = state.abbr;
-                option.textContent = `${state.name || state.abbr} (${state.abbr})`;
+                if (state.abbr === 'US') {
+                    option.textContent = `${state.name || state.abbr} (Nationwide)`;
+                } else {
+                    option.textContent = `${state.name || state.abbr} (${state.abbr})`;
+                }
                 fragment.appendChild(option);
             });
             stateSelect.appendChild(fragment);
@@ -2510,11 +2540,16 @@
 
         function populateCountyOptions(stateAbbr, selectedCode = '') {
             const countySelect = document.getElementById('easCountySelect');
+            const portionSelect = document.getElementById('easPortionSelect');
             if (!countySelect) {
                 return;
             }
             countySelect.innerHTML = '';
             countySelect.disabled = true;
+            if (portionSelect) {
+                portionSelect.value = '0';
+                portionSelect.disabled = true;
+            }
 
             const placeholder = document.createElement('option');
             placeholder.value = '';
@@ -2548,8 +2583,18 @@
             });
 
             countySelect.disabled = false;
+            if (portionSelect) {
+                portionSelect.disabled = false;
+            }
             if (selectedCode) {
-                countySelect.value = selectedCode;
+                const normalized = normalizeSameCode(selectedCode);
+                if (normalized) {
+                    const baseCode = `0${normalized.slice(1)}`;
+                    countySelect.value = baseCode;
+                    if (portionSelect) {
+                        portionSelect.value = normalized[0] || '0';
+                    }
+                }
             }
         }
 
@@ -2572,10 +2617,11 @@
                     code,
                     description: code,
                     pMeaning: null,
+                    pDigit: code ? code[0] : '0',
                     isStatewide: false,
                 };
                 const portion = detail.pMeaning ? detail.pMeaning : `P=${escapeHtml(detail.code[0])}`;
-                const portionLabel = detail.isStatewide ? 'Entire jurisdiction' : portion;
+                const portionLabel = detail.isStatewide && detail.pDigit === '0' ? 'Entire jurisdiction' : portion;
                 return `
                     <div class="border rounded-3 p-2 bg-dark bg-opacity-10 d-flex align-items-center justify-content-between mb-2 gap-3">
                         <div class="flex-grow-1">
@@ -2673,6 +2719,7 @@
         function handleAddSameCode() {
             const stateSelect = document.getElementById('easStateSelect');
             const countySelect = document.getElementById('easCountySelect');
+            const portionSelect = document.getElementById('easPortionSelect');
             if (!stateSelect || !countySelect) {
                 return;
             }
@@ -2682,10 +2729,19 @@
                 setEasGeneratorStatus('Select a state and county before adding a location code.', 'warning');
                 return;
             }
-            addSameCodes([countyCode]);
+            const normalizedCounty = normalizeSameCode(countyCode);
+            if (!normalizedCounty) {
+                setEasGeneratorStatus('Unable to determine the SAME code for the selected area.', 'danger');
+                return;
+            }
+            const portionValue = portionSelect ? portionSelect.value : '0';
+            const normalizedPortion = /^[0-9]$/.test(portionValue) ? portionValue : '0';
+            const combinedCode = `${normalizedPortion}${normalizedCounty.slice(1)}`;
+            addSameCodes([combinedCode]);
         }
 
         function initializeSameCodeSelector() {
+            populatePortionOptions();
             populateStateOptions();
             populateCountyOptions('');
             updateSelectedSameCodesDisplay();


### PR DESCRIPTION
## Summary
- allow operators to choose P-digit portions when selecting SAME/FIPS locations in the admin console
- add nationwide 000000 SAME coverage and friendly labeling to the FIPS registry
- align the P-digit descriptions with FCC guidance and document the new capability

## Testing
- python -m compileall app_utils/eas.py app_utils/fips_codes.py

------
https://chatgpt.com/codex/tasks/task_e_6901b156e8148320b89187687d838989