### PR TITLE
Fix audio event deletion not working

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,7 @@ from app_utils.eas import (
 from app_core.eas_storage import (
     backfill_eas_message_payloads,
     ensure_eas_audio_columns,
+    ensure_eas_message_foreign_key,
     get_eas_static_prefix,
 )
 from app_core.system_health import get_system_health
@@ -541,6 +542,11 @@ def initialize_database():
         if not ensure_eas_audio_columns(logger):
             _db_initialization_error = RuntimeError(
                 "EAS audio columns could not be ensured"
+            )
+            return False
+        if not ensure_eas_message_foreign_key(logger):
+            _db_initialization_error = RuntimeError(
+                "EAS message foreign key constraint could not be ensured"
             )
             return False
         backfill_eas_message_payloads(logger)

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -167,7 +167,7 @@ class EASMessage(db.Model):
     __tablename__ = "eas_messages"
 
     id = db.Column(db.Integer, primary_key=True)
-    cap_alert_id = db.Column(db.Integer, db.ForeignKey("cap_alerts.id"), index=True)
+    cap_alert_id = db.Column(db.Integer, db.ForeignKey("cap_alerts.id", ondelete="SET NULL"), index=True)
     same_header = db.Column(db.String(255), nullable=False)
     audio_filename = db.Column(db.String(255), nullable=False)
     text_filename = db.Column(db.String(255), nullable=False)


### PR DESCRIPTION
The EASMessage.cap_alert_id foreign key constraint was preventing deletion of audio events. The database was enforcing referential integrity without a defined ON DELETE behavior, blocking deletions.

Changes:
- Updated EASMessage model to include ondelete="SET NULL" in foreign key
- Added ensure_eas_message_foreign_key() function to migrate existing databases
- Function automatically detects and updates the constraint on app startup
- Follows existing migration pattern used by ensure_eas_audio_columns()

This allows audio events to be deleted while preserving data integrity. If a parent CAPAlert is deleted, the EASMessage.cap_alert_id is set to NULL.

Files modified:
- app_core/models.py: Updated foreign key definition
- app_core/eas_storage.py: Added migration function
- app.py: Call migration during database initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)