### PR TITLE
Fix audio links on alerts page

### DIFF
--- a/webapp/routes_public.py
+++ b/webapp/routes_public.py
@@ -462,7 +462,10 @@ def register(app: Flask, logger) -> None:
                                     "id": message.id,
                                     "created_at": message.created_at,
                                     "audio_url": audio_url,
-                                    "summary_url": text_url,
+                                    "text_url": text_url,
+                                    "detail_url": url_for(
+                                        "audio_detail", message_id=message.id
+                                    ),
                                 }
                             )
                     except Exception as exc:


### PR DESCRIPTION
## Summary
- ensure alert listing audio metadata includes the expected detail and transcript URLs
- align the alerts template context with the keys that the template renders

## Testing
- python -m compileall webapp/routes_public.py

------
https://chatgpt.com/codex/tasks/task_e_690354637a688320a1287ed7d2b37a43