### PR TITLE
Add alert verification analytics

### DIFF
--- a/app_core/migrations/versions/20240315_alert_delivery_reports.py
+++ b/app_core/migrations/versions/20240315_alert_delivery_reports.py
@@ -1,0 +1,51 @@
+"""Create alert delivery reports table for verification analytics."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240315_alert_delivery_reports"
+down_revision = "20240229_radio"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "alert_delivery_reports",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("scope", sa.String(length=16), nullable=False),
+        sa.Column("originator", sa.String(length=64), nullable=True),
+        sa.Column("station", sa.String(length=128), nullable=True),
+        sa.Column("total_alerts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("delivered_alerts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("delayed_alerts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("average_latency_seconds", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        "idx_alert_delivery_reports_scope_window",
+        "alert_delivery_reports",
+        ["scope", "window_start", "window_end"],
+    )
+    op.create_index(
+        "idx_alert_delivery_reports_originator",
+        "alert_delivery_reports",
+        ["originator"],
+    )
+    op.create_index(
+        "idx_alert_delivery_reports_station",
+        "alert_delivery_reports",
+        ["station"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_alert_delivery_reports_station", table_name="alert_delivery_reports")
+    op.drop_index("idx_alert_delivery_reports_originator", table_name="alert_delivery_reports")
+    op.drop_index("idx_alert_delivery_reports_scope_window", table_name="alert_delivery_reports")
+    op.drop_table("alert_delivery_reports")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -262,6 +262,50 @@ class ManualEASActivation(db.Model):
         }
 
 
+class AlertDeliveryReport(db.Model):
+    __tablename__ = "alert_delivery_reports"
+
+    id = db.Column(db.Integer, primary_key=True)
+    generated_at = db.Column(
+        db.DateTime(timezone=True), nullable=False, default=utc_now
+    )
+    window_start = db.Column(db.DateTime(timezone=True), nullable=False)
+    window_end = db.Column(db.DateTime(timezone=True), nullable=False)
+    scope = db.Column(db.String(16), nullable=False)
+    originator = db.Column(db.String(64))
+    station = db.Column(db.String(128))
+    total_alerts = db.Column(db.Integer, nullable=False, default=0)
+    delivered_alerts = db.Column(db.Integer, nullable=False, default=0)
+    delayed_alerts = db.Column(db.Integer, nullable=False, default=0)
+    average_latency_seconds = db.Column(db.Integer)
+
+    __table_args__ = (
+        db.Index(
+            "idx_alert_delivery_reports_scope_window",
+            "scope",
+            "window_start",
+            "window_end",
+        ),
+        db.Index("idx_alert_delivery_reports_originator", "originator"),
+        db.Index("idx_alert_delivery_reports_station", "station"),
+    )
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - convenience helper
+        return {
+            "id": self.id,
+            "generated_at": self.generated_at,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "scope": self.scope,
+            "originator": self.originator,
+            "station": self.station,
+            "total_alerts": self.total_alerts,
+            "delivered_alerts": self.delivered_alerts,
+            "delayed_alerts": self.delayed_alerts,
+            "average_latency_seconds": self.average_latency_seconds,
+        }
+
+
 class Intersection(db.Model):
     __tablename__ = "intersections"
 

--- a/app_utils/__init__.py
+++ b/app_utils/__init__.py
@@ -15,6 +15,7 @@ from .time import (
     utc_now,
 )
 from .formatting import format_bytes, format_uptime
+from .export import generate_csv
 from .system import build_system_health_snapshot
 from .alert_sources import (
     ALERT_SOURCE_IPAWS,
@@ -38,6 +39,7 @@ __all__ = [
     "is_alert_expired",
     "format_bytes",
     "format_uptime",
+    "generate_csv",
     "build_system_health_snapshot",
     "get_location_timezone",
     "get_location_timezone_name",

--- a/app_utils/export.py
+++ b/app_utils/export.py
@@ -1,0 +1,49 @@
+"""Shared helpers for generating CSV exports."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Iterable, Mapping, MutableMapping, Optional, Sequence
+
+
+def _resolve_fieldnames(
+    rows: Sequence[Mapping[str, object]] | Iterable[Mapping[str, object]],
+    fieldnames: Optional[Sequence[str]] = None,
+) -> Sequence[str]:
+    if fieldnames:
+        return [str(name) for name in fieldnames]
+
+    collected: MutableMapping[str, None] = {}
+    for row in rows:
+        for key in row.keys():
+            key_str = str(key)
+            if key_str not in collected:
+                collected[key_str] = None
+    return list(collected.keys())
+
+
+def generate_csv(
+    rows: Sequence[Mapping[str, object]] | Iterable[Mapping[str, object]],
+    *,
+    fieldnames: Optional[Sequence[str]] = None,
+    include_header: bool = True,
+) -> str:
+    """Return a CSV payload for the provided row dictionaries."""
+
+    serializable_rows = list(rows)
+    headers = _resolve_fieldnames(serializable_rows, fieldnames=fieldnames)
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=headers, extrasaction="ignore")
+
+    if include_header:
+        writer.writeheader()
+
+    for row in serializable_rows:
+        writer.writerow({name: row.get(name, "") for name in headers})
+
+    return buffer.getvalue()
+
+
+__all__ = ["generate_csv"]

