### PR TITLE
Fix M-Protocol display mode handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ tracks releases under the 2.1.x series.
   alert when regulations allow.
 - Bundled `ffmpeg`, `espeak`, and `libespeak-ng1` system packages in the Docker image so offline narration dependencies work out of the box during container builds.
 ### Fixed
+- Inserted the mandatory display-position byte in LED sign mode fields so M-Protocol
+  frames comply with Alpha controller requirements.
 - Surface offline pyttsx3 narration failures in the Manual Broadcast Builder with
   the underlying error details so operators can troubleshoot configuration
   issues without digging through logs.

--- a/led_sign_controller.py
+++ b/led_sign_controller.py
@@ -359,6 +359,7 @@ class Alpha9120CController:
         rgb_color: str = None,
         priority: MessagePriority = MessagePriority.NORMAL,
         file_label: str = "A",
+        display_position: str = " ",
     ) -> Optional[bytes]:
         """Build a complete M-Protocol message with all features.
 
@@ -401,8 +402,11 @@ class Alpha9120CController:
                 # Standard color
                 formatting += self.COLOR_CMD + color.value
 
-            # Display mode
-            formatting += self.MODE_CMD + mode.value
+            # Display mode (requires a position byte according to the M-Protocol spec)
+            position_char = (display_position or " ")[:1]
+            if not position_char:
+                position_char = " "
+            formatting += self.MODE_CMD + position_char + mode.value
 
             # Speed setting
             formatting += self.SPEED_CMD + speed.value


### PR DESCRIPTION
## Summary
- ensure the LED sign controller inserts the required display-position byte before display mode codes
- allow callers to override the position via a new optional parameter while defaulting to the middle-line space
- document the protocol compliance fix in the changelog

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6901ee8b226c8320af61f95ec3f52b28