### PR TITLE
Improve SAME decoder tolerance to timing drift

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from array import array
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from .eas import describe_same_header
 from .eas_fsk import SAME_BAUD, SAME_MARK_FREQ, SAME_SPACE_FREQ
@@ -149,13 +149,18 @@ def _goertzel(samples: Iterable[float], sample_rate: int, target_freq: float) ->
     return power if power > 0.0 else 0.0
 
 
-def _extract_bits(samples: List[float], sample_rate: int) -> List[int]:
+def _extract_bits(
+    samples: List[float], sample_rate: int, bit_rate: float
+) -> Tuple[List[int], float, float]:
     """Slice PCM audio into SAME bit periods and detect mark/space symbols."""
 
     bits: List[int] = []
     bit_confidences: List[float] = []
 
-    bit_rate = float(SAME_BAUD)
+    bit_rate = float(bit_rate)
+    if bit_rate <= 0:
+        raise AudioDecodeError("Bit rate must be positive when decoding SAME audio.")
+
     samples_per_bit = sample_rate / bit_rate
     carry = 0.0
     index = 0
@@ -189,10 +194,8 @@ def _extract_bits(samples: List[float], sample_rate: int) -> List[int]:
 
     average_confidence = sum(bit_confidences) / len(bit_confidences)
     minimum_confidence = min(bit_confidences) if bit_confidences else 0.0
-    _extract_bits.last_confidence = average_confidence  # type: ignore[attr-defined]
-    _extract_bits.min_confidence = minimum_confidence  # type: ignore[attr-defined]
 
-    return bits
+    return bits, average_confidence, minimum_confidence
 
 
 def _bits_to_text(bits: List[int]) -> Dict[str, object]:
@@ -266,6 +269,85 @@ def _bits_to_text(bits: List[int]) -> Dict[str, object]:
     }
 
 
+def _score_candidate(metadata: Dict[str, object]) -> float:
+    """Return a quality score for decoded SAME metadata."""
+
+    headers = metadata.get("headers") or []
+    text = metadata.get("text") or ""
+    frame_count = int(metadata.get("frame_count") or 0)
+    frame_errors = int(metadata.get("frame_errors") or 0)
+
+    score = float(frame_count - frame_errors)
+    score -= float(frame_errors * 2)
+
+    if headers:
+        score += 500.0 * len(headers)
+        uppercase_headers = [header.upper() for header in headers]
+        score += 200.0 * sum(1 for header in uppercase_headers if header.startswith("ZCZC"))
+        score += 100.0 * sum(1 for header in uppercase_headers if header.startswith("NNNN"))
+
+    if isinstance(text, str):
+        score += 50.0 * text.upper().count("ZCZC")
+
+    return score
+
+
+def _decode_with_candidate_rates(
+    samples: List[float],
+    sample_rate: int,
+    *,
+    base_rate: float,
+) -> Tuple[List[int], Dict[str, object], float, float]:
+    """Try decoding SAME bits using a range of baud rates."""
+
+    candidate_offsets = [0.0]
+    for step in (0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.04):
+        candidate_offsets.extend((-step, step))
+
+    best_bits: Optional[List[int]] = None
+    best_metadata: Optional[Dict[str, object]] = None
+    best_average: float = 0.0
+    best_minimum: float = 0.0
+    best_score: Optional[float] = None
+    best_rate: Optional[float] = None
+
+    for offset in candidate_offsets:
+        bit_rate = base_rate * (1.0 + offset)
+        try:
+            bits, average_confidence, minimum_confidence = _extract_bits(
+                samples, sample_rate, bit_rate
+            )
+        except AudioDecodeError:
+            continue
+
+        metadata = _bits_to_text(bits)
+        score = _score_candidate(metadata)
+
+        if best_score is None or score > best_score + 1e-6:
+            best_bits = bits
+            best_metadata = metadata
+            best_average = average_confidence
+            best_minimum = minimum_confidence
+            best_score = score
+            best_rate = bit_rate
+        elif (
+            best_score is not None
+            and abs(score - best_score) <= 1e-6
+            and best_rate is not None
+            and abs(bit_rate - base_rate) < abs(best_rate - base_rate)
+        ):
+            best_bits = bits
+            best_metadata = metadata
+            best_average = average_confidence
+            best_minimum = minimum_confidence
+            best_rate = bit_rate
+
+    if best_bits is None or best_metadata is None:
+        raise AudioDecodeError("The audio payload did not contain detectable SAME bursts.")
+
+    return best_bits, best_metadata, best_average, best_minimum
+
+
 def decode_same_audio(path: str, *, sample_rate: int = 44100) -> SAMEAudioDecodeResult:
     """Decode SAME headers from a WAV or MP3 file located at ``path``."""
 
