### PR TITLE
Add SAME audio decoder to alert verification dashboard

### DIFF
--- a/app_core/migrations/versions/20240510_eas_audio_decodes.py
+++ b/app_core/migrations/versions/20240510_eas_audio_decodes.py
@@ -1,0 +1,29 @@
+"""Add table for decoded SAME audio payloads."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240510_eas_audio_decodes"
+down_revision = "20240315_alert_delivery_reports"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "eas_decoded_audio",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("original_filename", sa.String(length=255), nullable=True),
+        sa.Column("content_type", sa.String(length=128), nullable=True),
+        sa.Column("raw_text", sa.Text(), nullable=True),
+        sa.Column("same_headers", sa.JSON(), nullable=True),
+        sa.Column("quality_metrics", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("eas_decoded_audio")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -197,6 +197,29 @@ class EASMessage(db.Model):
         }
 
 
+class EASDecodedAudio(db.Model):
+    __tablename__ = "eas_decoded_audio"
+
+    id = db.Column(db.Integer, primary_key=True)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now)
+    original_filename = db.Column(db.String(255))
+    content_type = db.Column(db.String(128))
+    raw_text = db.Column(db.Text)
+    same_headers = db.Column(db.JSON, default=list)
+    quality_metrics = db.Column(db.JSON, default=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "original_filename": self.original_filename,
+            "content_type": self.content_type,
+            "raw_text": self.raw_text,
+            "same_headers": list(self.same_headers or []),
+            "quality_metrics": dict(self.quality_metrics or {}),
+        }
+
+
 class ManualEASActivation(db.Model):
     __tablename__ = "manual_eas_activations"
 

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -1,0 +1,300 @@
+"""Decode SAME/EAS headers from audio files containing alert bursts."""
+
+from __future__ import annotations
+
+import math
+import os
+import shutil
+import subprocess
+from array import array
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from .eas import describe_same_header
+from .eas_fsk import SAME_BAUD, SAME_MARK_FREQ, SAME_SPACE_FREQ
+
+
+class AudioDecodeError(RuntimeError):
+    """Raised when an audio payload cannot be decoded into SAME headers."""
+
+
+@dataclass
+class SAMEHeaderDetails:
+    """Represents a decoded SAME header and the derived metadata."""
+
+    header: str
+    fields: Dict[str, object] = field(default_factory=dict)
+    confidence: float = 0.0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "header": self.header,
+            "fields": dict(self.fields),
+            "confidence": float(self.confidence),
+        }
+
+
+@dataclass
+class SAMEAudioDecodeResult:
+    """Container holding the outcome of decoding an audio payload."""
+
+    raw_text: str
+    headers: List[SAMEHeaderDetails]
+    bit_count: int
+    frame_count: int
+    frame_errors: int
+    duration_seconds: float
+    sample_rate: int
+    bit_confidence: float
+    min_bit_confidence: float
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "raw_text": self.raw_text,
+            "headers": [header.to_dict() for header in self.headers],
+            "bit_count": self.bit_count,
+            "frame_count": self.frame_count,
+            "frame_errors": self.frame_errors,
+            "duration_seconds": self.duration_seconds,
+            "sample_rate": self.sample_rate,
+            "bit_confidence": self.bit_confidence,
+            "min_bit_confidence": self.min_bit_confidence,
+        }
+
+
+def _run_ffmpeg_decode(path: str, sample_rate: int) -> bytes:
+    """Invoke ffmpeg to normalise an audio file to mono PCM samples."""
+
+    if not shutil.which("ffmpeg"):
+        raise AudioDecodeError(
+            "ffmpeg is required to decode audio files. Install ffmpeg and try again."
+        )
+
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        path,
+        "-ar",
+        str(sample_rate),
+        "-ac",
+        "1",
+        "-f",
+        "s16le",
+        "-",
+    ]
+
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover - subprocess
+        detail = exc.stderr.decode("utf-8", "ignore") if hasattr(exc, "stderr") else ""
+        raise AudioDecodeError(
+            f"Unable to decode audio with ffmpeg: {exc}" + (f" ({detail.strip()})" if detail else "")
+        ) from exc
+
+    if not result.stdout:
+        raise AudioDecodeError("ffmpeg produced no audio samples for decoding.")
+
+    return bytes(result.stdout)
+
+
+def _read_audio_samples(path: str, sample_rate: int) -> List[float]:
+    """Return normalised PCM samples from an arbitrary audio file."""
+
+    try:
+        import wave
+
+        with wave.open(path, "rb") as handle:
+            params = handle.getparams()
+            if params.nchannels == 1 and params.sampwidth == 2 and params.framerate == sample_rate:
+                pcm = handle.readframes(params.nframes)
+                if pcm:
+                    return _convert_pcm_to_floats(pcm)
+    except Exception:
+        pass
+
+    pcm_bytes = _run_ffmpeg_decode(path, sample_rate)
+    return _convert_pcm_to_floats(pcm_bytes)
+
+
+def _convert_pcm_to_floats(payload: bytes) -> List[float]:
+    """Convert 16-bit little-endian PCM bytes into a list of floats."""
+
+    pcm = array("h")
+    pcm.frombytes(payload)
+    if not pcm:
+        raise AudioDecodeError("Audio payload contained no PCM samples to decode.")
+
+    scale = 1.0 / 32768.0
+    return [sample * scale for sample in pcm]
+
+
+def _goertzel(samples: Iterable[float], sample_rate: int, target_freq: float) -> float:
+    """Compute the Goertzel power for ``target_freq`` within ``samples``."""
+
+    coeff = 2.0 * math.cos(2.0 * math.pi * target_freq / sample_rate)
+    s_prev = 0.0
+    s_prev2 = 0.0
+    for sample in samples:
+        s = sample + coeff * s_prev - s_prev2
+        s_prev2 = s_prev
+        s_prev = s
+    power = s_prev2 ** 2 + s_prev ** 2 - coeff * s_prev * s_prev2
+    return power if power > 0.0 else 0.0
+
+
+def _extract_bits(samples: List[float], sample_rate: int) -> List[int]:
+    """Slice PCM audio into SAME bit periods and detect mark/space symbols."""
+
+    bits: List[int] = []
+    bit_confidences: List[float] = []
+
+    bit_rate = float(SAME_BAUD)
+    samples_per_bit = sample_rate / bit_rate
+    carry = 0.0
+    index = 0
+
+    while index < len(samples):
+        total = samples_per_bit + carry
+        chunk_length = int(total)
+        if chunk_length <= 0:
+            chunk_length = 1
+        carry = total - chunk_length
+        end = index + chunk_length
+        if end > len(samples):
+            break
+
+        chunk = samples[index:end]
+        mark_power = _goertzel(chunk, sample_rate, SAME_MARK_FREQ)
+        space_power = _goertzel(chunk, sample_rate, SAME_SPACE_FREQ)
+        bit = 1 if mark_power >= space_power else 0
+        bits.append(bit)
+
+        if mark_power + space_power > 0:
+            confidence = abs(mark_power - space_power) / (mark_power + space_power)
+        else:
+            confidence = 0.0
+        bit_confidences.append(confidence)
+
+        index = end
+
+    if not bits:
+        raise AudioDecodeError("The audio payload did not contain detectable SAME bursts.")
+
+    average_confidence = sum(bit_confidences) / len(bit_confidences)
+    minimum_confidence = min(bit_confidences) if bit_confidences else 0.0
+    _extract_bits.last_confidence = average_confidence  # type: ignore[attr-defined]
+    _extract_bits.min_confidence = minimum_confidence  # type: ignore[attr-defined]
+
+    return bits
+
+
+def _bits_to_text(bits: List[int]) -> Dict[str, object]:
+    """Convert mark/space bits into ASCII SAME text and headers."""
+
+    characters: List[str] = []
+    frame_errors = 0
+    frame_count = 0
+
+    i = 0
+    while i + 10 <= len(bits):
+        frame_count += 1
+        start_bit = bits[i]
+        if start_bit != 0:
+            i += 1
+            continue
+
+        data_bits = bits[i + 1 : i + 8]
+        parity_or_unused = bits[i + 8]
+        stop_bit = bits[i + 9]
+
+        if stop_bit != 1:
+            frame_errors += 1
+            i += 1
+            continue
+
+        value = 0
+        for position, bit in enumerate(data_bits):
+            value |= (bit & 1) << position
+
+        if parity_or_unused not in (0, 1):
+            frame_errors += 1
+
+        try:
+            character = chr(value)
+        except ValueError:
+            frame_errors += 1
+            i += 10
+            continue
+
+        characters.append(character)
+        i += 10
+
+    raw_text = "".join(characters)
+
+    headers: List[str] = []
+    for segment in raw_text.split("\r"):
+        cleaned = segment.strip()
+        if not cleaned:
+            continue
+        if cleaned.upper().startswith("ZCZC") or cleaned.upper().startswith("NNNN"):
+            headers.append(cleaned)
+
+    return {
+        "text": raw_text,
+        "headers": headers,
+        "frame_count": frame_count,
+        "frame_errors": frame_errors,
+    }
+
+
+def decode_same_audio(path: str, *, sample_rate: int = 44100) -> SAMEAudioDecodeResult:
+    """Decode SAME headers from a WAV or MP3 file located at ``path``."""
+
+    if not os.path.exists(path):
+        raise AudioDecodeError(f"Audio file does not exist: {path}")
+
+    samples = _read_audio_samples(path, sample_rate)
+    bits = _extract_bits(samples, sample_rate)
+    metadata = _bits_to_text(bits)
+
+    raw_text = metadata["text"]
+    headers: List[SAMEHeaderDetails] = []
+    for header in metadata["headers"]:
+        headers.append(
+            SAMEHeaderDetails(
+                header=header,
+                fields=describe_same_header(header),
+                confidence=float(getattr(_extract_bits, "last_confidence", 0.0)),
+            )
+        )
+
+    duration_seconds = len(samples) / float(sample_rate)
+    average_confidence = float(getattr(_extract_bits, "last_confidence", 0.0))
+    min_confidence = float(getattr(_extract_bits, "min_confidence", 0.0))
+
+    return SAMEAudioDecodeResult(
+        raw_text=raw_text,
+        headers=headers,
+        bit_count=len(bits),
+        frame_count=metadata["frame_count"],
+        frame_errors=metadata["frame_errors"],
+        duration_seconds=duration_seconds,
+        sample_rate=sample_rate,
+        bit_confidence=average_confidence,
+        min_bit_confidence=min_confidence,
+    )
+
+
+__all__ = [
+    "AudioDecodeError",
+    "SAMEAudioDecodeResult",
+    "SAMEHeaderDetails",
+    "decode_same_audio",
+]

--- a/docs/eas_todo.md
+++ b/docs/eas_todo.md
@@ -46,8 +46,8 @@
   - [x] Correlate CAP messages with downstream playout logs in `app_core/eas_storage.py` to confirm full delivery paths.
   - [x] Add a validation view (`webapp/routes/alert_verification.py`, `templates/eas/alert_verification.html`) that highlights mismatches, missing audio, or delayed retransmissions.
   - [x] Generate trend analytics (per originator, per station) stored in a new reporting table with Alembic migration and surfaced via charts using the existing `static/js/charts/` helpers.
-  - [x] Ship CSV exports from the verification view using shared utilities in `app_utils/export.py`.
-  - [ ] Create a way to ingest .WAV and .MP3 files containing EAS Headers and display and possibly store the results of the decode.
+- [x] Ship CSV exports from the verification view using shared utilities in `app_utils/export.py`.
+  - [x] Create a way to ingest .WAV and .MP3 files containing EAS Headers and display and possibly store the results of the decode.
 
 ## 8. Security & Access Controls
 - [ ] Harden operator access and system security.

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -22,6 +22,170 @@
         </div>
     </div>
 
+    <div class="card mb-4">
+        <div class="card-header bg-transparent d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+            <h5 class="card-title mb-0"><i class="fas fa-wave-square text-primary"></i> SAME Audio Header Decoder</h5>
+            <span class="text-muted small">Upload a WAV or MP3 recording of SAME bursts.</span>
+        </div>
+        <div class="card-body">
+            <form method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
+                <input type="hidden" name="days" value="{{ window_days }}">
+                <div class="col-md-6">
+                    <label class="form-label" for="audio_file">Audio file</label>
+                    <input class="form-control" type="file" id="audio_file" name="audio_file" accept=".wav,.mp3" required>
+                    <div class="form-text">Only the header portion is analysed; voice content is ignored.</div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-check mt-4">
+                        <input class="form-check-input" type="checkbox" id="store_results" name="store_results" {% if request.form.get('store_results') == 'on' %}checked{% endif %}>
+                        <label class="form-check-label" for="store_results">Store decode results</label>
+                    </div>
+                </div>
+                <div class="col-md-3 text-md-end">
+                    <button class="btn btn-primary" type="submit">
+                        <i class="fas fa-microphone-lines"></i> Decode Audio
+                    </button>
+                </div>
+            </form>
+
+            {% if decode_errors %}
+                <div class="alert alert-danger mt-3 mb-0">
+                    <ul class="mb-0">
+                        {% for error in decode_errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+
+            {% if stored_decode and not decode_errors %}
+                <div class="alert alert-success mt-3 mb-0">
+                    <i class="fas fa-check-circle"></i>
+                    Decoded results stored for {{ stored_decode.original_filename or 'uploaded audio' }}.
+                </div>
+            {% endif %}
+
+            {% if decode_result %}
+                <div class="mt-4">
+                    <h6 class="text-muted text-uppercase">Decode Summary</h6>
+                    <dl class="row mb-3 small">
+                        <dt class="col-sm-4">Detected headers</dt>
+                        <dd class="col-sm-8">{{ decode_result.headers|length }}</dd>
+                        <dt class="col-sm-4">Confidence</dt>
+                        <dd class="col-sm-8">{{ '%.2f'|format(decode_result.bit_confidence * 100) }}% avg · {{ '%.2f'|format(decode_result.min_bit_confidence * 100) }}% min</dd>
+                        <dt class="col-sm-4">Frame quality</dt>
+                        <dd class="col-sm-8">{{ decode_result.frame_count - decode_result.frame_errors }} valid of {{ decode_result.frame_count }}</dd>
+                        <dt class="col-sm-4">Duration analysed</dt>
+                        <dd class="col-sm-8">{{ '%.2f'|format(decode_result.duration_seconds) }} seconds @ {{ decode_result.sample_rate }} Hz</dd>
+                    </dl>
+
+                    {% if decode_result.raw_text %}
+                        <div class="mb-3">
+                            <label class="form-label">Raw decoded text</label>
+                            <pre class="bg-light border rounded px-3 py-2 small mb-0">{{ decode_result.raw_text }}</pre>
+                        </div>
+                    {% endif %}
+
+                    {% if decode_result.headers %}
+                        <div class="row g-3">
+                            {% for header in decode_result.headers %}
+                                <div class="col-xl-6">
+                                    <div class="border rounded p-3 h-100">
+                                        <div class="d-flex justify-content-between align-items-center mb-2">
+                                            <h6 class="mb-0">{{ header.header }}</h6>
+                                            <span class="badge bg-primary">{{ '%.1f'|format(header.confidence * 100) }}% confidence</span>
+                                        </div>
+                                        {% set detail = header.fields or {} %}
+                                        <dl class="row small mb-0">
+                                            <dt class="col-sm-5">Originator</dt>
+                                            <dd class="col-sm-7">{{ detail.originator or '—' }}{% if detail.originator_description %} ({{ detail.originator_description }}){% endif %}</dd>
+                                            <dt class="col-sm-5">Event</dt>
+                                            <dd class="col-sm-7">{{ detail.event_code or '—' }}</dd>
+                                            <dt class="col-sm-5">Station</dt>
+                                            <dd class="col-sm-7">{{ detail.station_identifier or '—' }}</dd>
+                                            <dt class="col-sm-5">Purge duration</dt>
+                                            <dd class="col-sm-7">{{ detail.purge_label or detail.purge_code or '—' }}</dd>
+                                            <dt class="col-sm-5">Issue time</dt>
+                                            <dd class="col-sm-7">{{ detail.issue_time_label or '—' }}</dd>
+                                        </dl>
+                                        {% if detail.locations %}
+                                            <div class="mt-2">
+                                                <h6 class="text-muted text-uppercase small mb-1">Locations ({{ detail.location_count }})</h6>
+                                                <ul class="list-unstyled small mb-0">
+                                                    {% for location in detail.locations %}
+                                                        <li>
+                                                            <strong>{{ location.code }}</strong>
+                                                            · {{ location.description }}
+                                                            {% if location.p_meaning %}
+                                                                <span class="text-muted">({{ location.p_meaning }})</span>
+                                                            {% endif %}
+                                                        </li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <p class="text-muted mb-0">No SAME headers were detected in the supplied audio.</p>
+                    {% endif %}
+                </div>
+            {% endif %}
+
+            {% if recent_decodes %}
+                <hr>
+                <h6 class="text-muted text-uppercase mb-3">Recent Stored Decodes</h6>
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col">Recorded</th>
+                                <th scope="col">Source File</th>
+                                <th scope="col">Headers</th>
+                                <th scope="col">Confidence</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for decode in recent_decodes %}
+                                <tr>
+                                    <td>
+                                        {% if decode.created_at %}
+                                            {{ format_local_datetime(decode.created_at, include_utc=True) }}
+                                        {% else %}
+                                            <span class="text-muted">Unknown</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ decode.original_filename or '—' }}</td>
+                                    <td>
+                                        {% if decode.same_headers %}
+                                            <ul class="list-unstyled mb-0 small">
+                                                {% for header in decode.same_headers %}
+                                                    <li>{{ header.header or header }}</li>
+                                                {% endfor %}
+                                            </ul>
+                                        {% else %}
+                                            <span class="text-muted small">None captured</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% set metrics = decode.quality_metrics or {} %}
+                                        {% if metrics.bit_confidence is not none %}
+                                            {{ '%.1f'|format(metrics.bit_confidence * 100) }}%
+                                        {% else %}
+                                            <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
     {% set summary = payload.summary or {} %}
     {% set total = summary.total or 0 %}
     {% set delivered = (summary.delivered or 0) + (summary.partial or 0) %}


### PR DESCRIPTION
## Summary
- add a SAME audio decoding helper that extracts headers from WAV and MP3 inputs
- persist decoded headers and quality metrics for later review via a new database table
- extend the alert verification dashboard with an upload form, decode results, and stored history

## Testing
- python -m compileall app_utils/eas_decode.py webapp/routes/alert_verification.py app_core/eas_storage.py app_core/models.py

------
https://chatgpt.com/codex/tasks/task_e_6903af7e552c83209d2a0988bd3ebe1e