### PR TITLE
Add plain language summaries to SAME decode results

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -20,7 +20,7 @@ try:  # pragma: no cover - GPIO hardware is optional and platform specific
 except Exception:  # pragma: no cover - gracefully handle non-RPi environments
     RPiGPIO = None
 
-from app_utils.event_codes import resolve_event_code
+from app_utils.event_codes import EVENT_CODE_REGISTRY, resolve_event_code
 
 from .eas_fsk import (
     SAME_BAUD,
@@ -207,6 +207,8 @@ def describe_same_header(
 
     originator = parts[1] if len(parts) > 1 else ''
     event_code = parts[2] if len(parts) > 2 else ''
+    event_entry = EVENT_CODE_REGISTRY.get(event_code)
+    event_name = event_entry.get('name') if event_entry else None
 
     locations: List[str] = []
     duration_fragment = ''
@@ -304,6 +306,7 @@ def describe_same_header(
         'originator': originator,
         'originator_description': ORIGINATOR_DESCRIPTIONS.get(originator),
         'event_code': event_code,
+        'event_name': event_name,
         'location_count': len(detailed_locations),
         'locations': detailed_locations,
         'purge_code': duration_digits or None,

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -95,6 +95,11 @@
                                             <h6 class="mb-0">{{ header.header }}</h6>
                                             <span class="badge bg-primary">{{ '%.1f'|format(header.confidence * 100) }}% confidence</span>
                                         </div>
+                                        {% if header.summary %}
+                                            <p class="small fw-semibold text-primary mb-2">
+                                                {{ header.summary }}
+                                            </p>
+                                        {% endif %}
                                         {% set detail = header.fields or {} %}
                                         <dl class="row small mb-0">
                                             <dt class="col-sm-5">Originator</dt>
@@ -162,7 +167,13 @@
                                         {% if decode.same_headers %}
                                             <ul class="list-unstyled mb-0 small">
                                                 {% for header in decode.same_headers %}
-                                                    <li>{{ header.header or header }}</li>
+                                                    <li class="mb-2">
+                                                        {% if header.summary is defined and header.summary %}
+                                                            <div class="fw-semibold">{{ header.summary }}</div>
+                                                        {% endif %}
+                                                        {% set header_text = header.header if header.header is defined else header %}
+                                                        <div class="text-muted">{{ header_text or header }}</div>
+                                                    </li>
                                                 {% endfor %}
                                             </ul>
                                         {% else %}


### PR DESCRIPTION
## Summary
- add event name metadata to SAME header descriptions
- build a plain language summary when decoding audio and store it with results
- surface the new summary text in the alert verification detail and history views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6904a2e610f08320a1e9378898591653