@@ -273,8 +355,10 @@ def decode_same_audio(path: str, *, sample_rate: int = 44100) -> SAMEAudioDecode
         raise AudioDecodeError(f"Audio file does not exist: {path}")
 
     samples = _read_audio_samples(path, sample_rate)
-    bits = _extract_bits(samples, sample_rate)
-    metadata = _bits_to_text(bits)
+    base_rate = float(SAME_BAUD)
+    bits, metadata, average_confidence, minimum_confidence = _decode_with_candidate_rates(
+        samples, sample_rate, base_rate=base_rate
+    )
 
     raw_text = metadata["text"]
     headers: List[SAMEHeaderDetails] = []
@@ -283,13 +367,11 @@ def decode_same_audio(path: str, *, sample_rate: int = 44100) -> SAMEAudioDecode
             SAMEHeaderDetails(
                 header=header,
                 fields=describe_same_header(header),
-                confidence=float(getattr(_extract_bits, "last_confidence", 0.0)),
+                confidence=average_confidence,
             )
         )
 
     duration_seconds = len(samples) / float(sample_rate)
-    average_confidence = float(getattr(_extract_bits, "last_confidence", 0.0))
-    min_confidence = float(getattr(_extract_bits, "min_confidence", 0.0))
 
     return SAMEAudioDecodeResult(
         raw_text=raw_text,
@@ -300,7 +382,7 @@ def decode_same_audio(path: str, *, sample_rate: int = 44100) -> SAMEAudioDecode
         duration_seconds=duration_seconds,
         sample_rate=sample_rate,
         bit_confidence=average_confidence,
-        min_bit_confidence=min_confidence,
+        min_bit_confidence=minimum_confidence,
     )
 
 

--- a/tests/test_eas_decode.py
+++ b/tests/test_eas_decode.py
@@ -1,0 +1,60 @@
+import struct
+import sys
+import wave
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from app_utils.eas_decode import decode_same_audio
+from app_utils.eas_fsk import (
+    SAME_BAUD,
+    SAME_MARK_FREQ,
+    SAME_SPACE_FREQ,
+    encode_same_bits,
+    generate_fsk_samples,
+)
+
+
+def _write_same_audio(path: str, header: str, *, sample_rate: int = 44100, scale: float = 1.0) -> None:
+    bits = encode_same_bits(header, include_preamble=True)
+    base_rate = float(SAME_BAUD)
+    bit_rate = base_rate * scale
+    mark_freq = SAME_MARK_FREQ * scale
+    space_freq = SAME_SPACE_FREQ * scale
+    samples = generate_fsk_samples(
+        bits,
+        sample_rate=sample_rate,
+        bit_rate=bit_rate,
+        mark_freq=mark_freq,
+        space_freq=space_freq,
+        amplitude=20000,
+    )
+
+    with wave.open(path, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(b"".join(struct.pack("<h", sample) for sample in samples))
+
+
+def test_decode_same_audio_handles_slightly_slow_baud(tmp_path) -> None:
+    header = "ZCZC-ABC-DEF-123456-000001-"
+    path = tmp_path / "slow.wav"
+    _write_same_audio(str(path), header, scale=0.96)
+
+    result = decode_same_audio(str(path))
+
+    assert any(item.header == header for item in result.headers)
+
+
+def test_decode_same_audio_handles_slightly_fast_baud(tmp_path) -> None:
+    header = "ZCZC-ABC-DEF-123456-000001-"
+    path = tmp_path / "fast.wav"
+    _write_same_audio(str(path), header, scale=1.04)
+
+    result = decode_same_audio(str(path))
+
+    assert any(item.header == header for item in result.headers)


### PR DESCRIPTION
## Summary
- update the SAME audio decoder to evaluate multiple candidate baud rates and choose the best-scoring header extraction
- return confidence metrics directly from the bit extractor and reuse them for decoded headers
- add regression tests that verify decoding succeeds when the baud rate drifts a few percent from nominal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690482e52b7c8320bdc4a15ec5798761