--- a/docs/eas_todo.md
+++ b/docs/eas_todo.md
@@ -42,11 +42,11 @@
   - Add automated tests (pytest-based under `tests/`) covering ingest/output mocks and GPIO logic to prevent regressions.
 
 ## 7. Alert Verification & Analytics
-- [ ] Build an alert verification pipeline.
-  - Correlate CAP messages with downstream playout logs in `app_core/eas_storage.py` to confirm full delivery paths.
-  - Add a validation view (`webapp/routes/alert_verification.py`, `templates/eas/alert_verification.html`) that highlights mismatches, missing audio, or delayed retransmissions.
-  - Generate trend analytics (per originator, per station) stored in a new reporting table with Alembic migration and surfaced via charts using the existing `static/js/charts/` helpers.
-  - Ship CSV exports from the verification view using shared utilities in `app_utils/export.py`.
+- [x] Build an alert verification pipeline.
+  - [x] Correlate CAP messages with downstream playout logs in `app_core/eas_storage.py` to confirm full delivery paths.
+  - [x] Add a validation view (`webapp/routes/alert_verification.py`, `templates/eas/alert_verification.html`) that highlights mismatches, missing audio, or delayed retransmissions.
+  - [x] Generate trend analytics (per originator, per station) stored in a new reporting table with Alembic migration and surfaced via charts using the existing `static/js/charts/` helpers.
+  - [x] Ship CSV exports from the verification view using shared utilities in `app_utils/export.py`.
 
 ## 8. Security & Access Controls
 - [ ] Harden operator access and system security.

