### PR TITLE
Fix login redirect loop issue

### DIFF
--- a/webapp/admin/auth.py
+++ b/webapp/admin/auth.py
@@ -20,8 +20,12 @@ def register_auth_routes(app, logger):
     def _is_safe_redirect_target(target: Optional[str]) -> bool:
         if not target:
             return False
-        ref_url = urlparse(request.host_url)
+        # Parse the target URL to extract the path
         test_url = urlparse(urljoin(request.host_url, target))
+        # Don't redirect to login page itself to prevent redirect loops
+        if test_url.path.rstrip('/') == '/login':
+            return False
+        ref_url = urlparse(request.host_url)
         return test_url.scheme in ('http', 'https') and ref_url.netloc == test_url.netloc
 
     @app.route('/login', methods=['GET', 'POST'])


### PR DESCRIPTION
The login flow was creating an infinite redirect loop when the 'next' parameter pointed to '/login'. This occurred because:

1. User logs in successfully with next=/login
2. Code redirects to /login (since it was a "safe" target)
3. User is already authenticated, so code redirects to next=/login again
4. Loop continues indefinitely

Fix: Updated _is_safe_redirect_target() to reject '/login' as a valid redirect target. Now users are redirected to the admin page instead, breaking the loop.

Location: webapp/admin/auth.py lines 20-29