### PR TITLE
Remove duplicate monitoring routes from app module

### DIFF
--- a/app.py
+++ b/app.py
@@ -369,60 +369,6 @@ def bad_request_error(error):
 
 
 # =============================================================================
-# HEALTH CHECK AND MONITORING ROUTES
-# =============================================================================
-
-@app.route('/health')
-def health_check():
-    """Simple health check endpoint"""
-    try:
-        # Test database connection
-        db.session.execute(text('SELECT 1')).fetchone()
-
-        return jsonify({
-            'status': 'healthy',
-            'timestamp': utc_now().isoformat(),
-            'local_timestamp': local_now().isoformat(),
-            'version': SYSTEM_VERSION,
-            'database': 'connected',
-            'led_available': LED_AVAILABLE
-        })
-    except Exception as e:
-        return jsonify({
-            'status': 'unhealthy',
-            'error': str(e),
-            'timestamp': utc_now().isoformat(),
-            'local_timestamp': local_now().isoformat()
-        }), 500
-
-
-@app.route('/ping')
-def ping():
-    """Simple ping endpoint"""
-    return jsonify({
-        'pong': True,
-        'timestamp': utc_now().isoformat(),
-        'local_timestamp': local_now().isoformat()
-    })
-
-
-@app.route('/version')
-def version():
-    """Version information endpoint"""
-    location = get_location_settings()
-    return jsonify({
-        'version': SYSTEM_VERSION,
-        'name': 'NOAA CAP Alerts System',
-        'author': 'KR8MER Amateur Radio Emergency Communications',
-        'description': f"Emergency alert system for {location['county_name']}, {location['state_code']}",
-        'timezone': get_location_timezone_name(),
-        'led_available': LED_AVAILABLE,
-        'timestamp': utc_now().isoformat(),
-        'local_timestamp': local_now().isoformat()
-    })
-
-
-# =============================================================================
 # ADDITIONAL UTILITY ROUTES
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- remove the inline /health, /ping, and /version routes from app.py to avoid conflicting with the monitoring blueprint

## Testing
- python3 -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_6902795ddf2483209c8448d46392ed3d