--- a/static/js/charts/alert_delivery.js
+++ b/static/js/charts/alert_delivery.js
@@ -1,0 +1,112 @@
+(function (window) {
+    'use strict';
+
+    function resolveSeries(entries) {
+        const categories = [];
+        const delivered = [];
+        const missed = [];
+        const delayed = [];
+        const tooltips = [];
+
+        entries.forEach((entry) => {
+            const total = entry.total || 0;
+            const deliveredCount = entry.delivered || 0;
+            const delayedCount = entry.delayed || 0;
+            const missedCount = Math.max(total - deliveredCount, 0);
+            categories.push(entry.label || 'Unknown');
+            delivered.push(deliveredCount);
+            missed.push(missedCount);
+            delayed.push(delayedCount);
+            tooltips.push(entry);
+        });
+
+        return { categories, delivered, missed, delayed, tooltips };
+    }
+
+    function renderChart(containerId, entries) {
+        if (!window.Highcharts) {
+            console.warn('Highcharts is not available; skipping chart render for', containerId);
+            return;
+        }
+
+        const target = document.getElementById(containerId);
+        if (!target) {
+            return;
+        }
+
+        const series = resolveSeries(entries);
+        if (series.categories.length === 0) {
+            target.innerHTML = '<p class="text-muted mb-0">No data available for this chart.</p>';
+            return;
+        }
+
+        Highcharts.chart(containerId, {
+            chart: {
+                type: 'column',
+                backgroundColor: 'transparent'
+            },
+            title: { text: null },
+            xAxis: {
+                categories: series.categories,
+                crosshair: true,
+                labels: { style: { color: 'var(--text-color)' } }
+            },
+            yAxis: {
+                min: 0,
+                title: { text: 'Alerts', style: { color: 'var(--text-color)' } },
+                labels: { style: { color: 'var(--text-color)' } }
+            },
+            legend: {
+                itemStyle: { color: 'var(--text-color)' }
+            },
+            tooltip: {
+                shared: true,
+                useHTML: true,
+                formatter: function () {
+                    const pointIndex = this.points && this.points.length ? this.points[0].point.index : 0;
+                    const entry = series.tooltips[pointIndex] || {};
+                    const rate = entry.delivery_rate != null ? entry.delivery_rate.toFixed(1) + '%' : '—';
+                    const latency = entry.average_latency_seconds != null ? entry.average_latency_seconds.toFixed(1) + ' s' : '—';
+                    return `
+                        <div class="small">
+                            <strong>${entry.label || 'Unknown'}</strong><br>
+                            Delivery Rate: ${rate}<br>
+                            Avg Latency: ${latency}<br>
+                            Delayed Alerts: ${entry.delayed || 0}
+                        </div>
+                    `;
+                }
+            },
+            plotOptions: {
+                column: {
+                    stacking: 'normal',
+                    borderWidth: 0
+                }
+            },
+            series: [
+                {
+                    name: 'Delivered',
+                    data: series.delivered,
+                    color: '#28a745'
+                },
+                {
+                    name: 'Missed',
+                    data: series.missed,
+                    color: '#dc3545'
+                }
+            ]
+        });
+    }
+
+    function render(config) {
+        const originators = Array.isArray(config.originators) ? config.originators : [];
+        const stations = Array.isArray(config.stations) ? config.stations : [];
+
+        renderChart('alert-originator-chart', originators);
+        renderChart('alert-station-chart', stations);
+    }
+
+    window.AlertVerificationCharts = {
+        render
+    };
+})(window);

