### PR TITLE
Add attribution to multimon-ng for SAME decoder algorithm reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ EAS Station is not just an alert monitor—it's a **complete emergency broadcast
 
 ### 📻 Verification & Compliance
 - **Multi-SDR Orchestration** - Automatic IQ/PCM capture from RTL2832U and Airspy receivers during SAME events
-- **Audio Decode Verification** - Extract SAME headers from received broadcasts with confidence scoring
+- **Audio Decode Verification** - Extract SAME headers from received broadcasts with confidence scoring (algorithm inspired by [multimon-ng](https://github.com/EliasOenal/multimon-ng))
 - **Delivery Analytics** - Track received vs. relayed alerts with per-originator trending
 - **Compliance Exports** - CSV/PDF reports for FCC and state emergency management audits
 - **Complete Audit Trail** - Timestamped logs of all ingestions, broadcasts, and manual activations
@@ -970,6 +970,7 @@ This project is provided as-is for emergency communications and public safety pu
 - **Flask Community** - Web framework and extensions
 - **Bootstrap & Font Awesome** - UI components and icons
 - **Amateur Radio Community** - Emergency communications support
+- **[multimon-ng](https://github.com/EliasOenal/multimon-ng)** - SAME/EAS decoder algorithm reference used for testing and debugging our Python implementation
 
 ---
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -244,11 +244,12 @@
                             </h3>
                             <ul class="list-unstyled">
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>NumPy</strong> - Waveform generation</li>
-                                <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>SciPy</strong> - Signal processing</li>
+                                <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>SciPy</strong> - Signal processing and audio resampling</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>FFmpeg</strong> - Audio format conversion</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>SoX</strong> - Audio processing utilities</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>Azure AI Speech</strong> - Neural TTS voices</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>eSpeak NG</strong> - Offline TTS fallback</li>
+                                <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong><a href="https://github.com/EliasOenal/multimon-ng" target="_blank" rel="noopener" class="text-decoration-none">multimon-ng</a></strong> - Algorithm reference for SAME/EAS decoder testing</li>
                             </ul>
                         </div>
 
@@ -501,7 +502,8 @@
                     <p class="text-muted small mb-0">
                         Originally developed for amateur radio emergency communications by KR8MER.<br>
                         Built with contributions from broadcasters, emergency managers, and developers worldwide.<br>
-                        Special thanks to NOAA, NWS, and FEMA for providing public CAP feeds.
+                        Special thanks to NOAA, NWS, and FEMA for providing public CAP feeds.<br>
+                        SAME/EAS decoder algorithm inspired by <a href="https://github.com/EliasOenal/multimon-ng" target="_blank" rel="noopener" class="text-muted text-decoration-underline">multimon-ng</a>, used for testing and debugging our Python implementation.
                     </p>
                 </div>
             </div>

--- a/templates/help.html
+++ b/templates/help.html
@@ -442,6 +442,7 @@ AZURE_SPEECH_REGION=eastus</code></pre>
                                         <li><strong>Attention Tone:</strong> 853 Hz + 960 Hz, 8-10 seconds</li>
                                         <li><strong>Header Bursts:</strong> 3x transmission of SAME header</li>
                                         <li><strong>EOM Bursts:</strong> 3x end-of-message tone</li>
+                                        <li><strong>Decoder Algorithm:</strong> Correlation-based FSK detection with DLL timing recovery, inspired by <a href="https://github.com/EliasOenal/multimon-ng" target="_blank" rel="noopener">multimon-ng</a></li>
                                     </ul>
 
                                     <p><strong>Voice Synthesis Options:</strong></p>


### PR DESCRIPTION
Credit multimon-ng (https://github.com/EliasOenal/multimon-ng) for providing the algorithm reference used during testing and debugging of our Python-based SAME/EAS decoder implementation. While we did not copy code directly, we studied multimon-ng's proven correlation-based FSK detection and DLL timing recovery approach to improve our decoder's reliability.

Attribution added to:
- README.md (Acknowledgments section and Verification & Compliance)
- templates/about.html (Technology Stack and License & Credits)
- templates/help.html (Audio Generation Settings)