### PR TITLE
Ensure PostGIS extension before database initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,7 @@ from webapp.admin.boundaries import (
     ensure_alert_source_columns,
     ensure_boundary_geometry_column,
 )
+from app_core.database import ensure_postgis_extension
 # Re-export manual import utilities for CLI scripts that import from ``app``.
 from webapp.admin.maintenance import (
     NOAAImportError,
@@ -543,7 +544,7 @@ def initialize_database():
         return
 
     try:
-        if not ensure_postgis_extension():
+        if not ensure_postgis_extension(logger):
             _db_initialization_error = RuntimeError("PostGIS extension could not be ensured")
             return False
         db.create_all()

--- a/app_core/database.py
+++ b/app_core/database.py
@@ -1,0 +1,58 @@
+"""Database helpers for ensuring optional PostgreSQL/PostGIS features."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+from app_core.extensions import db
+
+
+def ensure_postgis_extension(logger: Any) -> bool:
+    """Ensure the PostGIS extensions are available when using PostgreSQL."""
+
+    engine = db.engine
+    if engine.dialect.name != "postgresql":
+        logger.debug(
+            "Skipping PostGIS extension check for non-PostgreSQL database (%s)",
+            engine.dialect.name,
+        )
+        return True
+
+    try:
+        with engine.connect() as connection:
+            connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+
+            postgis_installed = connection.execute(
+                text("SELECT 1 FROM pg_extension WHERE extname = 'postgis'")
+            ).scalar()
+
+            if not postgis_installed:
+                logger.info("Enabling PostGIS extension for spatial operations")
+                connection.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+            else:
+                logger.debug("PostGIS extension already enabled")
+
+            try:
+                topology_installed = connection.execute(
+                    text("SELECT 1 FROM pg_extension WHERE extname = 'postgis_topology'")
+                ).scalar()
+                if not topology_installed:
+                    connection.execute(
+                        text("CREATE EXTENSION IF NOT EXISTS postgis_topology")
+                    )
+            except SQLAlchemyError as exc:
+                logger.debug(
+                    "PostGIS topology extension could not be enabled automatically: %s",
+                    exc,
+                )
+
+        return True
+    except SQLAlchemyError as exc:
+        logger.error("Failed to ensure PostGIS extension: %s", exc)
+        return False
+
+
+__all__ = ["ensure_postgis_extension"]


### PR DESCRIPTION
## Summary
- add a reusable database helper that ensures the PostGIS extensions are installed when connecting to PostgreSQL
- call the helper during application startup so the previous NameError is resolved and spatial tables can be created safely

## Testing
- python3 -m py_compile app.py app_core/database.py

------
https://chatgpt.com/codex/tasks/task_e_690267f8952883209de02251c2c42526