### PR TITLE
Default IPAWS poller feeds to FEMA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ POLL_INTERVAL_SEC=180
 CAP_ENDPOINTS=
 # Default IPAWS CAP feed list consumed by the ipaws-poller service (comma-separated)
 IPAWS_CAP_FEED_URLS=https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/public/recent/2024-02-15T12:00:00Z
+# Optional fallback settings when no IPAWS feed list is supplied
+IPAWS_DEFAULT_LOOKBACK_HOURS=12
+# IPAWS_DEFAULT_START=2024-02-15T12:00:00Z
+# IPAWS_DEFAULT_ENDPOINT_TEMPLATE=https://tdl.apps.fema.gov/IPAWSOPEN_EAS_SERVICE/rest/public/recent/{timestamp}
 LOG_LEVEL=INFO
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ docker compose up -d --force-recreate
   continues to work without code changes.
 - Alerts fetched across NOAA and IPAWS feeds are deduplicated by CAP identifier and stamped with
   their source so the dashboard, statistics, and exports reflect the originating system.
+- The dedicated container advertises `CAP_POLLER_MODE=IPAWS`, so if you do not provide
+  `IPAWS_CAP_FEED_URLS` the poller automatically falls back to the FEMA staging public feed
+  (12-hour lookback by default). Override the fallback window or template with
+  `IPAWS_DEFAULT_LOOKBACK_HOURS`, `IPAWS_DEFAULT_START`, or `IPAWS_DEFAULT_ENDPOINT_TEMPLATE`.
 - You can supply alternative feed URLs at runtime by passing `--cap-endpoint` arguments or a
   `CAP_ENDPOINTS` environment variable to any poller service. When unset, the original NOAA
   poller continues targeting the Weather Service zone feeds derived from your location settings.

--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ from app_core.eas_storage import (
     get_eas_static_prefix,
 )
 from app_core.system_health import get_system_health
