### PR TITLE
Update old repository references to reflect rename

### DIFF
--- a/DATABASE_CONSISTENCY_FIXES.md
+++ b/DATABASE_CONSISTENCY_FIXES.md
@@ -265,11 +265,11 @@ POSTGRES_HOST=alerts-db
 
 ```bash
 # Test that app starts with proper credentials
-cd ~/noaa_alerts_systems
-sudo docker compose restart app
+cd ~/eas-station
+docker compose restart app
 
 # Check logs for errors
-sudo docker compose logs app | grep -i "error\|password"
+docker compose logs app | grep -i "error\|password"
 
 # Should see no errors about DATABASE_URL or missing credentials
 ```

--- a/ENV_MIGRATION_GUIDE.md
+++ b/ENV_MIGRATION_GUIDE.md
@@ -41,7 +41,7 @@ Open your `.env` file and make these changes:
 # ALERTS_DB_USER=postgres
 # ALERTS_DB_PASS=postgres
 # ALERTS_DB_CONTAINER=alerts-db
-# ALERTS_DB_VOLUME=noaa_alerts_systems_alerts-db
+# ALERTS_DB_VOLUME=eas-station_alerts-db
 # ALERTS_DB_VERSION=16.2
 
 # 2. ADD these new lines after POLL_INTERVAL_SEC:
@@ -118,12 +118,12 @@ After migration:
 
 ```bash
 # Restart containers to pick up changes
-cd ~/noaa_alerts_systems
-sudo docker compose down
-sudo docker compose up -d
+cd ~/eas-station
+docker compose down
+docker compose up -d
 
 # Check logs
-sudo docker compose logs -f ipaws-poller
+docker compose logs -f ipaws-poller
 
 # Should see:
 # INFO:__main__:Starting CAP Alert Poller with LED Integration - Mode: IPAWS
@@ -138,7 +138,7 @@ If you have issues:
 cp .env.backup .env
 
 # Restart
-sudo docker compose restart
+docker compose restart
 ```
 
 ## Questions?

--- a/README.md
+++ b/README.md
@@ -491,13 +491,13 @@ nano .env  # or use your preferred editor
 
 **Using Docker exec:**
 ```bash
-docker compose exec postgresql psql -U casaos -d casaos
+docker compose exec postgresql psql -U postgres -d alerts
 ```
 
 **From host machine (if psql installed):**
 ```bash
-psql -h localhost -p 5432 -U casaos -d casaos
-# Password: casaos (or your custom password)
+psql -h localhost -p 5432 -U postgres -d alerts
+# Password: change-me (or your custom password from .env)
 ```
 
 ### Database Schema
@@ -518,19 +518,19 @@ The system automatically creates the following tables:
 **Create Backup:**
 ```bash
 # Dump entire database
-docker compose exec postgresql pg_dump -U casaos casaos > backup_$(date +%Y%m%d_%H%M%S).sql
+docker compose exec postgresql pg_dump -U postgres alerts > backup_$(date +%Y%m%d_%H%M%S).sql
 
 # Backup with compression
-docker compose exec postgresql pg_dump -U casaos casaos | gzip > backup.sql.gz
+docker compose exec postgresql pg_dump -U postgres alerts | gzip > backup.sql.gz
 ```
 
 **Restore from Backup:**
 ```bash
 # From plain SQL
-cat backup_20250128_120000.sql | docker compose exec -T postgresql psql -U casaos -d casaos
+cat backup_20250128_120000.sql | docker compose exec -T postgresql psql -U postgres -d alerts
 
 # From compressed backup
-gunzip -c backup.sql.gz | docker compose exec -T postgresql psql -U casaos -d casaos
+gunzip -c backup.sql.gz | docker compose exec -T postgresql psql -U postgres -d alerts
 ```
 
 **Reset Database (WARNING: Deletes all data):**
