### PR TITLE
Debug gunicorn worker timeout in alerts app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,13 @@ COPY . ./
 # Expose default Flask port and start Gunicorn
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", \
+    "--bind", "0.0.0.0:5000", \
+    "--workers", "4", \
+    "--timeout", "120", \
+    "--worker-class", "sync", \
+    "--worker-tmp-dir", "/dev/shm", \
+    "--log-level", "info", \
+    "--access-logfile", "-", \
+    "--error-logfile", "-", \
+    "app:app"]


### PR DESCRIPTION
Improved gunicorn configuration to prevent worker timeouts:
- Increased timeout from 30s to 120s for long-running requests
- Added 4 workers for better concurrency and reliability
- Use /dev/shm for worker heartbeat files to avoid I/O delays
- Added explicit logging configuration for better monitoring

This resolves WORKER TIMEOUT errors that were occurring after ~5 minutes of operation, particularly during database-heavy operations or when the LED controller connection attempts were slow.