### PR TITLE
Track alert provenance and de-duplicate multi-feed polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # Core application settings
 # -----------------------------------------------------------------------------
 SECRET_KEY=replace-with-a-long-random-string
-APP_BUILD_VERSION=2.1.9
-NOAA_USER_AGENT=KR8MER CAP Alert System/2.1 (+https://github.com/KR8MER/noaa_alerts_systems)
+APP_BUILD_VERSION=2.2.0
+NOAA_USER_AGENT=KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/noaa_alerts_systems; NOAA+IPAWS)
 
 # -----------------------------------------------------------------------------
 # Database connection (PostgreSQL + PostGIS)
@@ -24,6 +24,10 @@ POSTGRES_PASSWORD=change-me
 # Poller and logging behaviour
 # -----------------------------------------------------------------------------
 POLL_INTERVAL_SEC=180
+# Optional override for CAP pollers; comma-separated list applied when set on a service.
+CAP_ENDPOINTS=
+# Default IPAWS CAP feed list consumed by the ipaws-poller service (comma-separated)
+IPAWS_CAP_FEED_URLS=https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/public/recent/2024-02-15T12:00:00Z
 LOG_LEVEL=INFO
 
 # -----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,3 +209,16 @@ tracks releases under the 2.1.x series.
 - Added containerized deployment assets (Dockerfile, docker-compose) and operational
   scripts for managing services.
 
+## [2.2.0] - 2025-10-29
+### Added
+- Recorded the originating feed for each CAP alert and poll cycle, exposing the source in the
+  alerts dashboard, detail view, exports, and LED signage.
+- Normalised IPAWS XML payloads with explicit source tagging and circle-to-polygon conversion
+  while tracking duplicate identifiers filtered during multi-feed polling.
+
+### Changed
+- Automatically migrate existing databases to include `cap_alerts.source` and
+  `poll_history.data_source` columns during application or poller start-up.
+- Surfaced poll provenance in the statistics dashboard, including the observed feed sources
+  for the most recent runs.
+

--- a/app_core/alerts.py
+++ b/app_core/alerts.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional, Tuple
 from flask import current_app, has_app_context
 from sqlalchemy import or_, text
 
-from app_utils import utc_now
+from app_utils import ALERT_SOURCE_NOAA, normalize_alert_source, utc_now
 
 from .extensions import db
 from .models import Boundary, CAPAlert, Intersection
