### PR TITLE
Improve SAME audio decoder robustness

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -110,11 +110,23 @@ def _read_audio_samples(path: str, sample_rate: int) -> List[float]:
     try:
         import wave
 
+        import audioop
+
         with wave.open(path, "rb") as handle:
             params = handle.getparams()
-            if params.nchannels == 1 and params.sampwidth == 2 and params.framerate == sample_rate:
+            if params.nchannels == 1 and params.sampwidth == 2:
                 pcm = handle.readframes(params.nframes)
                 if pcm:
+                    target_rate = sample_rate
+                    if params.framerate != target_rate:
+                        pcm, _ = audioop.ratecv(
+                            pcm,
+                            params.sampwidth,
+                            params.nchannels,
+                            params.framerate,
+                            target_rate,
+                            None,
+                        )
                     return _convert_pcm_to_floats(pcm)
     except Exception:
         pass
@@ -132,7 +144,11 @@ def _convert_pcm_to_floats(payload: bytes) -> List[float]:
         raise AudioDecodeError("Audio payload contained no PCM samples to decode.")
 
     scale = 1.0 / 32768.0
-    return [sample * scale for sample in pcm]
+    floats = [sample * scale for sample in pcm]
+    if floats:
+        mean = sum(floats) / len(floats)
+        floats = [sample - mean for sample in floats]
+    return floats
 
 
 def _goertzel(samples: Iterable[float], sample_rate: int, target_freq: float) -> float:
@@ -150,7 +166,12 @@ def _goertzel(samples: Iterable[float], sample_rate: int, target_freq: float) ->
 
 
 def _extract_bits(
-    samples: List[float], sample_rate: int, bit_rate: float
+    samples: List[float],
+    sample_rate: int,
+    bit_rate: float,
+    *,
+    start_offset: int = 0,
+    invert: bool = False,
 ) -> Tuple[List[int], float, float]:
     """Slice PCM audio into SAME bit periods and detect mark/space symbols."""
 
@@ -163,7 +184,10 @@ def _extract_bits(
 
     samples_per_bit = sample_rate / bit_rate
     carry = 0.0
-    index = 0
+    index = int(start_offset)
+
+    if index < 0:
+        index = 0
 
     while index < len(samples):
         total = samples_per_bit + carry
@@ -178,7 +202,10 @@ def _extract_bits(
         chunk = samples[index:end]
         mark_power = _goertzel(chunk, sample_rate, SAME_MARK_FREQ)
         space_power = _goertzel(chunk, sample_rate, SAME_SPACE_FREQ)
-        bit = 1 if mark_power >= space_power else 0
+        if invert:
+            bit = 0 if mark_power >= space_power else 1
+        else:
+            bit = 1 if mark_power >= space_power else 0
         bits.append(bit)
 
         if mark_power + space_power > 0:
@@ -285,6 +312,24 @@ def _score_candidate(metadata: Dict[str, object]) -> float:
         uppercase_headers = [header.upper() for header in headers]
         score += 200.0 * sum(1 for header in uppercase_headers if header.startswith("ZCZC"))
         score += 100.0 * sum(1 for header in uppercase_headers if header.startswith("NNNN"))
+        allowed_chars = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+/")
+        for header in headers:
+            score -= 50.0 * sum(1 for char in header if ord(char) < 32 or ord(char) >= 127)
+            score -= 100.0 * sum(
+                1 for char in header.upper() if char not in allowed_chars
+            )
+            score -= 25.0 * sum(
+                1 for char in header if char.isalpha() and char != char.upper()
+            )
+            parts = header.split('-')
+            if len(parts) > 1:
+                originator = parts[1]
+                if not (len(originator) == 3 and originator.isalpha() and originator.isupper()):
+                    score -= 150.0
+            if len(parts) > 2:
+                event_code = parts[2]
+                if not (len(event_code) == 3 and event_code.isalpha() and event_code.isupper()):
+                    score -= 150.0
 
     if isinstance(text, str):
         score += 50.0 * text.upper().count("ZCZC")
@@ -313,34 +358,61 @@ def _decode_with_candidate_rates(
 
     for offset in candidate_offsets:
         bit_rate = base_rate * (1.0 + offset)
-        try:
-            bits, average_confidence, minimum_confidence = _extract_bits(
-                samples, sample_rate, bit_rate
-            )
-        except AudioDecodeError:
-            continue
+        samples_per_bit = sample_rate / bit_rate
+        max_offset = int(math.ceil(samples_per_bit))
+        if max_offset <= 0:
+            max_offset = 1
+        # Bound the search space to avoid excessive work on long recordings while
+        # still covering a full bit period at common sample rates.
+        max_offset = min(max_offset, 200)
 
-        metadata = _bits_to_text(bits)
-        score = _score_candidate(metadata)
+        for invert in (False, True):
+            for start_offset in range(max_offset):
+                try:
+                    bits, average_confidence, minimum_confidence = _extract_bits(
+                        samples,
+                        sample_rate,
+                        bit_rate,
+                        start_offset=start_offset,
+                        invert=invert,
+                    )
+                except AudioDecodeError:
+                    continue
 
-        if best_score is None or score > best_score + 1e-6:
-            best_bits = bits
-            best_metadata = metadata
-            best_average = average_confidence
-            best_minimum = minimum_confidence
-            best_score = score
-            best_rate = bit_rate
-        elif (
-            best_score is not None
-            and abs(score - best_score) <= 1e-6
-            and best_rate is not None
-            and abs(bit_rate - base_rate) < abs(best_rate - base_rate)
-        ):
-            best_bits = bits
-            best_metadata = metadata
-            best_average = average_confidence
-            best_minimum = minimum_confidence
-            best_rate = bit_rate
+                metadata = _bits_to_text(bits)
+                score = _score_candidate(metadata)
+
+                if best_score is None or score > best_score + 1e-6:
+                    best_bits = bits
+                    best_metadata = metadata
+                    best_average = average_confidence
+                    best_minimum = minimum_confidence
+                    best_score = score
+                    best_rate = bit_rate
+                    continue
+
+                if best_score is None or abs(score - best_score) > 1e-6:
+                    continue
+
+                better = False
+                if average_confidence > best_average + 1e-6:
+                    better = True
+                elif abs(average_confidence - best_average) <= 1e-6:
+                    if minimum_confidence > best_minimum + 1e-6:
+                        better = True
+                    elif abs(minimum_confidence - best_minimum) <= 1e-6:
+                        if (
+                            best_rate is not None
+                            and abs(bit_rate - base_rate) < abs(best_rate - base_rate)
+                        ):
+                            better = True
+
+                if better:
+                    best_bits = bits
+                    best_metadata = metadata
+                    best_average = average_confidence
+                    best_minimum = minimum_confidence
+                    best_rate = bit_rate
 
     if best_bits is None or best_metadata is None:
         raise AudioDecodeError("The audio payload did not contain detectable SAME bursts.")


### PR DESCRIPTION
## Summary
- resample mono WAV inputs in the SAME decoder without requiring ffmpeg and normalise PCM to remove DC offset
- search additional bit alignments and symbol polarity while penalising malformed SAME headers to improve candidate scoring
- cover decoding with a leading fractional-bit offset in tests to guard the alignment logic

## Testing
- pytest tests/test_eas_decode.py -q
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_690489daaf4883208740a25e24ee0e3c