--- a/templates/base.html
+++ b/templates/base.html
@@ -305,6 +305,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('alert_verification') }}">
+                            <i class="fas fa-shield-check"></i> Verification
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <span class="nav-link disabled text-nowrap">
                             <i class="fas fa-user-shield"></i> {{ current_user.username }}
                         </span>

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -1,0 +1,282 @@
+{% extends "base.html" %}
+{% block title %}Alert Verification & Analytics{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+        <div>
+            <h1 class="h3 mb-1">Alert Verification &amp; Analytics</h1>
+            <p class="text-muted mb-0">
+                Monitoring window: last {{ window_days }} days · Generated
+                {% if payload.generated_at %}
+                    {{ format_local_datetime(payload.generated_at, include_utc=True) }}
+                {% else %}
+                    —
+                {% endif %}
+            </p>
+        </div>
+        <div class="btn-group" role="group">
+            <a class="btn btn-outline-primary" href="{{ url_for('alert_verification_export', days=window_days) }}">
+                <i class="fas fa-file-csv"></i> Export CSV
+            </a>
+        </div>
+    </div>
+
+    {% set summary = payload.summary or {} %}
+    {% set total = summary.total or 0 %}
+    {% set delivered = (summary.delivered or 0) + (summary.partial or 0) %}
+    {% set issues_count = (summary.partial or 0) + (summary.pending or 0) + (summary.awaiting_playout or 0) + (summary.missing or 0) %}
+    {% set success_rate = (delivered / total * 100) if total else None %}
+
+    <div class="row g-3 mb-4">
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><i class="fas fa-circle-check text-success"></i> Delivery Success</h5>
+                    <p class="display-6 fw-semibold mb-1">
+                        {% if success_rate is not none %}
+                            {{ '%.1f'|format(success_rate) }}%
+                        {% else %}
+                            <span class="text-muted">N/A</span>
+                        {% endif %}
+                    </p>
+                    <p class="text-muted mb-2">Alerts with at least one successful playout.</p>
+                    <dl class="row mb-0 small">
+                        <dt class="col-6">Total Alerts</dt>
+                        <dd class="col-6 text-end">{{ total }}</dd>
+                        <dt class="col-6">Fully Delivered</dt>
+                        <dd class="col-6 text-end">{{ summary.delivered or 0 }}</dd>
+                        <dt class="col-6">Partial Delivery</dt>
+                        <dd class="col-6 text-end">{{ summary.partial or 0 }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><i class="fas fa-triangle-exclamation text-warning"></i> Alerts Requiring Attention</h5>
+                    <p class="display-6 fw-semibold mb-1">{{ issues_count }}</p>
+                    <p class="text-muted mb-2">Alerts pending, missing, or with failed outputs.</p>
+                    <dl class="row mb-0 small">
+                        <dt class="col-6">Pending</dt>
+                        <dd class="col-6 text-end">{{ summary.pending or 0 }}</dd>
+                        <dt class="col-6">Awaiting Playout</dt>
+                        <dd class="col-6 text-end">{{ summary.awaiting_playout or 0 }}</dd>
+                        <dt class="col-6">Missing Audio</dt>
+                        <dd class="col-6 text-end">{{ summary.missing or 0 }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title"><i class="fas fa-hourglass-half text-info"></i> Average Latency</h5>
+                    <p class="display-6 fw-semibold mb-1">
+                        {% if summary.average_latency_seconds is not none %}
+                            {{ '%.1f'|format(summary.average_latency_seconds) }}s
+                        {% else %}
+                            <span class="text-muted">No samples</span>
+                        {% endif %}
+                    </p>
+                    <p class="text-muted mb-2">Delay threshold: {{ payload.delay_threshold_seconds }}s</p>
+                    {% if trends.originators %}
+                        <p class="small text-muted mb-0">{{ trends.originators|length }} originators analysed.</p>
+                    {% else %}
+                        <p class="small text-muted mb-0">No playout metrics recorded during this window.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header bg-transparent d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+            <h5 class="card-title mb-0"><i class="fas fa-chart-line text-primary"></i> Delivery Trends</h5>
+            <span class="badge bg-secondary">Delay threshold: {{ payload.delay_threshold_seconds }} seconds</span>
+        </div>
+        <div class="card-body">
+            {% if trends.originators or trends.stations %}
+                <div class="row g-4">
+                    <div class="col-lg-6">
+                        <h6 class="text-muted text-uppercase">By Originator</h6>
+                        <div id="alert-originator-chart" style="min-height: 260px;"></div>
+                    </div>
+                    <div class="col-lg-6">
+                        <h6 class="text-muted text-uppercase">By Output Target</h6>
+                        <div id="alert-station-chart" style="min-height: 260px;"></div>
+                    </div>
+                </div>
+            {% else %}
+                <p class="text-muted mb-0">No delivery metrics are available for this window.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header bg-transparent">
+            <h5 class="card-title mb-0"><i class="fas fa-list-check text-secondary"></i> Alert Delivery Records</h5>
+        </div>
+        <div class="card-body">
+            {% if payload.records %}
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col">Sent</th>
+                                <th scope="col">Identifier</th>
+                                <th scope="col">Event</th>
+                                <th scope="col">Status</th>
+                                <th scope="col">Outputs</th>
+                                <th scope="col" class="text-end">Latency</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for record in payload.records %}
+                                <tr>
+                                    <td>
+                                        {% if record.sent %}
+                                            {{ format_local_datetime(record.sent, include_utc=True) }}
+                                        {% else %}
+                                            <span class="text-muted">Unknown</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-nowrap">{{ record.identifier or '—' }}</td>
+                                    <td>{{ record.event or '—' }}</td>
+                                    <td>
+                                        {% if record.delivery_status == 'delivered' %}
+                                            <span class="badge bg-success text-uppercase">Delivered</span>
+                                        {% elif record.delivery_status == 'partial' %}
+                                            <span class="badge bg-warning text-dark text-uppercase">Partial</span>
+                                        {% elif record.delivery_status == 'pending' %}
+                                            <span class="badge bg-info text-uppercase">Pending</span>
+                                        {% elif record.delivery_status == 'missing' %}
+                                            <span class="badge bg-danger text-uppercase">Missing</span>
+                                        {% else %}
+                                            <span class="badge bg-secondary text-uppercase">{{ record.delivery_status or 'Unknown' }}</span>
+                                        {% endif %}
+                                        {% if record.issues %}
+                                            <div class="small text-muted mt-1">
+                                                {% for issue in record.issues %}
+                                                    <div><i class="fas fa-circle-exclamation text-warning"></i> {{ issue }}</div>
+                                                {% endfor %}
+                                            </div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if record.target_details %}
+                                            <ul class="list-unstyled mb-0 small">
+                                                {% for target in record.target_details %}
+                                                    <li>
+                                                        <strong>{{ target.target }}</strong>
+                                                        {% if target.status == 'delivered' %}
+                                                            <span class="text-success">delivered</span>
+                                                        {% elif target.status == 'failed' %}
+                                                            <span class="text-danger">failed</span>
+                                                        {% elif target.status == 'pending' %}
+                                                            <span class="text-info">pending</span>
+                                                        {% elif target.status == 'partial' %}
+                                                            <span class="text-warning">partial</span>
+                                                        {% else %}
+                                                            <span class="text-muted">{{ target.status }}</span>
+                                                        {% endif %}
+                                                        {% if target.latency_seconds is not none %}
+                                                            · {{ '%.1f'|format(target.latency_seconds) }}s
+                                                        {% endif %}
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        {% else %}
+                                            <span class="text-muted small">No playout data</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-end">
+                                        {% if record.average_latency_seconds is not none %}
+                                            {{ '%.1f'|format(record.average_latency_seconds) }}s
+                                        {% else %}
+                                            <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-muted mb-0">No CAP alerts were recorded during this window.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header bg-transparent">
+            <h5 class="card-title mb-0"><i class="fas fa-link-slash text-danger"></i> Unmatched Playout Records</h5>
+        </div>
+        <div class="card-body">
+            {% if payload.orphans %}
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col">Timestamp</th>
+                                <th scope="col">SAME Header</th>
+                                <th scope="col">Events Logged</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for orphan in payload.orphans %}
+                                <tr>
+                                    <td>
+                                        {% if orphan.created_at %}
+                                            {{ format_local_datetime(orphan.created_at, include_utc=True) }}
+                                        {% else %}
+                                            <span class="text-muted">Unknown</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-nowrap">{{ orphan.same_header }}</td>
+                                    <td>
+                                        {% if orphan.playout_events %}
+                                            <ul class="list-unstyled mb-0 small">
+                                                {% for event in orphan.playout_events %}
+                                                    <li>
+                                                        <strong>{{ event.target }}</strong>
+                                                        — {{ event.status }}
+                                                        {% if event.latency_seconds is not none %}
+                                                            ({{ '%.1f'|format(event.latency_seconds) }}s)
+                                                        {% endif %}
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        {% else %}
+                                            <span class="text-muted">No playout metadata captured.</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-muted mb-0">All playout records were matched to CAP alerts.</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="{{ url_for('static', filename='js/charts/alert_delivery.js') }}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.AlertVerificationCharts) {
+                window.AlertVerificationCharts.render({
+                    originators: {{ trends.originators | tojson }},
+                    stations: {{ trends.stations | tojson }},
+                    delayThreshold: {{ payload.delay_threshold_seconds | tojson }}
+                });
+            }
+        });
+    </script>
+{% endblock %}

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -17,7 +17,7 @@ from . import (
     routes_public,
     template_helpers,
 )
