### PR TITLE
Add database models for radio receiver configuration

### DIFF
--- a/docs/eas_todo.md
+++ b/docs/eas_todo.md
@@ -6,6 +6,7 @@
   - Sketch a `radio/` package (for example `app_core/radio/manager.py`) that defines a `ReceiverInterface` abstraction (configure, tune, start/stop stream) and concrete drivers for supported SDR SDKs (SoapySDR, RTL-SDR via pyrtlsdr, Airspy, etc.).
   - Extend the poller layer (`poller/` services) to request audio captures via the new manager when SAME bursts are detected, buffering raw IQ or PCM data per receiver.
   - Persist receiver configuration in Postgres (new tables via Alembic migration under `app_core/models.py`) and surface a CRUD UI in `webapp/routes/settings_radio.py` with a template in `templates/settings/radio.html`.
+    - [x] Added SQLAlchemy models for receiver configuration and status history in `app_core/models.py`.
   - Update system health endpoints to report receiver lock, signal metrics, and error states.
 
 ## 2. Audio Ingest Pipeline


### PR DESCRIPTION
## Summary
- add SQLAlchemy models to persist radio receiver configurations and status samples
- extend the radio manager with helpers to consume database-backed receiver records
- document the new persistence layer progress in the EAS parity to-do list

## Testing
- python3 -m py_compile app_core/models.py app_core/radio/manager.py

------
https://chatgpt.com/codex/tasks/task_e_6903852cd99483209db04d41b4075186