### PR TITLE
Clarify pyttsx3 libespeak failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ tracks releases under the 2.1.x series.
   “No attention signal (omit)” option so manual packages can exclude the dual-tone or 1050 Hz
   alert when regulations allow.
 ### Fixed
+- Surface offline pyttsx3 narration failures in the Manual Broadcast Builder with
+  the underlying error details so operators can troubleshoot configuration
+  issues without digging through logs.
+- Detect missing libespeak dependencies when pyttsx3 fails and surface
+  installation guidance so offline narration can be restored quickly.
 - Count manual EAS activations when calculating Audio Archive totals and show them
   alongside automated captures so archived transmissions are visible in the history
   table.


### PR DESCRIPTION
## Summary
- add a pyttsx3 error hint that explains the missing libespeak dependency and how to install it
- ensure manual broadcast warnings surface the actionable remediation when offline narration fails
- document the improved troubleshooting guidance in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901b7db4bb483208f97d14943bebbcd