### PR TITLE
Fix template syntax error and JSON serialization bug

### DIFF
--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -149,6 +149,7 @@
         </div>
     </div>
 </div>
+{% endblock %}
 
 {% block scripts %}
 <script>

--- a/webapp/admin/audio/manual.py
+++ b/webapp/admin/audio/manual.py
@@ -268,6 +268,13 @@ def register_manual_routes(app, logger, eas_config) -> None:
             'composite': composite_component,
         }
 
+        # Create response-safe components without wav_bytes (not JSON serializable)
+        response_components = {
+            key: {k: v for k, v in value.items() if k != 'wav_bytes'}
+            for key, value in stored_components.items()
+            if value
+        }
+
         response_payload: Dict[str, Any] = {
             'identifier': identifier,
             'event_code': resolved_event_code,
@@ -283,7 +290,7 @@ def register_manual_routes(app, logger, eas_config) -> None:
             'duration_minutes': duration_minutes,
             'sent_at': sent_dt.isoformat(),
             'expires_at': expires_dt.isoformat(),
-            'components': stored_components,
+            'components': response_components,
             'sample_rate': sample_rate,
             'same_header_detail': header_detail,
             'storage_path': storage_root,


### PR DESCRIPTION
Fixed two critical bugs preventing manual EAS generation:

1. Template Syntax Error (manual_eas_print.html):
   - Missing {% endblock %} to close the content block
   - Was opening scripts block before closing content block
   - Added proper endblock tag before scripts section

2. JSON Serialization Error (manual.py):
   - wav_bytes (binary data) was being included in JSON response
   - Created response_components dict that excludes wav_bytes
   - Kept wav_bytes in stored_components for database storage
   - Only JSON-safe fields sent in API response

Both issues now resolved - manual EAS generation works correctly and audio data is properly stored in database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)