### PR TITLE
Fix SAME decoder header detection with leading noise

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -243,8 +243,20 @@ def _bits_to_text(bits: List[int]) -> Dict[str, object]:
         cleaned = segment.strip()
         if not cleaned:
             continue
-        if cleaned.upper().startswith("ZCZC") or cleaned.upper().startswith("NNNN"):
-            headers.append(cleaned)
+
+        upper_segment = cleaned.upper()
+        header_start = -1
+        for marker in ("ZCZC", "NNNN"):
+            header_start = upper_segment.find(marker)
+            if header_start != -1:
+                break
+
+        if header_start == -1:
+            continue
+
+        candidate = cleaned[header_start:]
+        if candidate:
+            headers.append(candidate)
 
     return {
         "text": raw_text,


### PR DESCRIPTION
## Summary
- ensure SAME audio decoder locates ZCZC/NNNN headers even when preceded by extraneous characters
- allow alert verification UI to display parsed SAME header details for captures like ++++ZCZC sequences

## Testing
- python -m compileall app_utils/eas_decode.py

------
https://chatgpt.com/codex/tasks/task_e_6903f25ffbf0832083b4196a35780fed