### PR TITLE
Align env example with shared DB vars

### DIFF
--- a/.env
+++ b/.env
@@ -16,19 +16,25 @@ NOAA_USER_AGENT=KR8MER CAP Alert System/2.1 (+https://github.com/KR8MER/noaa_ale
 # -----------------------------------------------------------------------------
 # Database connection (PostgreSQL + PostGIS)
 # -----------------------------------------------------------------------------
-POSTGRES_HOST=alerts-db
-POSTGRES_PORT=5432
-POSTGRES_DB=alerts
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-DATABASE_URL=postgresql+psycopg2://postgres:postgres@alerts-db:5432/alerts
+DB_HOST=alerts-db
+DB_PORT=5432
+DB_NAME=alerts
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+POSTGRES_HOST=${DB_HOST}
+POSTGRES_PORT=${DB_PORT}
+POSTGRES_DB=${DB_NAME}
+POSTGRES_USER=${DB_USER}
+POSTGRES_PASSWORD=${DB_PASSWORD}
+DATABASE_URL=postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}
 
 # Additional database metadata shared with infrastructure tooling
-ALERTS_DB_HOST=alerts-db
-ALERTS_DB_PORT=5432
-ALERTS_DB_NAME=alerts
-ALERTS_DB_USER=postgres
-ALERTS_DB_PASS=postgres
+ALERTS_DB_HOST=${DB_HOST}
+ALERTS_DB_PORT=${DB_PORT}
+ALERTS_DB_NAME=${DB_NAME}
+ALERTS_DB_USER=${DB_USER}
+ALERTS_DB_PASS=${DB_PASSWORD}
 ALERTS_DB_CONTAINER=alerts-db
 ALERTS_DB_VOLUME=noaa_alerts_systems_alerts-db
 ALERTS_DB_VERSION=16.2

--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,20 @@ NOAA_USER_AGENT=KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/noaa_
 
 # -----------------------------------------------------------------------------
 # Database connection (PostgreSQL + PostGIS)
-# Update POSTGRES_PASSWORD for any production deployment.
+# Update DB_PASSWORD/POSTGRES_PASSWORD for any production deployment.
 # -----------------------------------------------------------------------------
-POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
-POSTGRES_DB=alerts
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change-me
+# Shared database defaults used by dependent services
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=alerts
+DB_USER=postgres
+DB_PASSWORD=change-me
+
+POSTGRES_HOST=${DB_HOST}
+POSTGRES_PORT=${DB_PORT}
+POSTGRES_DB=${DB_NAME}
+POSTGRES_USER=${DB_USER}
+POSTGRES_PASSWORD=${DB_PASSWORD}
 # DATABASE_URL can override the values above when provided; leave blank to build it automatically.
 # DATABASE_URL=
 


### PR DESCRIPTION
## Summary
- mirror the shared DB_* variable pattern from .env into .env.example
- ensure POSTGRES_* entries in the example file still resolve via the shared base values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903244e13888320ab4a4d150e8deb3c