+from app_core.poller_debug import ensure_poll_debug_table
 from webapp import register_routes
 from webapp.admin.boundaries import (
     ensure_alert_source_columns,
@@ -118,12 +119,15 @@ from app_core.led import (
 from app_core.location import get_location_settings, update_location_settings
 from app_core.models import (
     AdminUser,
+    Boundary,
     CAPAlert,
     EASMessage,
+    Intersection,
     ManualEASActivation,
     LEDMessage,
     LEDSignStatus,
     LocationSettings,
+    PollDebugRecord,
     PollHistory,
     SystemLog,
 )
@@ -554,6 +558,11 @@ def initialize_database():
         if not ensure_manual_eas_audio_columns(logger):
             _db_initialization_error = RuntimeError(
                 "Manual EAS audio columns could not be ensured"
+            )
+            return False
+        if not ensure_poll_debug_table(logger):
+            _db_initialization_error = RuntimeError(
+                "Poll debug table could not be ensured"
             )
             return False
         backfill_eas_message_payloads(logger)

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -292,6 +292,38 @@ class PollHistory(db.Model):
     data_source = db.Column(db.String(64))
 
 
+class PollDebugRecord(db.Model):
+    __tablename__ = "poll_debug_records"
+
+    id = db.Column(db.Integer, primary_key=True)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
+    poll_run_id = db.Column(db.String(64), nullable=False, index=True)
+    poll_started_at = db.Column(db.DateTime(timezone=True), nullable=False)
+    poll_status = db.Column(db.String(20), nullable=False, default="UNKNOWN")
+    data_source = db.Column(db.String(64))
+    alert_identifier = db.Column(db.String(255))
+    alert_event = db.Column(db.String(255))
+    alert_sent = db.Column(db.DateTime(timezone=True))
+    source = db.Column(db.String(64))
+    is_relevant = db.Column(db.Boolean, default=False, nullable=False)
+    relevance_reason = db.Column(db.String(255))
+    relevance_matches = db.Column(db.JSON, default=list)
+    ugc_codes = db.Column(db.JSON, default=list)
+    area_desc = db.Column(db.Text)
+    was_saved = db.Column(db.Boolean, default=False, nullable=False)
+    was_new = db.Column(db.Boolean, default=False, nullable=False)
+    alert_db_id = db.Column(db.Integer)
+    parse_success = db.Column(db.Boolean, default=False, nullable=False)
+    parse_error = db.Column(db.Text)
+    polygon_count = db.Column(db.Integer)
+    geometry_type = db.Column(db.String(64))
+    geometry_geojson = db.Column(db.JSON)
+    geometry_preview = db.Column(db.JSON)
+    raw_properties = db.Column(db.JSON)
+    raw_xml_present = db.Column(db.Boolean, default=False, nullable=False)
+    notes = db.Column(db.Text)
+
+
 class LocationSettings(db.Model):
     __tablename__ = "location_settings"
 

--- a/app_core/poller_debug.py
+++ b/app_core/poller_debug.py
@@ -1,0 +1,93 @@
+"""Utilities for capturing and presenting poller debug information."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy import inspect
+from sqlalchemy.exc import SQLAlchemyError
+
+from .extensions import db
+from .models import PollDebugRecord
+
+
+def ensure_poll_debug_table(logger) -> bool:
+    """Ensure the poll_debug_records table exists before it is queried."""
+
+    try:
+        PollDebugRecord.__table__.create(bind=db.engine, checkfirst=True)
+        inspector = inspect(db.engine)
+        if "poll_debug_records" not in inspector.get_table_names():
+            logger.error("poll_debug_records table missing after creation attempt")
+            return False
+        return True
+    except SQLAlchemyError as exc:
+        logger.error("Failed to ensure poll_debug_records table: %s", exc)
+        return False
+
+
+def serialise_debug_record(record: PollDebugRecord) -> dict:
+    """Convert a ``PollDebugRecord`` into JSON-friendly data for templates."""
+
+    return {
+        "id": record.id,
+        "created_at": record.created_at,
+        "poll_run_id": record.poll_run_id,
+        "poll_started_at": record.poll_started_at,
+        "poll_status": record.poll_status,
+        "data_source": record.data_source,
+        "alert_identifier": record.alert_identifier,
+        "alert_event": record.alert_event,
+        "alert_sent": record.alert_sent,
+        "source": record.source,
+        "is_relevant": record.is_relevant,
+        "relevance_reason": record.relevance_reason,
+        "relevance_matches": record.relevance_matches or [],
+        "ugc_codes": record.ugc_codes or [],
+        "area_desc": record.area_desc,
+        "was_saved": record.was_saved,
+        "was_new": record.was_new,
+        "alert_db_id": record.alert_db_id,
+        "parse_success": record.parse_success,
+        "parse_error": record.parse_error,
+        "polygon_count": record.polygon_count,
+        "geometry_type": record.geometry_type,
+        "geometry_geojson": record.geometry_geojson,
+        "geometry_preview": record.geometry_preview,
+        "raw_properties": record.raw_properties,
+        "raw_xml_present": record.raw_xml_present,
+        "notes": record.notes,
+    }
+
+
+def summarise_run(records: Iterable[PollDebugRecord]) -> dict:
+    """Aggregate a poll run into summary metadata plus serialised alerts."""
+
+    serialised: List[dict] = [serialise_debug_record(record) for record in records]
+    if not serialised:
+        return {"alerts": [], "totals": {}}
+
+    totals = {
+        "alerts": len(serialised),
+        "accepted": sum(1 for item in serialised if item.get("is_relevant")),
+        "saved": sum(1 for item in serialised if item.get("was_saved")),
+        "new_saved": sum(1 for item in serialised if item.get("was_new")),
+        "parse_failures": sum(1 for item in serialised if not item.get("parse_success")),
+    }
+
+    base = serialised[0]
+    return {
+        "poll_run_id": base.get("poll_run_id"),
+        "poll_started_at": base.get("poll_started_at"),
+        "poll_status": base.get("poll_status"),
+        "data_source": base.get("data_source"),
+        "alerts": serialised,
+        "totals": totals,
+    }
+
+
+__all__ = [
+    "ensure_poll_debug_table",
+    "serialise_debug_record",
+    "summarise_run",
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file:
       - .env
     environment:
+      CAP_POLLER_MODE: IPAWS
       CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/templates/ipaws_debug.html
+++ b/templates/ipaws_debug.html
@@ -1,0 +1,152 @@
+{% extends "base.html" %}
+{% block title %}IPAWS Poller Debug{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+        <div>
+            <h1 class="h3 mb-1">IPAWS Poller Debug Console</h1>
+            <p class="text-muted mb-0">
+                Review captured IPAWS poll cycles, including filtered alerts, polygon geometry, and raw CAP properties.
+            </p>
+        </div>
+        <div class="text-muted small">
+            Displaying most recent debug runs (timezone: {{ timezone_name }}).
+        </div>
+    </div>
+
+    {% if not debug_runs %}
+        <div class="alert alert-info shadow-sm">
+            No IPAWS poller debug entries have been captured yet. Trigger the poller to populate this view.
+        </div>
+    {% endif %}
+
+    {% for run in debug_runs %}
+        <div class="card mb-4 shadow-sm">
+            <div class="card-header bg-light">
+                <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                    <div>
+                        <div class="fw-semibold">Poll started: {{ run.poll_started_display or 'Unknown' }}</div>
+                        <div class="text-muted small">
+                            Status: {{ run.poll_status }} | Sources: {{ run.data_source or 'n/a' }} | Run ID: {{ run.poll_run_id }}
+                        </div>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2">
+                        <span class="badge bg-primary">Alerts {{ run.totals.alerts }}</span>
+                        <span class="badge bg-success">Accepted {{ run.totals.accepted }}</span>
+                        <span class="badge bg-info text-dark">Saved {{ run.totals.saved }}</span>
+                        <span class="badge bg-warning text-dark">Parse issues {{ run.totals.parse_failures }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Event</th>
+                                <th scope="col">Identifier</th>
+                                <th scope="col">Relevance</th>
+                                <th scope="col">Database</th>
+                                <th scope="col">Geometry</th>
+                                <th scope="col">Timing</th>
+                                <th scope="col">Notes &amp; Payloads</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for alert in run.alerts %}
+                                {% set row_class = '' %}
+                                {% if not alert.parse_success %}
+                                    {% set row_class = 'table-danger' %}
+                                {% elif not alert.is_relevant %}
+                                    {% set row_class = 'table-warning' %}
+                                {% elif alert.was_new %}
+                                    {% set row_class = 'table-success' %}
+                                {% elif alert.was_saved %}
+                                    {% set row_class = 'table-info' %}
+                                {% endif %}
+                                <tr class="{{ row_class }}">
+                                    <td>
+                                        <div class="fw-semibold">{{ alert.alert_event or 'Unknown event' }}</div>
+                                        <div class="text-muted small">{{ alert.source or 'Unknown source' }}</div>
+                                        {% if alert.area_desc %}
+                                            <div class="small">{{ alert.area_desc }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="font-monospace small">{{ alert.alert_identifier or alert.identifier or 'n/a' }}</div>
+                                        {% if alert.raw_xml_present %}
+                                            <span class="badge bg-secondary mt-1">Raw XML</span>
+                                        {% endif %}
+                                        {% if alert.ugc_codes %}
+                                            <div class="small text-muted">UGC: {{ alert.ugc_codes|join(', ') }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if alert.is_relevant %}
+                                            <span class="badge bg-success">Accepted</span>
+                                        {% else %}
+                                            <span class="badge bg-warning text-dark">Filtered</span>
+                                        {% endif %}
+                                        <div class="small text-muted">{{ alert.relevance_reason or 'n/a' }}</div>
+                                        {% if alert.relevance_matches %}
+                                            <div class="small">{{ alert.relevance_matches|join(', ') }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if alert.was_saved %}
+                                            <span class="badge bg-info text-dark">Saved</span>
+                                        {% else %}
+                                            <span class="badge bg-secondary">Not saved</span>
+                                        {% endif %}
+                                        {% if alert.was_new %}
+                                            <span class="badge bg-success ms-1">New</span>
+                                        {% endif %}
+                                        {% if alert.alert_db_id %}
+                                            <div class="small text-muted">DB ID {{ alert.alert_db_id }}</div>
+                                        {% endif %}
+                                        {% if alert.parse_error %}
+                                            <div class="text-danger small">{{ alert.parse_error }}</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="small">{{ alert.geometry_type or 'None' }}{% if alert.polygon_count %} ({{ alert.polygon_count }}){% endif %}</div>
+                                        {% if alert.geometry_preview %}
+                                            <details class="small mt-1">
+                                                <summary>Preview</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_preview | tojson(indent=2) }}</pre>
+                                            </details>
+                                        {% endif %}
+                                        {% if alert.geometry_geojson %}
+                                            <details class="small mt-2">
+                                                <summary>GeoJSON</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_geojson | tojson(indent=2) }}</pre>
+                                            </details>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <div class="small">Sent: {{ alert.alert_sent_display or 'Unknown' }}</div>
+                                        <div class="text-muted small">Captured: {{ alert.created_at_display or 'Unknown' }}</div>
+                                    </td>
+                                    <td>
+                                        {% set note_text = alert.notes or '' %}
+                                        {% if note_text %}
+                                            {% for line in note_text.split('\n') %}
+                                                <div class="small text-muted">{{ line }}</div>
+                                            {% endfor %}
+                                        {% endif %}
+                                        <details class="small mt-2">
+                                            <summary>Raw properties</summary>
+                                            <pre class="small bg-light border rounded p-2">{{ alert.raw_properties | tojson(indent=2) }}</pre>
+                                        </details>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an IPAWS poller mode flag so the shared poller defaults to FEMA staging endpoints when no custom CAP feeds are provided
- configure the ipaws-poller service and environment sample to expose the new fallback controls
- document the new behaviour and tuning options in the README

## Testing
- python -m py_compile poller/cap_poller.py

------
https://chatgpt.com/codex/tasks/task_e_690298f43ae48320b7a758550a8a2c28