### PR TITLE
Remove redundant EAS route wrapper

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -9,7 +9,6 @@ from flask import Flask
 
 from . import (
     routes_admin,
-    routes_eas,
     routes_debug,
     routes_exports,
     routes_settings_radio,

--- a/webapp/routes_eas.py
+++ b/webapp/routes_eas.py
@@ -1,7 +1,0 @@
-"""Expose the EAS workflow blueprint registration helper."""
-
-from __future__ import annotations
-
-from .eas import register
-
-__all__ = ['register']


### PR DESCRIPTION
## Summary
- remove the webapp.routes_eas shim so the EAS workflow blueprint is only registered once
- update the route registry imports to rely on the canonical webapp.eas module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6904e9ca9a2c8320b0d4b57f352a5316