### PR TITLE
Fix M-Protocol display mode handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # Core application settings
 # -----------------------------------------------------------------------------
 SECRET_KEY=replace-with-a-long-random-string
-APP_BUILD_VERSION=2.1.7
+APP_BUILD_VERSION=2.1.8
 NOAA_USER_AGENT=KR8MER CAP Alert System/2.1 (+https://github.com/KR8MER/noaa_alerts_systems)
 
 # -----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ tracks releases under the 2.1.x series.
 - Prevented the LED fallback initializer from raising a `NameError` when the optional
   controller module is missing so deployments without sign hardware continue to boot.
 
+## [2.1.8] - 2025-10-30
+### Fixed
+- Inserted the mandatory display-position byte in LED sign mode fields so M-Protocol
+  frames comply with Alpha controller requirements.
+
 ## [2.1.7] - 2025-10-29
 ### Removed
 - Purged IDE metadata, historical log outputs, unused static assets, and legacy diagnostic scripts

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ Flask Web Application with Enhanced Boundary Management and Alerts History
 
 Author: KR8MER Amateur Radio Emergency Communications
 Description: Emergency alert system with configurable U.S. jurisdiction support and proper timezone handling
-Version: 2.1.7 - Removes legacy artifacts and unused assets from the repository
+Version: 2.1.8 - Adds Alpha LED display-position compliance for M-Protocol messages
 """
 
 # =============================================================================
@@ -153,7 +153,7 @@ app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-key-change-in-production')
 
 # Application versioning (exposed via templates for quick deployment verification)
-SYSTEM_VERSION = os.environ.get('APP_BUILD_VERSION', '2.1.7')
+SYSTEM_VERSION = os.environ.get('APP_BUILD_VERSION', '2.1.8')
 
 # NOAA API configuration for manual alert import workflows
 NOAA_API_BASE_URL = 'https://api.weather.gov/alerts'

--- a/led_sign_controller.py
+++ b/led_sign_controller.py
@@ -359,6 +359,7 @@ class Alpha9120CController:
         rgb_color: str = None,
         priority: MessagePriority = MessagePriority.NORMAL,
         file_label: str = "A",
+        display_position: str = " ",
     ) -> Optional[bytes]:
         """Build a complete M-Protocol message with all features.
 
@@ -401,8 +402,11 @@ class Alpha9120CController:
                 # Standard color
                 formatting += self.COLOR_CMD + color.value
 
-            # Display mode
-            formatting += self.MODE_CMD + mode.value
+            # Display mode (requires a position byte according to the M-Protocol spec)
+            position_char = (display_position or " ")[:1]
+            if not position_char:
+                position_char = " "
+            formatting += self.MODE_CMD + position_char + mode.value
 
             # Speed setting
             formatting += self.SPEED_CMD + speed.value


### PR DESCRIPTION
## Summary
- ensure the LED sign controller inserts the required display-position byte before display mode codes
- allow callers to override the position via a new optional parameter while defaulting to the middle-line space
- document the protocol compliance fix in the changelog under a 2.1.8 release entry
- bump the application version metadata (environment defaults and fallback) to 2.1.8 so deployments advertise the new build

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_6901ee8b226c8320af61f95ec3f52b28