### PR TITLE
Ensure radio receiver tables exist before use

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ from app_core.eas_storage import (
 )
 from app_core.system_health import get_system_health
 from app_core.poller_debug import ensure_poll_debug_table
+from app_core.radio import ensure_radio_tables
 from webapp import register_routes
 from webapp.admin.boundaries import (
     ensure_alert_source_columns,
@@ -685,6 +686,11 @@ def initialize_database():
             if not ensure_poll_debug_table(logger):
                 _db_initialization_error = RuntimeError(
                     "Poll debug table could not be ensured"
+                )
+                return False
+            if not ensure_radio_tables(logger):
+                _db_initialization_error = RuntimeError(
+                    "Radio receiver tables could not be ensured"
                 )
                 return False
             backfill_eas_message_payloads(logger)

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -427,6 +427,74 @@ class LEDSignStatus(db.Model):
     is_connected = db.Column(db.Boolean, default=False)
 
 
+class RadioReceiver(db.Model):
+    __tablename__ = "radio_receivers"
+
+    id = db.Column(db.Integer, primary_key=True)
+    identifier = db.Column(db.String(64), unique=True, nullable=False)
+    driver = db.Column(db.String(64), nullable=False)
+    frequency_hz = db.Column(db.Float, nullable=False)
+    sample_rate = db.Column(db.Integer, nullable=False)
+    gain = db.Column(db.Float)
+    channel = db.Column(db.Integer)
+    enabled = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
+
+    statuses = db.relationship(
+        "RadioReceiverStatus",
+        back_populates="receiver",
+        cascade="all, delete-orphan",
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "identifier": self.identifier,
+            "driver": self.driver,
+            "frequency_hz": self.frequency_hz,
+            "sample_rate": self.sample_rate,
+            "gain": self.gain,
+            "channel": self.channel,
+            "enabled": self.enabled,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class RadioReceiverStatus(db.Model):
+    __tablename__ = "radio_receiver_status"
+
+    id = db.Column(db.Integer, primary_key=True)
+    receiver_id = db.Column(
+        db.Integer,
+        db.ForeignKey("radio_receivers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    locked = db.Column(db.Boolean, nullable=False, default=False)
+    signal_strength = db.Column(db.Float)
+    last_error = db.Column(db.Text)
+    reported_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
+
+    receiver = db.relationship("RadioReceiver", back_populates="statuses")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "receiver_id": self.receiver_id,
+            "locked": self.locked,
+            "signal_strength": self.signal_strength,
+            "last_error": self.last_error,
+            "reported_at": self.reported_at.isoformat() if self.reported_at else None,
+        }
+
+
 __all__ = [
     "Boundary",
     "CAPAlert",
@@ -438,4 +506,6 @@ __all__ = [
     "LocationSettings",
     "LEDMessage",
     "LEDSignStatus",
+    "RadioReceiver",
+    "RadioReceiverStatus",
 ]

--- a/app_core/radio/__init__.py
+++ b/app_core/radio/__init__.py
@@ -1,10 +1,12 @@
 """Radio receiver management primitives for multi-SDR support."""
 
 from .manager import ReceiverInterface, ReceiverConfig, RadioManager, ReceiverStatus
+from .schema import ensure_radio_tables
 
 __all__ = [
     "ReceiverInterface",
     "ReceiverConfig",
     "RadioManager",
     "ReceiverStatus",
+    "ensure_radio_tables",
 ]

--- a/app_core/radio/schema.py
+++ b/app_core/radio/schema.py
@@ -1,0 +1,39 @@
+"""Database helpers for radio receiver persistence."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import inspect
+from sqlalchemy.exc import SQLAlchemyError
+
+from app_core.extensions import db
+from app_core.models import RadioReceiver, RadioReceiverStatus
+
+
+_TABLE_NAMES: Iterable[str] = ("radio_receivers", "radio_receiver_status")
+
+
+def ensure_radio_tables(logger) -> bool:
+    """Ensure radio receiver tables exist before accessing them."""
+
+    try:
+        RadioReceiver.__table__.create(bind=db.engine, checkfirst=True)
+        RadioReceiverStatus.__table__.create(bind=db.engine, checkfirst=True)
+
+        inspector = inspect(db.engine)
+        missing = [name for name in _TABLE_NAMES if name not in inspector.get_table_names()]
+        if missing:
+            logger.error(
+                "Radio receiver tables missing after creation attempt: %s",
+                ", ".join(sorted(missing)),
+            )
+            return False
+
+        return True
+    except SQLAlchemyError as exc:
+        logger.error("Failed to ensure radio receiver tables: %s", exc)
+        return False
+
+
+__all__ = ["ensure_radio_tables"]

--- a/docs/eas_todo.md
+++ b/docs/eas_todo.md
@@ -39,3 +39,24 @@
   - Provide guided setup scripts (`tools/setup_wizard.py`) that populate `.env`, radio configs, and audio profiles.
   - Extend Docker services (update `docker-compose.yml`) with containers for audio capture (PulseAudio/JACK) and hardware access, documenting udev rules in `docs/deployment/audio_hardware.md`.
   - Add automated tests (pytest-based under `tests/`) covering ingest/output mocks and GPIO logic to prevent regressions.
+
+## 7. Alert Verification & Analytics
+- [ ] Build an alert verification pipeline.
+  - Correlate CAP messages with downstream playout logs in `app_core/eas_storage.py` to confirm full delivery paths.
+  - Add a validation view (`webapp/routes/alert_verification.py`, `templates/eas/alert_verification.html`) that highlights mismatches, missing audio, or delayed retransmissions.
+  - Generate trend analytics (per originator, per station) stored in a new reporting table with Alembic migration and surfaced via charts using the existing `static/js/charts/` helpers.
+  - Ship CSV exports from the verification view using shared utilities in `app_utils/export.py`.
+
+## 8. Security & Access Controls
+- [ ] Harden operator access and system security.
+  - Implement role-based access controls in `app_core/auth/roles.py` and enforce them across admin routes.
+  - Require MFA enrollment for operator accounts, adding TOTP enrollment flows in `webapp/routes/auth.py` and templates under `templates/auth/`.
+  - Add security auditing hooks that log configuration and control changes to a dedicated table with retention policies.
+  - Document security procedures in `docs/security_hardening.md`, including recommended firewall rules and patch cadence.
+
+## 9. Resilience & Disaster Recovery
+- [ ] Improve resilience for severe weather outages.
+  - Create automated database backup routines (`tools/backup_scheduler.py`) and provide restore playbooks in `docs/disaster_recovery.md`.
+  - Add health probes for dependent services (database, Redis, audio daemons) exposed via `/health/dependencies` endpoint.
+  - Implement an optional cold-standby node synchronization workflow using `docker-compose.override.yml` examples for multi-site deployments.
+  - Provide operator runbooks in `docs/runbooks/outage_response.md` describing failover activation and validation steps.

--- a/noaa.sql
+++ b/noaa.sql
@@ -175,6 +175,33 @@ CREATE TABLE IF NOT EXISTS led_sign_status (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_led_sign_status_ip ON led_sign_status(sign_ip);
 
+-- Persistent SDR receiver configuration and health telemetry
+CREATE TABLE IF NOT EXISTS radio_receivers (
+    id SERIAL PRIMARY KEY,
+    identifier VARCHAR(64) NOT NULL UNIQUE,
+    driver VARCHAR(64) NOT NULL,
+    frequency_hz DOUBLE PRECISION NOT NULL,
+    sample_rate INTEGER NOT NULL,
+    gain DOUBLE PRECISION,
+    channel INTEGER,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS radio_receiver_status (
+    id SERIAL PRIMARY KEY,
+    receiver_id INTEGER NOT NULL REFERENCES radio_receivers(id) ON DELETE CASCADE,
+    locked BOOLEAN NOT NULL DEFAULT FALSE,
+    signal_strength DOUBLE PRECISION,
+    last_error TEXT,
+    reported_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_radio_receivers_identifier ON radio_receivers(identifier);
+CREATE INDEX IF NOT EXISTS idx_radio_receiver_status_receiver_id ON radio_receiver_status(receiver_id);
+CREATE INDEX IF NOT EXISTS idx_radio_receiver_status_reported_at ON radio_receiver_status(reported_at DESC);
+
 -- Persistent location configuration used by the admin console
 CREATE TABLE IF NOT EXISTS location_settings (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add ORM models for radio receiver configuration and status tracking
- ensure the new tables are created at startup and exposed via the radio package
- update the bootstrap SQL schema with the radio receiver tables and indexes

## Testing
- python3 -m py_compile app.py app_core/models.py app_core/radio/__init__.py app_core/radio/schema.py

------
https://chatgpt.com/codex/tasks/task_e_690386408eec832082934805163326f2