-from .routes import eas_compliance
+from .routes import alert_verification, eas_compliance
 
 
 @dataclass(frozen=True)
@@ -35,6 +35,7 @@ def iter_route_modules() -> Iterable[RouteModule]:
     yield RouteModule("template_helpers", template_helpers.register, requires_logger=False)
     yield RouteModule("routes_public", routes_public.register)
     yield RouteModule("routes_monitoring", routes_monitoring.register)
+    yield RouteModule("routes_alert_verification", alert_verification.register)
     yield RouteModule("routes_eas_compliance", eas_compliance.register)
     yield RouteModule("routes_settings_radio", routes_settings_radio.register)
     yield RouteModule("routes_exports", routes_exports.register)

--- a/webapp/routes/alert_verification.py
+++ b/webapp/routes/alert_verification.py
@@ -1,0 +1,138 @@
+"""Routes powering the alert verification and analytics dashboard."""
+
+from __future__ import annotations
+
+from flask import Flask, Response, render_template, request
+
+from app_core.eas_storage import (
+    build_alert_delivery_trends,
+    collect_alert_delivery_records,
+)
+from app_utils import format_local_datetime
+from app_utils.export import generate_csv
+
+
+def register(app: Flask, logger) -> None:
+    """Register alert verification routes on the Flask application."""
+
+    route_logger = logger.getChild("alert_verification")
+
+    def _resolve_window_days() -> int:
+        value = request.args.get("days", type=int)
+        if value is None:
+            return 30
+        return max(1, min(int(value), 365))
+
+    def _serialize_csv_rows(records):
+        for record in records:
+            targets = ", ".join(
+                f"{target['target']} ({target['status']})"
+                for target in record.get("target_details", [])
+            )
+            issues = "; ".join(record.get("issues") or [])
+            yield {
+                "cap_identifier": record.get("identifier") or "",
+                "event": record.get("event") or "",
+                "sent_utc": (record.get("sent").isoformat() if record.get("sent") else ""),
+                "source": record.get("source") or "",
+                "delivery_status": record.get("delivery_status") or "unknown",
+                "average_latency_seconds": (
+                    round(record["average_latency_seconds"], 2)
+                    if isinstance(record.get("average_latency_seconds"), (int, float))
+                    else ""
+                ),
+                "targets": targets,
+                "issues": issues,
+            }
+
+    @app.route("/admin/alert-verification")
+    def alert_verification():
+        window_days = _resolve_window_days()
+
+        try:
+            payload = collect_alert_delivery_records(window_days=window_days)
+            trends = build_alert_delivery_trends(
+                payload["records"],
+                window_start=payload["window_start"],
+                window_end=payload["window_end"],
+                delay_threshold=payload["delay_threshold_seconds"],
+                logger=route_logger,
+            )
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            route_logger.error("Failed to assemble alert verification data: %s", exc)
+            try:
+                fallback_threshold = int(
+                    app.config.get("ALERT_VERIFICATION_DELAY_THRESHOLD_SECONDS", 120)
+                )
+            except (TypeError, ValueError):
+                fallback_threshold = 120
+
+            payload = {
+                "window_start": None,
+                "window_end": None,
+                "generated_at": None,
+                "delay_threshold_seconds": fallback_threshold,
+                "summary": {
+                    "total": 0,
+                    "delivered": 0,
+                    "partial": 0,
+                    "pending": 0,
+                    "missing": 0,
+                    "awaiting_playout": 0,
+                    "average_latency_seconds": None,
+                },
+                "records": [],
+                "orphans": [],
+            }
+            trends = {
+                "generated_at": None,
+                "delay_threshold_seconds": payload["delay_threshold_seconds"],
+                "originators": [],
+                "stations": [],
+            }
+
+        return render_template(
+            "eas/alert_verification.html",
+            window_days=window_days,
+            payload=payload,
+            trends=trends,
+            format_local_datetime=format_local_datetime,
+        )
+
+    @app.route("/admin/alert-verification/export.csv")
+    def alert_verification_export():
+        window_days = _resolve_window_days()
+
+        try:
+            payload = collect_alert_delivery_records(window_days=window_days)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            route_logger.error("Failed to generate alert verification export: %s", exc)
+            return Response(
+                "Unable to generate alert verification export. See logs for details.",
+                status=500,
+                mimetype="text/plain",
+            )
+
+        rows = list(_serialize_csv_rows(payload["records"]))
+        csv_payload = generate_csv(
+            rows,
+            fieldnames=[
+                "cap_identifier",
+                "event",
+                "sent_utc",
+                "source",
+                "delivery_status",
+                "average_latency_seconds",
+                "targets",
+                "issues",
+            ],
+        )
+
+        response = Response(csv_payload, mimetype="text/csv")
+        response.headers["Content-Disposition"] = (
+            f"attachment; filename=alert_verification_{window_days}d.csv"
+        )
+        return response
+
+
+__all__ = ["register"]


### PR DESCRIPTION
## Summary
- build alert delivery correlation and trend helpers for verification analytics
- add alert delivery report persistence and surface new dashboard with charts and CSV export
- introduce shared CSV utility, navigation link, and mark the verification task complete

## Testing
- python -m py_compile app_core/models.py app_core/eas_storage.py app_utils/export.py app_utils/__init__.py webapp/routes/alert_verification.py webapp/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_6903aacff1288320ada546a501967d82