### PR TITLE
Fix login redirect loop by changing SameSite cookie from Strict to Lax

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,7 +162,7 @@ else:
     session_cookie_secure = not (debug_env or debug_flag)
 
 app.config['SESSION_COOKIE_SECURE'] = session_cookie_secure
-app.config['SESSION_COOKIE_SAMESITE'] = 'Strict'
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 try:
     session_hours = int(os.environ.get('SESSION_LIFETIME_HOURS', '12'))
 except ValueError:


### PR DESCRIPTION
Root cause: The SESSION_COOKIE_SAMESITE='Strict' setting was preventing the browser from sending the session cookie after POST-redirect-GET flow.

Flow that was broken:
1. User submits login form (POST /login)
2. Server creates session and redirects to /admin
3. Browser follows redirect (GET /admin)
4. With SameSite=Strict, browser doesn't send session cookie
5. Server sees no session, redirects to /login with next=/admin
6. User is logged in but redirected to /login again
7. Login handler sees logged-in user, redirects to next=/admin
8. Infinite redirect loop

Solution: Change SESSION_COOKIE_SAMESITE from 'Strict' to 'Lax'
- SameSite=Lax allows cookies with top-level navigations (POST-redirect-GET)
- Still protects against CSRF from cross-site requests
- Maintains security while fixing the login flow

Location: app.py line 165