@@ -190,6 +190,7 @@ def parse_noaa_cap_alert(alert_payload: dict) -> Optional[Tuple[dict, Optional[d
             "description": properties.get("description", "") or "",
             "instruction": properties.get("instruction", "") or "",
             "raw_json": alert_payload,
+            "source": normalize_alert_source(properties.get("source") or ALERT_SOURCE_NOAA),
         }
 
         return parsed, geometry

--- a/app_utils/__init__.py
+++ b/app_utils/__init__.py
@@ -16,6 +16,15 @@ from .time import (
 )
 from .formatting import format_bytes, format_uptime
 from .system import build_system_health_snapshot
+from .alert_sources import (
+    ALERT_SOURCE_IPAWS,
+    ALERT_SOURCE_MANUAL,
+    ALERT_SOURCE_NOAA,
+    ALERT_SOURCE_UNKNOWN,
+    expand_source_summary,
+    normalize_alert_source,
+    summarise_sources,
+)
 
 __all__ = [
     "PUTNAM_COUNTY_TZ",
@@ -33,4 +42,11 @@ __all__ = [
     "get_location_timezone",
     "get_location_timezone_name",
     "set_location_timezone",
+    "ALERT_SOURCE_NOAA",
+    "ALERT_SOURCE_IPAWS",
+    "ALERT_SOURCE_MANUAL",
+    "ALERT_SOURCE_UNKNOWN",
+    "normalize_alert_source",
+    "summarise_sources",
+    "expand_source_summary",
 ]

--- a/app_utils/alert_sources.py
+++ b/app_utils/alert_sources.py
@@ -1,0 +1,57 @@
+"""Canonical alert source identifiers and helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Set
+
+
+ALERT_SOURCE_NOAA = "NOAA"
+ALERT_SOURCE_IPAWS = "IPAWS"
+ALERT_SOURCE_MANUAL = "MANUAL"
+ALERT_SOURCE_UNKNOWN = "UNKNOWN"
+
+_VALID_SOURCES: Set[str] = {
+    ALERT_SOURCE_NOAA,
+    ALERT_SOURCE_IPAWS,
+    ALERT_SOURCE_MANUAL,
+    ALERT_SOURCE_UNKNOWN,
+}
+
+
+def normalize_alert_source(value: Optional[str]) -> str:
+    """Return a canonical alert source label for persistence/UI."""
+
+    if not value:
+        return ALERT_SOURCE_UNKNOWN
+
+    candidate = value.strip().upper()
+    if candidate in _VALID_SOURCES:
+        return candidate
+
+    # Allow callers to preface additional context (e.g. "NOAA REST")
+    # while still keeping the canonical prefix for downstream grouping.
+    for known in _VALID_SOURCES:
+        if candidate.startswith(f"{known} "):
+            return known
+
+    return ALERT_SOURCE_UNKNOWN
+
+
+def summarise_sources(values: Iterable[str]) -> str:
+    """Serialise a collection of sources for poll history tracking."""
+
+    normalised = {normalize_alert_source(item) for item in values if item}
+    normalised.discard(ALERT_SOURCE_UNKNOWN)
+    if not normalised:
+        return ALERT_SOURCE_UNKNOWN
+    return "|".join(sorted(normalised))
+
+
+def expand_source_summary(summary: Optional[str]) -> Set[str]:
+    """Expand a poll history summary string back to individual sources."""
+
+    if not summary:
+        return set()
+    parts = {part.strip() for part in summary.split("|") if part}
+    return {normalize_alert_source(part) for part in parts if part}
+

--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -9,6 +9,11 @@ services:
       alerts-db:
         condition: service_healthy
 
+  ipaws-poller:
+    depends_on:
+      alerts-db:
+        condition: service_healthy
+
   alerts-db:
     image: ${ALERTS_DB_IMAGE:-postgis/postgis:17-3.4}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,22 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  ipaws-poller:
+    image: noaa-alerts:latest
+    command:
+      - python
+      - poller/cap_poller.py
+      - --continuous
+      - --interval
+      - "120"
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
   alerts-db:
     image: ${ALERTS_DB_IMAGE:-postgis/postgis:17-3.4}
     profiles:

--- a/docs/ipaws_feed_integration.md
+++ b/docs/ipaws_feed_integration.md
@@ -1,0 +1,82 @@
+# IPAWS Feed and Pub/Sub Integration Overview
+
+This document distills guidance received from the IPAWS Program Management Office and
+outlines concrete ways our NOAA Alerts System can leverage the provided feeds and the AWS
+Simple Notification Service (SNS) pilot.
+
+## Key Takeaways
+
+- IPAWS exposes unauthenticated REST feeds for Emergency Alert System (EAS), Non-Weather
+  Emergency Messages (NWEM), Wireless Emergency Alerts (WEA), and the aggregated Public feed.
+- Vendors should poll staging feeds first, no more frequently than every two minutes, and
+  cache responses before redistributing alerts to end users.
+- Feeds return CAP XML payloads; the shared poller now parses those documents (including
+  polygons, circles, and SAME geocodes) into the existing alert ingestion workflow without
+  requiring separate code paths.
+- Alerts stored in PostGIS are now stamped with their originating feed (NOAA, IPAWS, or manual)
+  and the poller logs duplicate identifiers filtered from multi-feed runs.
+- IPAWS is piloting SNS topics that mirror the public feed to support push-style
+  integrations. Subscription options include email, HTTPS webhooks, and several AWS-native
+  targets.
+
+## REST Feed Consumption Strategy
+
+1. **Start in Staging**  
+   Use the provided staging URLs during development and QA:
+
+   - `https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/eas/recent/<timestamp>`
+   - `https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/nwem/recent/<timestamp>`
+   - `https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/PublicWEA/recent/<timestamp>`
+   - `https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/public/recent/<timestamp>`
+   - `https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/public_non_eas/recent/<timestamp>`
+
+   Replace `<timestamp>` with the ISO-8601 marker for the most recent alert we processed.
+
+2. **Implement Back-off and Caching**  
+   - Respect the two-minute polling guidance to avoid throttling.
+   - Store the raw CAP XML payloads in our database or object storage for downstream
+     dissemination.
+   - De-duplicate by `identifier` and `sent` timestamp to prevent replay. The shared poller
+     performs this automatically and records how many duplicates were discarded each cycle.
+
+3. **Redistribute Internally**  
+   - Surface alerts through our existing WebSocket, REST, and LED sign delivery pipelines.
+   - Maintain audit logs noting the source feed and retrieval time.
+
+4. **Transition to Production**  
+   Once staging integration is validated, swap the base domain to `https://apps.fema.gov`
+   and monitor for differences in volume or schema.
+
+## SNS Pub/Sub Integration Strategy
+
+1. **Subscription Setup**  
+   - Request addition of our preferred endpoint (e.g., HTTPS webhook or Amazon Kinesis Data
+     Firehose) to the `EAS_PUBLIC_FEED` topic via the IPAWS engineering team.
+   - Ensure the endpoint can receive and acknowledge SNS subscription confirmation
+     messages.
+
+2. **Message Handling**  
+   - SNS delivers the same payloads as the Public feed. Validate the message signature,
+     parse the CAP alert, and persist it via our existing ingestion pipeline.
+   - Consider using SNS as a trigger to accelerate pull-based refreshes when the polling
+     interval is too coarse.
+
+3. **Fallback and Monitoring**  
+   - Keep the REST polling flow active as a fallback until SNS topics reach parity for all
+     desired dissemination channels.
+   - Instrument metrics on delivery latency, failures, and retry counts.
+
+## Next Steps for Our Team
+
+- Prototype a staging poller that uses the public feed, respects caching guidance, and
+  hydrates our internal models.
+- Evaluate the HTTPS SNS subscription path by exposing a webhook endpoint (e.g.,
+  `/api/ipaws/sns`) capable of processing confirmation and notification messages.
+- Coordinate with the IPAWS Engineering Branch (fema-ipaws-eng@fema.dhs.gov) to register
+  our staging subscription and confirm production onboarding requirements.
+
+## Additional Resources
+
+- [IPAWS All-Hazard Info Feed overview](https://www.fema.gov/about/offices/national-continuity-programs/integrated-public-alert-warning-system/open-platform-emergency-networks)
+- [AWS SNS HTTP/HTTPS endpoint setup guide](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html)
+

--- a/led_sign_controller.py
+++ b/led_sign_controller.py
@@ -18,6 +18,7 @@ import json
 import re
 
 from app_utils.location_settings import DEFAULT_LOCATION_SETTINGS, ensure_list
+from app_utils.alert_sources import normalize_alert_source
 
 
 class MessagePriority(Enum):
@@ -1071,10 +1072,19 @@ class Alpha9120CController:
         lines = ['', '', '', '']
 
         # Line 1: Alert count or severity
+        source_label = normalize_alert_source(getattr(alert, 'source', None))
+        if source_label == 'UNKNOWN':
+            source_label = ''
+        header_parts = []
+        if source_label:
+            header_parts.append(source_label)
+        header_parts.append(alert.severity)
+        header_text = ' '.join(part for part in header_parts if part)
         if total_alerts > 1:
-            lines[0] = f"{alert.severity} ({total_alerts})"
+            header_text = f"{header_text} ({total_alerts})"
         else:
-            lines[0] = f"{alert.severity} ALERT"
+            header_text = f"{header_text} ALERT"
+        lines[0] = header_text[:self.max_chars_per_line]
 
         # Line 2: Event type
         lines[1] = alert.event[:self.max_chars_per_line]

--- a/manual_alert_fetch.py
+++ b/manual_alert_fetch.py
@@ -24,6 +24,7 @@ from app import (
     normalize_manual_import_datetime,
     format_noaa_timestamp,
 )
+from app_utils import ALERT_SOURCE_NOAA
 
 
 def parse_cli_datetime(raw_value: str, description: str) -> datetime:
@@ -133,6 +134,7 @@ def execute_import(args: argparse.Namespace) -> int:
             continue
 
         parsed, geometry = parsed_result
+        parsed.setdefault('source', ALERT_SOURCE_NOAA)
         alert_identifier = parsed['identifier']
 
         if alert_identifier not in identifiers:

--- a/manual_eas_event.py
+++ b/manual_eas_event.py
@@ -22,6 +22,7 @@ from app import (
     parse_nws_datetime,
     utc_now,
 )
+from app_utils import ALERT_SOURCE_MANUAL
 from app_utils.eas import EASBroadcaster, load_eas_config
 from app_utils.event_codes import (
     ALL_EVENT_CODES,
@@ -435,6 +436,7 @@ def broadcast_manual_cap(
         payload.pop('_geometry_data', None)
         payload['event_code'] = broadcast_event_code
         payload['event_codes'] = event_codes
+        payload['source'] = ALERT_SOURCE_MANUAL
 
         existing = CAPAlert.query.filter_by(identifier=payload['identifier']).first()
         action = 'created'

--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -993,7 +993,10 @@
                             {% if alert.raw_json %}
                             <div class="mt-3">
                                 <small class="text-muted">
-                                    <strong>Data Source:</strong> {{ alert.raw_json.get('properties', {}).get('@id', 'Unknown') if alert.raw_json.get('properties') else 'Unknown' }}<br>
+                                    <strong>Source:</strong> {{ (alert.source or 'UNKNOWN')|upper }}<br>
+                                    {% if alert.raw_json.get('properties', {}).get('@id') %}
+                                    <strong>Origin URI:</strong> {{ alert.raw_json.get('properties', {}).get('@id') }}<br>
+                                    {% endif %}
                                     <strong>Last Updated:</strong> {{ alert.updated_at | format_local_datetime if alert.updated_at else 'Unknown' }}
                                 </small>
                             </div>

--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -104,6 +104,17 @@
                                 </select>
                             </div>
                             <div class="col-md-2">
+                                <label for="source" class="form-label">Source</label>
+                                <select class="form-select" id="source" name="source">
+                                    <option value="">All Sources</option>
+                                    {% for source in sources %}
+                                    <option value="{{ source }}" {% if source == current_filters.source %}selected{% endif %}>
+                                        {{ source }}
+                                    </option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-2">
                                 <label for="per_page" class="form-label">Per Page</label>
                                 <select class="form-select" id="per_page" name="per_page">
                                     <option value="25" {% if current_filters.per_page == 25 %}selected{% endif %}>25</option>
@@ -157,6 +168,7 @@
                                     <th>Event</th>
                                     <th>Severity</th>
                                     <th>Status</th>
+                                    <th>Source</th>
                                     <th>Sent</th>
                                     <th>Expires</th>
                                     <th>Headline</th>
@@ -183,6 +195,13 @@
                                     </td>
                                     <td>
                                         <span class="badge bg-outline-secondary">{{ alert.status }}</span>
+                                    </td>
+                                    <td>
+                                        {% if alert.source %}
+                                        <span class="badge bg-dark text-uppercase">{{ alert.source }}</span>
+                                        {% else %}
+                                        <span class="text-muted">Unknown</span>
+                                        {% endif %}
                                     </td>
                                     <td>
                                         <small class="text-muted">

--- a/templates/stats/_scripts.html
+++ b/templates/stats/_scripts.html
@@ -468,7 +468,11 @@ function updateKpiCards(aggregates) {
     }
     const reliabilityDelta = document.getElementById('reliabilityDelta');
     if (reliabilityDelta && statsData.polling) {
-        reliabilityDelta.textContent = `Source: ${statsData.polling.data_source || 'poll_history'}`;
+        const provenance = statsData.polling.data_source || 'poll_history';
+        const sources = (statsData.polling.sources && statsData.polling.sources.length)
+            ? statsData.polling.sources.join(', ')
+            : 'Unknown';
+        reliabilityDelta.textContent = `Source: ${sources} (${provenance})`;
     }
 }
 


### PR DESCRIPTION
## Summary
- capture the originating feed for each CAP alert and poll run, auto-migrate database columns, and expose the source throughout the UI, exports, statistics, and LED signage
- extend the CAP poller to normalise IPAWS XML payloads, tag them as IPAWS, and track filtered duplicate identifiers while logging observed feed sources
- document the new provenance workflow, bump the application version to 2.2.0, and surface the source filter/metadata in the dashboard

## Testing
- python -m py_compile app.py poller/cap_poller.py app_core/alerts.py app_core/models.py led_sign_controller.py manual_alert_fetch.py manual_eas_event.py app_utils/__init__.py app_utils/alert_sources.py

------
https://chatgpt.com/codex/tasks/task_e_69022367c4348320a50a91195d037e75