@@ -721,7 +721,7 @@ docker stats
 **Solutions:**
 1. Validate GeoJSON format at [geojson.io](https://geojson.io)
 2. Ensure UTF-8 encoding (not UTF-16 or other)
-3. Check PostGIS extension: `docker compose exec postgresql psql -U casaos -d casaos -c "SELECT PostGIS_Version();"`
+3. Check PostGIS extension: `docker compose exec postgresql psql -U postgres -d alerts -c "SELECT PostGIS_Version();"`
 4. Verify upload folder permissions: `docker compose exec app ls -la /app/uploads`
 5. Check file size limits in Flask configuration
 
@@ -786,8 +786,8 @@ docker stats
    brew install postgresql postgis
 
    # Create database
-   createdb casaos
-   psql -d casaos -c "CREATE EXTENSION postgis;"
+   createdb alerts
+   psql -d alerts -c "CREATE EXTENSION postgis;"
    ```
 
 4. **Configure `.env` for local development:**

--- a/app_core/alerts.py
+++ b/app_core/alerts.py
@@ -138,7 +138,7 @@ def _fetch_intersections_per_boundary(alert: CAPAlert, alert_geom) -> List[Dict[
     return intersections
 
 
-_fallback_logger = logging.getLogger("noaa_alerts_systems")
+_fallback_logger = logging.getLogger("eas_station")
 
 
 def _logger():

--- a/fix_templates.sh
+++ b/fix_templates.sh
@@ -1,5 +1,8 @@
- # Go to project directory
-cd /home/pi/noaa_alerts_system
+# NOTE: This is a legacy maintenance script from the original deployment.
+# Adjust paths as needed for your environment.
+
+# Go to project directory
+cd "$(dirname "$0")"
 
 # Remove corrupted files
 for html_file in *.html; do
@@ -106,14 +109,14 @@ cat > templates/admin.html << 'EOF'
 EOF
 
 # Fix WSGI file
-cp wsgi.py wsgi.py.backup
+cp wsgi.py wsgi.py.backup 2>/dev/null || true
 cat > wsgi.py << 'EOF'
 #!/usr/bin/env python3
 import sys
 import os
 
-# Set working directory
-project_dir = '/home/pi/noaa_alerts_system'
+# Set working directory to script location
+project_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(project_dir)
 sys.path.insert(0, project_dir)
 

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -402,7 +402,7 @@ class CAPPoller:
         self.session = requests.Session()
         default_user_agent = os.getenv(
             'NOAA_USER_AGENT',
-            'KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/noaa_alerts_systems; NOAA+IPAWS)',
+            'KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/eas-station; NOAA+IPAWS)',
         )
         self.session.headers.update({
             'User-Agent': default_user_agent,

--- a/poller/duplicate_cleanup_utility.py
+++ b/poller/duplicate_cleanup_utility.py
@@ -10,8 +10,10 @@ from datetime import datetime
 from collections import defaultdict
 
 # Add project root to path
-sys.path.insert(0, '/home/pi/noaa_alerts_system')
-os.chdir('/home/pi/noaa_alerts_system')
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(script_dir)
+sys.path.insert(0, project_root)
+os.chdir(project_root)
 
 from app import app, db, CAPAlert, Intersection
 from sqlalchemy import func

--- a/templates/about.html
+++ b/templates/about.html
@@ -82,7 +82,7 @@
                     <h2 class="h4 mb-3"><i class="fas fa-file-alt me-2"></i>Project Resources</h2>
                     <p class="mb-3">Need more detail? Explore the reference material shipped with the repository:</p>
                     <ul class="mb-0">
-                        <li><a href="https://github.com/KR8MER/noaa_alerts_systems" class="text-decoration-none" target="_blank" rel="noopener">Project on GitHub</a> for history, issues, and community coordination.</li>
+                        <li><a href="https://github.com/KR8MER/eas-station" class="text-decoration-none" target="_blank" rel="noopener">Project on GitHub</a> for history, issues, and community coordination.</li>
                         <li><a href="{{ url_for('help_page') }}" class="text-decoration-none">Help &amp; Operations Guide</a> for practical workflows.</li>
                         <li>Repository copies of <code>ABOUT.md</code> and <code>HELP.md</code> ship with every deployment for offline reference.</li>
                     </ul>

--- a/templates/help.html
+++ b/templates/help.html
@@ -118,7 +118,7 @@
                         <h2 class="h4 mb-1"><i class="fas fa-question-circle me-2"></i>Need additional assistance?</h2>
                         <p class="mb-0">Reach out through the KR8MER amateur radio channels or the project&apos;s GitHub discussions to collaborate with fellow operators.</p>
                     </div>
-                    <a class="btn btn-primary" href="https://github.com/KR8MER/noaa_alerts_systems" target="_blank" rel="noopener">
+                    <a class="btn btn-primary" href="https://github.com/KR8MER/eas-station" target="_blank" rel="noopener">
                         <i class="fab fa-github me-2"></i>Project Repository
                     </a>
                 </div>

--- a/webapp/admin/maintenance.py
+++ b/webapp/admin/maintenance.py
@@ -51,7 +51,7 @@ NOAA_ALLOWED_QUERY_PARAMS = frozenset(
 )
 NOAA_USER_AGENT = os.environ.get(
     "NOAA_USER_AGENT",
-    "KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/noaa_alerts_systems; NOAA+IPAWS)",
+    "KR8MER Emergency Alert Hub/2.1 (+https://github.com/KR8MER/eas-station; NOAA+IPAWS)",
 )
 
 


### PR DESCRIPTION
This commit updates all references from the old repository names (casaos, noaa_alerts_system, noaa_alerts_systems) to the current eas-station repository name and structure.

Changes include:
- Updated database credentials in README from casaos to postgres/alerts
- Updated GitHub URLs from KR8MER/noaa_alerts_systems to KR8MER/eas-station
- Updated project paths in utility scripts to use dynamic path resolution
- Updated logger name from noaa_alerts_systems to eas_station
- Updated legacy script paths and added deprecation notices
- Updated documentation with current repository name and structure

All command examples and documentation now reflect the current deployment structure and naming conventions.