### PR TITLE
Add IPAWS poller debug capture and dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ from app_core.eas_storage import (
     get_eas_static_prefix,
 )
 from app_core.system_health import get_system_health
+from app_core.poller_debug import ensure_poll_debug_table
 from webapp import register_routes
 from webapp.admin.boundaries import (
     ensure_alert_source_columns,
@@ -124,6 +125,7 @@ from app_core.models import (
     LEDMessage,
     LEDSignStatus,
     LocationSettings,
+    PollDebugRecord,
     PollHistory,
     SystemLog,
 )
@@ -554,6 +556,11 @@ def initialize_database():
         if not ensure_manual_eas_audio_columns(logger):
             _db_initialization_error = RuntimeError(
                 "Manual EAS audio columns could not be ensured"
+            )
+            return False
+        if not ensure_poll_debug_table(logger):
+            _db_initialization_error = RuntimeError(
+                "Poll debug table could not be ensured"
             )
             return False
         backfill_eas_message_payloads(logger)

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -292,6 +292,38 @@ class PollHistory(db.Model):
     data_source = db.Column(db.String(64))
 
 
+class PollDebugRecord(db.Model):
+    __tablename__ = "poll_debug_records"
+
+    id = db.Column(db.Integer, primary_key=True)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
+    poll_run_id = db.Column(db.String(64), nullable=False, index=True)
+    poll_started_at = db.Column(db.DateTime(timezone=True), nullable=False)
+    poll_status = db.Column(db.String(20), nullable=False, default="UNKNOWN")
+    data_source = db.Column(db.String(64))
+    alert_identifier = db.Column(db.String(255))
+    alert_event = db.Column(db.String(255))
+    alert_sent = db.Column(db.DateTime(timezone=True))
+    source = db.Column(db.String(64))
+    is_relevant = db.Column(db.Boolean, default=False, nullable=False)
+    relevance_reason = db.Column(db.String(255))
+    relevance_matches = db.Column(db.JSON, default=list)
+    ugc_codes = db.Column(db.JSON, default=list)
+    area_desc = db.Column(db.Text)
+    was_saved = db.Column(db.Boolean, default=False, nullable=False)
+    was_new = db.Column(db.Boolean, default=False, nullable=False)
+    alert_db_id = db.Column(db.Integer)
+    parse_success = db.Column(db.Boolean, default=False, nullable=False)
+    parse_error = db.Column(db.Text)
+    polygon_count = db.Column(db.Integer)
+    geometry_type = db.Column(db.String(64))
+    geometry_geojson = db.Column(db.JSON)
+    geometry_preview = db.Column(db.JSON)
+    raw_properties = db.Column(db.JSON)
+    raw_xml_present = db.Column(db.Boolean, default=False, nullable=False)
+    notes = db.Column(db.Text)
+
+
 class LocationSettings(db.Model):
     __tablename__ = "location_settings"
 

--- a/app_core/poller_debug.py
+++ b/app_core/poller_debug.py
@@ -1,0 +1,93 @@
+"""Utilities for capturing and presenting poller debug information."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy import inspect
+from sqlalchemy.exc import SQLAlchemyError
+
+from .extensions import db
+from .models import PollDebugRecord
+
+
+def ensure_poll_debug_table(logger) -> bool:
+    """Ensure the poll_debug_records table exists before it is queried."""
+
+    try:
+        PollDebugRecord.__table__.create(bind=db.engine, checkfirst=True)
+        inspector = inspect(db.engine)
+        if "poll_debug_records" not in inspector.get_table_names():
+            logger.error("poll_debug_records table missing after creation attempt")
+            return False
+        return True
+    except SQLAlchemyError as exc:
+        logger.error("Failed to ensure poll_debug_records table: %s", exc)
+        return False
+
+
+def serialise_debug_record(record: PollDebugRecord) -> dict:
+    """Convert a ``PollDebugRecord`` into JSON-friendly data for templates."""
+
+    return {
+        "id": record.id,
+        "created_at": record.created_at,
+        "poll_run_id": record.poll_run_id,
+        "poll_started_at": record.poll_started_at,
+        "poll_status": record.poll_status,
+        "data_source": record.data_source,
+        "alert_identifier": record.alert_identifier,
+        "alert_event": record.alert_event,
+        "alert_sent": record.alert_sent,
+        "source": record.source,
+        "is_relevant": record.is_relevant,
+        "relevance_reason": record.relevance_reason,
+        "relevance_matches": record.relevance_matches or [],
+        "ugc_codes": record.ugc_codes or [],
+        "area_desc": record.area_desc,
+        "was_saved": record.was_saved,
+        "was_new": record.was_new,
+        "alert_db_id": record.alert_db_id,
+        "parse_success": record.parse_success,
+        "parse_error": record.parse_error,
+        "polygon_count": record.polygon_count,
+        "geometry_type": record.geometry_type,
+        "geometry_geojson": record.geometry_geojson,
+        "geometry_preview": record.geometry_preview,
+        "raw_properties": record.raw_properties,
+        "raw_xml_present": record.raw_xml_present,
+        "notes": record.notes,
+    }
+
+
+def summarise_run(records: Iterable[PollDebugRecord]) -> dict:
+    """Aggregate a poll run into summary metadata plus serialised alerts."""
+
+    serialised: List[dict] = [serialise_debug_record(record) for record in records]
+    if not serialised:
+        return {"alerts": [], "totals": {}}
+
+    totals = {
+        "alerts": len(serialised),
+        "accepted": sum(1 for item in serialised if item.get("is_relevant")),
+        "saved": sum(1 for item in serialised if item.get("was_saved")),
+        "new_saved": sum(1 for item in serialised if item.get("was_new")),
+        "parse_failures": sum(1 for item in serialised if not item.get("parse_success")),
+    }
+
+    base = serialised[0]
+    return {
+        "poll_run_id": base.get("poll_run_id"),
+        "poll_started_at": base.get("poll_started_at"),
+        "poll_status": base.get("poll_status"),
+        "data_source": base.get("data_source"),
+        "alerts": serialised,
+        "totals": totals,
+    }
+
+
+__all__ = [
+    "ensure_poll_debug_table",
+    "serialise_debug_record",
+    "summarise_run",
+]

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 import json
+import uuid
 import requests
 import logging
 import hashlib
@@ -105,7 +106,16 @@ try:
     if project_root.endswith('/poller'):
         project_root = os.path.dirname(project_root)
     sys.path.insert(0, project_root)
-    from app import db, CAPAlert, SystemLog, Boundary, Intersection, LocationSettings, EASMessage  # type: ignore
+    from app import (
+        db,
+        CAPAlert,
+        SystemLog,
+        Boundary,
+        Intersection,
+        LocationSettings,
+        EASMessage,
+        PollDebugRecord,
+    )  # type: ignore
     from sqlalchemy import Column, Integer, String, DateTime, Text, JSON  # noqa: F401
 
     class PollHistory(db.Model):  # type: ignore
@@ -215,6 +225,37 @@ except Exception as e:
         error_message = Column(Text)
         data_source = Column(String(64))
 
+    class PollDebugRecord(Base):
+        __tablename__ = 'poll_debug_records'
+        __table_args__ = {'extend_existing': True}
+        id = Column(Integer, primary_key=True)
+        created_at = Column(DateTime, default=utc_now)
+        poll_run_id = Column(String(64), index=True)
+        poll_started_at = Column(DateTime, nullable=False)
+        poll_status = Column(String(20), default='UNKNOWN')
+        data_source = Column(String(64))
+        alert_identifier = Column(String(255))
+        alert_event = Column(String(255))
+        alert_sent = Column(DateTime)
+        source = Column(String(64))
+        is_relevant = Column(Boolean, default=False)
+        relevance_reason = Column(String(255))
+        relevance_matches = Column(JSON)
+        ugc_codes = Column(JSON)
+        area_desc = Column(Text)
+        was_saved = Column(Boolean, default=False)
+        was_new = Column(Boolean, default=False)
+        alert_db_id = Column(Integer)
+        parse_success = Column(Boolean, default=False)
+        parse_error = Column(Text)
+        polygon_count = Column(Integer)
+        geometry_type = Column(String(64))
+        geometry_geojson = Column(JSON)
+        geometry_preview = Column(JSON)
+        raw_properties = Column(JSON)
+        raw_xml_present = Column(Boolean, default=False)
+        notes = Column(Text)
+
     class LocationSettings(Base):
         __tablename__ = 'location_settings'
         __table_args__ = {'extend_existing': True}
@@ -280,6 +321,8 @@ class CAPPoller:
             self.logger.warning(f"Database table verification failed: {e}")
 
         self._ensure_source_columns()
+        self._debug_table_checked = False
+        self._ensure_debug_records_table()
 
         self.location_settings = self._load_location_settings()
         self.location_name = f"{self.location_settings['county_name']}, {self.location_settings['state_code']}".strip(', ')
@@ -413,6 +456,17 @@ class CAPPoller:
                 self.db_session.rollback()
             except Exception:
                 pass
+
+    def _ensure_debug_records_table(self) -> bool:
+        if getattr(self, "_debug_table_checked", False):
+            return self._debug_table_checked
+        try:
+            PollDebugRecord.__table__.create(bind=self.engine, checkfirst=True)
+            self._debug_table_checked = True
+        except Exception as exc:
+            self.logger.debug("Could not ensure poll_debug_records table: %s", exc)
+            self._debug_table_checked = False
+        return self._debug_table_checked
 
     # ---------- Engine with retry ----------
     def _load_location_settings(self) -> Dict[str, Any]:
@@ -841,30 +895,119 @@ class CAPPoller:
 
         return unique_alerts
 
+    def _safe_json_copy(self, value: Any) -> Any:
+        try:
+            return json.loads(json.dumps(value, default=str))
+        except Exception:
+            return value
+
+    def _summarise_geometry(self, geometry: Optional[Dict]) -> Tuple[Optional[str], Optional[int], Optional[List[List[float]]]]:
+        if not geometry or not isinstance(geometry, dict):
+            return None, None, None
+
+        geom_type = geometry.get('type')
+        coordinates = geometry.get('coordinates')
+        polygon_count: Optional[int] = None
+        preview: Optional[List[List[float]]] = None
+
+        if geom_type == 'Polygon':
+            polygon_count = 1
+            rings = coordinates or []
+            if rings and isinstance(rings, list) and rings[0]:
+                preview = [list(point) for point in rings[0][: min(len(rings[0]), 12)]]
+        elif geom_type == 'MultiPolygon':
+            polygon_count = len(coordinates or []) if isinstance(coordinates, list) else 0
+            if coordinates and isinstance(coordinates, list):
+                first_polygon = coordinates[0] or []
+                if first_polygon and isinstance(first_polygon, list) and first_polygon[0]:
+                    preview = [list(point) for point in first_polygon[0][: min(len(first_polygon[0]), 12)]]
+        else:
+            if isinstance(coordinates, list):
+                polygon_count = len(coordinates)
+                preview = [list(point) for point in coordinates[: min(len(coordinates), 12)]]
+
+        return geom_type, polygon_count, preview
+
     # ---------- Relevance ----------
-    def is_relevant_alert(self, alert_data: Dict) -> bool:
+    def get_alert_relevance_details(self, alert_data: Dict) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            'is_relevant': False,
+            'reason': 'NO_MATCH',
+            'matched_ugc': None,
+            'matched_terms': [],
+            'relevance_matches': [],
+            'ugc_codes': [],
+            'area_desc': '',
+            'log': None,
+        }
+
         try:
             properties = alert_data.get('properties', {})
             event = properties.get('event', 'Unknown')
-            geocode = properties.get('geocode', {})
+            geocode = properties.get('geocode', {}) or {}
             ugc_codes = geocode.get('UGC', []) or []
+            normalized_ugc = [str(ugc).upper() for ugc in ugc_codes if ugc]
+            result['ugc_codes'] = normalized_ugc
 
-            for ugc in ugc_codes:
-                if str(ugc).upper() in self.zone_codes:
-                    self.logger.info(f"✓ Alert ACCEPTED by UGC: {event} ({ugc})")
-                    return True
+            area_desc_raw = properties.get('areaDesc') or ''
+            if isinstance(area_desc_raw, list):
+                area_desc_raw = '; '.join(area_desc_raw)
+            area_desc_upper = area_desc_raw.upper()
+            result['area_desc'] = area_desc_raw
 
-            area_desc = (properties.get('areaDesc') or '').upper()
-            matched_terms = [term for term in self.putnam_county_identifiers if term and term in area_desc]
+            for ugc in normalized_ugc:
+                if ugc in self.zone_codes:
+                    message = f"✓ Alert ACCEPTED by UGC: {event} ({ugc})"
+                    result.update(
+                        {
+                            'is_relevant': True,
+                            'reason': 'UGC_MATCH',
+                            'matched_ugc': ugc,
+                            'relevance_matches': [ugc],
+                            'log': {'level': 'info', 'message': message},
+                        }
+                    )
+                    return result
+
+            matched_terms = [
+                term for term in self.putnam_county_identifiers if term and term in area_desc_upper
+            ]
+            result['matched_terms'] = matched_terms
             if matched_terms:
-                self.logger.info(f"✓ Alert ACCEPTED by area match: {event} ({matched_terms[0]})")
-                return True
+                message = f"✓ Alert ACCEPTED by area match: {event} ({matched_terms[0]})"
+                result.update(
+                    {
+                        'is_relevant': True,
+                        'reason': 'AREA_MATCH',
+                        'relevance_matches': matched_terms,
+                        'log': {'level': 'info', 'message': message},
+                    }
+                )
+                return result
 
-            self.logger.info(f"✗ REJECT (not specific enough for {self.county_upper}): {event} - {area_desc}")
-            return False
-        except Exception as e:
-            self.logger.error(f"Error checking relevance: {e}")
-            return False
+            message = (
+                f"✗ REJECT (not specific enough for {self.county_upper}): {event} - {area_desc_upper}"
+            )
+            result['log'] = {'level': 'info', 'message': message}
+            return result
+        except Exception as exc:
+            result['log'] = {'level': 'error', 'message': f"Error checking relevance: {exc}"}
+            result['error'] = str(exc)
+            return result
+
+    def is_relevant_alert(self, alert_data: Dict) -> bool:
+        details = self.get_alert_relevance_details(alert_data)
+        log_entry = details.get('log') or {}
+        message = log_entry.get('message')
+        if message:
+            level = (log_entry.get('level') or 'info').lower()
+            if level == 'error':
+                self.logger.error(message)
+            elif level == 'warning':
+                self.logger.warning(message)
+            else:
+                self.logger.info(message)
+        return bool(details.get('is_relevant'))
 
     # ---------- Parse ----------
     def parse_cap_alert(self, alert_data: Dict) -> Optional[Dict]:
@@ -1086,6 +1229,104 @@ class CAPPoller:
             stats['errors'] += 1
         return stats
 
+    def _initialise_debug_entry(
+        self,
+        alert_data: Dict,
+        relevance: Dict[str, Any],
+        poll_run_id: str,
+        poll_started_at: datetime,
+    ) -> Dict[str, Any]:
+        properties = alert_data.get('properties', {})
+        identifier = (properties.get('identifier') or '').strip() or 'No ID'
+        sent_raw = properties.get('sent')
+        sent_dt = parse_nws_datetime(sent_raw) if sent_raw else None
+        geometry = alert_data.get('geometry') if isinstance(alert_data.get('geometry'), dict) else None
+        geom_type, polygon_count, preview = self._summarise_geometry(geometry)
+
+        log_entry = relevance.get('log') if isinstance(relevance, dict) else None
+        notes: List[str] = []
+        if log_entry and log_entry.get('message'):
+            notes.append(str(log_entry['message']))
+
+        entry = {
+            'poll_run_id': poll_run_id,
+            'poll_started_at': poll_started_at,
+            'identifier': identifier,
+            'event': properties.get('event', 'Unknown'),
+            'alert_sent': sent_dt,
+            'source': properties.get('source'),
+            'raw_properties': self._safe_json_copy(properties),
+            'geometry_geojson': self._safe_json_copy(geometry) if geometry else None,
+            'geometry_preview': preview,
+            'geometry_type': geom_type,
+            'polygon_count': polygon_count,
+            'is_relevant': relevance.get('is_relevant', False),
+            'relevance_reason': relevance.get('reason'),
+            'relevance_matches': relevance.get('relevance_matches', []),
+            'ugc_codes': relevance.get('ugc_codes', []),
+            'area_desc': relevance.get('area_desc'),
+            'raw_xml_present': bool(alert_data.get('raw_xml')),
+            'parse_success': False,
+            'parse_error': None,
+            'was_saved': False,
+            'was_new': False,
+            'alert_db_id': None,
+            'notes': notes,
+        }
+
+        return entry
+
+    def persist_debug_records(
+        self,
+        poll_run_id: str,
+        poll_started_at: datetime,
+        stats: Dict[str, Any],
+        debug_records: List[Dict[str, Any]],
+    ) -> None:
+        if not debug_records:
+            return
+        if not self._ensure_debug_records_table():
+            return
+
+        try:
+            data_source = summarise_sources(stats.get('sources', []))
+            for entry in debug_records:
+                record = PollDebugRecord(
+                    poll_run_id=poll_run_id,
+                    poll_started_at=poll_started_at,
+                    poll_status=stats.get('status', 'UNKNOWN'),
+                    data_source=data_source,
+                    alert_identifier=entry.get('identifier'),
+                    alert_event=entry.get('event'),
+                    alert_sent=entry.get('alert_sent'),
+                    source=entry.get('source'),
+                    is_relevant=entry.get('is_relevant', False),
+                    relevance_reason=entry.get('relevance_reason'),
+                    relevance_matches=self._safe_json_copy(entry.get('relevance_matches')),
+                    ugc_codes=self._safe_json_copy(entry.get('ugc_codes')),
+                    area_desc=entry.get('area_desc'),
+                    was_saved=entry.get('was_saved', False),
+                    was_new=entry.get('was_new', False),
+                    alert_db_id=entry.get('alert_db_id'),
+                    parse_success=entry.get('parse_success', False),
+                    parse_error=entry.get('parse_error'),
+                    polygon_count=entry.get('polygon_count'),
+                    geometry_type=entry.get('geometry_type'),
+                    geometry_geojson=self._safe_json_copy(entry.get('geometry_geojson')),
+                    geometry_preview=self._safe_json_copy(entry.get('geometry_preview')),
+                    raw_properties=self._safe_json_copy(entry.get('raw_properties')),
+                    raw_xml_present=entry.get('raw_xml_present', False),
+                    notes="\n".join(filter(None, entry.get('notes', []))) or None,
+                )
+                self.db_session.add(record)
+            self.db_session.commit()
+        except Exception as exc:
+            self.logger.error(f"Failed to persist poll debug records: {exc}")
+            try:
+                self.db_session.rollback()
+            except Exception:
+                pass
+
     def cleanup_old_poll_history(self):
         try:
             # Ensure table exists
@@ -1108,6 +1349,36 @@ class CAPPoller:
             self.logger.error(f"cleanup_old_poll_history error: {e}")
             try: self.db_session.rollback()
             except: pass
+
+    def cleanup_old_debug_records(self):
+        if not self._ensure_debug_records_table():
+            return
+
+        try:
+            cutoff = utc_now() - timedelta(days=7)
+            old_count = (
+                self.db_session.query(PollDebugRecord)
+                .filter(PollDebugRecord.created_at < cutoff)
+                .count()
+            )
+            if old_count > 500:
+                subq = (
+                    self.db_session.query(PollDebugRecord.id)
+                    .order_by(PollDebugRecord.created_at.desc())
+                    .limit(500)
+                    .subquery()
+                )
+                self.db_session.query(PollDebugRecord).filter(
+                    PollDebugRecord.created_at < cutoff,
+                    ~PollDebugRecord.id.in_(subq),
+                ).delete(synchronize_session=False)
+                self.db_session.commit()
+        except Exception as exc:
+            self.logger.error(f"cleanup_old_debug_records error: {exc}")
+            try:
+                self.db_session.rollback()
+            except Exception:
+                pass
 
     def log_poll_history(self, stats):
         try:
@@ -1160,6 +1431,7 @@ class CAPPoller:
         start = time.time()
         poll_start_utc = utc_now()
         poll_start_local = local_now()
+        poll_run_id = uuid.uuid4().hex
 
         stats = {
             'alerts_fetched': 0, 'alerts_new': 0, 'alerts_updated': 0,
@@ -1170,7 +1442,10 @@ class CAPPoller:
             'poll_time_local': poll_start_local.isoformat(),
             'timezone': self.location_settings['timezone'], 'led_updated': False,
             'sources': [], 'duplicates_filtered': 0,
+            'poll_run_id': poll_run_id,
         }
+
+        debug_records: List[Dict[str, Any]] = []
 
         try:
             self.logger.info(
@@ -1189,16 +1464,46 @@ class CAPPoller:
 
                 self.logger.info(f"Processing alert: {event} (ID: {alert_id[:20] if alert_id!='No ID' else 'No ID'}...)")
 
-                if not self.is_relevant_alert(alert_data):
+                relevance = self.get_alert_relevance_details(alert_data)
+                log_entry = relevance.get('log') or {}
+                message = log_entry.get('message')
+                if message:
+                    level = (log_entry.get('level') or 'info').lower()
+                    if level == 'error':
+                        self.logger.error(message)
+                    elif level == 'warning':
+                        self.logger.warning(message)
+                    else:
+                        self.logger.info(message)
+
+                debug_entry = self._initialise_debug_entry(alert_data, relevance, poll_run_id, poll_start_utc)
+                debug_records.append(debug_entry)
+
+                if not relevance.get('is_relevant'):
                     self.logger.info(f"• Filtered out (not specific to {self.county_upper})")
                     stats['alerts_filtered'] += 1
+                    debug_entry.setdefault('notes', []).append('Filtered out by strict location rules')
                     continue
 
                 stats['alerts_accepted'] += 1
                 parsed = self.parse_cap_alert(alert_data)
                 if not parsed:
                     self.logger.warning(f"Failed to parse: {event}")
+                    debug_entry['parse_error'] = 'parse_cap_alert returned None'
+                    debug_entry.setdefault('notes', []).append('Parsing failed')
                     continue
+
+                debug_entry['parse_success'] = True
+                debug_entry['identifier'] = parsed.get('identifier', debug_entry['identifier'])
+                debug_entry['source'] = parsed.get('source', debug_entry.get('source'))
+                debug_entry['alert_sent'] = parsed.get('sent', debug_entry.get('alert_sent'))
+                geometry_data = parsed.get('_geometry_data')
+                if geometry_data:
+                    debug_entry['geometry_geojson'] = self._safe_json_copy(geometry_data)
+                    geom_type, polygon_count, preview = self._summarise_geometry(geometry_data)
+                    debug_entry['geometry_type'] = geom_type
+                    debug_entry['polygon_count'] = polygon_count
+                    debug_entry['geometry_preview'] = preview
 
                 is_new, alert = self.save_cap_alert(parsed)
                 if is_new:
@@ -1213,8 +1518,16 @@ class CAPPoller:
                         f"Updated {self.location_name} alert: {alert.event if alert else parsed['event']} - Sent: {format_local_datetime(parsed.get('sent'))}"
                     )
 
+                debug_entry['was_saved'] = bool(alert)
+                debug_entry['was_new'] = bool(is_new and alert is not None)
+                debug_entry['alert_db_id'] = getattr(alert, 'id', None) if alert else None
+                if not alert:
+                    debug_entry.setdefault('notes', []).append('Database save failed')
+
             self.cleanup_old_poll_history()
             self.log_poll_history(stats)
+            self.persist_debug_records(poll_run_id, poll_start_utc, stats, debug_records)
+            self.cleanup_old_debug_records()
 
             if self.led_controller:
                 self.update_led_display()
@@ -1236,6 +1549,9 @@ class CAPPoller:
             stats['execution_time_ms'] = int((time.time() - start) * 1000)
             self.logger.error(f"Error in polling cycle: {e}")
             self.log_system_event('ERROR', f"CAP polling failed: {e}", stats)
+
+            self.persist_debug_records(poll_run_id, poll_start_utc, stats, debug_records)
+            self.cleanup_old_debug_records()
 
         return stats
 

--- a/templates/ipaws_debug.html
+++ b/templates/ipaws_debug.html
@@ -1,0 +1,152 @@
+{% extends "base.html" %}
+{% block title %}IPAWS Poller Debug{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+        <div>
+            <h1 class="h3 mb-1">IPAWS Poller Debug Console</h1>
+            <p class="text-muted mb-0">
+                Review captured IPAWS poll cycles, including filtered alerts, polygon geometry, and raw CAP properties.
+            </p>
+        </div>
+        <div class="text-muted small">
+            Displaying most recent debug runs (timezone: {{ timezone_name }}).
+        </div>
+    </div>
+
+    {% if not debug_runs %}
+        <div class="alert alert-info shadow-sm">
+            No IPAWS poller debug entries have been captured yet. Trigger the poller to populate this view.
+        </div>
+    {% endif %}
+
+    {% for run in debug_runs %}
+        <div class="card mb-4 shadow-sm">
+            <div class="card-header bg-light">
+                <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                    <div>
+                        <div class="fw-semibold">Poll started: {{ run.poll_started_display or 'Unknown' }}</div>
+                        <div class="text-muted small">
+                            Status: {{ run.poll_status }} | Sources: {{ run.data_source or 'n/a' }} | Run ID: {{ run.poll_run_id }}
+                        </div>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2">
+                        <span class="badge bg-primary">Alerts {{ run.totals.alerts }}</span>
+                        <span class="badge bg-success">Accepted {{ run.totals.accepted }}</span>
+                        <span class="badge bg-info text-dark">Saved {{ run.totals.saved }}</span>
+                        <span class="badge bg-warning text-dark">Parse issues {{ run.totals.parse_failures }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Event</th>
+                                <th scope="col">Identifier</th>
+                                <th scope="col">Relevance</th>
+                                <th scope="col">Database</th>
+                                <th scope="col">Geometry</th>
+                                <th scope="col">Timing</th>
+                                <th scope="col">Notes &amp; Payloads</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for alert in run.alerts %}
+                                {% set row_class = '' %}
+                                {% if not alert.parse_success %}
+                                    {% set row_class = 'table-danger' %}
+                                {% elif not alert.is_relevant %}
+                                    {% set row_class = 'table-warning' %}
+                                {% elif alert.was_new %}
+                                    {% set row_class = 'table-success' %}
+                                {% elif alert.was_saved %}
+                                    {% set row_class = 'table-info' %}
+                                {% endif %}
+                                <tr class="{{ row_class }}">
+                                    <td>
+                                        <div class="fw-semibold">{{ alert.alert_event or 'Unknown event' }}</div>
+                                        <div class="text-muted small">{{ alert.source or 'Unknown source' }}</div>
+                                        {% if alert.area_desc %}
+                                            <div class="small">{{ alert.area_desc }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="font-monospace small">{{ alert.alert_identifier or alert.identifier or 'n/a' }}</div>
+                                        {% if alert.raw_xml_present %}
+                                            <span class="badge bg-secondary mt-1">Raw XML</span>
+                                        {% endif %}
+                                        {% if alert.ugc_codes %}
+                                            <div class="small text-muted">UGC: {{ alert.ugc_codes|join(', ') }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if alert.is_relevant %}
+                                            <span class="badge bg-success">Accepted</span>
+                                        {% else %}
+                                            <span class="badge bg-warning text-dark">Filtered</span>
+                                        {% endif %}
+                                        <div class="small text-muted">{{ alert.relevance_reason or 'n/a' }}</div>
+                                        {% if alert.relevance_matches %}
+                                            <div class="small">{{ alert.relevance_matches|join(', ') }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if alert.was_saved %}
+                                            <span class="badge bg-info text-dark">Saved</span>
+                                        {% else %}
+                                            <span class="badge bg-secondary">Not saved</span>
+                                        {% endif %}
+                                        {% if alert.was_new %}
+                                            <span class="badge bg-success ms-1">New</span>
+                                        {% endif %}
+                                        {% if alert.alert_db_id %}
+                                            <div class="small text-muted">DB ID {{ alert.alert_db_id }}</div>
+                                        {% endif %}
+                                        {% if alert.parse_error %}
+                                            <div class="text-danger small">{{ alert.parse_error }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="small">{{ alert.geometry_type or 'None' }}{% if alert.polygon_count %} ({{ alert.polygon_count }}){% endif %}</div>
+                                        {% if alert.geometry_preview %}
+                                            <details class="small mt-1">
+                                                <summary>Preview</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_preview | tojson(indent=2) }}</pre>
+                                            </details>
+                                        {% endif %}
+                                        {% if alert.geometry_geojson %}
+                                            <details class="small mt-2">
+                                                <summary>GeoJSON</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_geojson | tojson(indent=2) }}</pre>
+                                            </details>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="small">Sent: {{ alert.alert_sent_display or 'Unknown' }}</div>
+                                        <div class="text-muted small">Captured: {{ alert.created_at_display or 'Unknown' }}</div>
+                                    </td>
+                                    <td>
+                                        {% set note_text = alert.notes or '' %}
+                                        {% if note_text %}
+                                            {% for line in note_text.split('\n') %}
+                                                <div class="small text-muted">{{ line }}</div>
+                                            {% endfor %}
+                                        {% endif %}
+                                        <details class="small mt-2">
+                                            <summary>Raw properties</summary>
+                                            <pre class="small bg-light border rounded p-2">{{ alert.raw_properties | tojson(indent=2) }}</pre>
+                                        </details>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a PollDebugRecord model and helper utilities so poller runs can be persisted for analysis
- extend the CAP poller to capture per-alert debug details, store them in the new table, and ensure the table exists during app startup
- expose a /debug/ipaws page with a Bootstrap table to review captured runs, including geometry previews and raw CAP payloads

## Testing
- python -m py_compile app.py app_core/poller_debug.py poller/cap_poller.py webapp/routes_debug.py

------
https://chatgpt.com/codex/tasks/task_e_690298f43ae48320b7a758550a8a2c28