### PR TITLE
Close setup_mode conditional in admin template

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -912,6 +912,8 @@
         <div id="operationStatus" class="mt-3" style="display: none;"></div>
     </div>
 
+    {% endif %}
+
     {% if not setup_mode %}
     <!-- Confirmation Modal -->
     <div class="modal fade confirmation-modal" id="confirmationModal" tabindex="-1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- close the setup_mode conditional in the admin template so Jinja stops searching for a missing endif and the page renders again

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_6904f860f0108320a07e1207b3bf9498