### PR TITLE
Guard purge admin route

### DIFF
--- a/webapp/routes_admin.py
+++ b/webapp/routes_admin.py
@@ -13,12 +13,14 @@ from flask import (
     abort,
     current_app,
     flash,
+    g,
     jsonify,
     redirect,
     render_template,
     render_template_string,
     request,
     send_file,
+    session,
     url_for,
 )
 from sqlalchemy import desc, func, or_
@@ -1515,6 +1517,9 @@ def register(app, logger):
 
     @app.route('/admin/eas_messages/purge', methods=['POST'])
     def admin_purge_eas_messages():
+        if g.current_user is None:
+            return jsonify({'error': 'Authentication required.'}), 401
+
         payload = request.get_json(silent=True) or {}
 
         ids = payload.get('ids')


### PR DESCRIPTION
## Summary
- import the Flask g and session helpers used by the admin routes
- require an authenticated admin user before allowing bulk EAS message purges

## Testing
- python -m compileall webapp/routes_admin.py

------
https://chatgpt.com/codex/tasks/task_e_69023dfbd7c88320b4cb7316c085568a