### PR TITLE
Restore audio playback in archive

### DIFF
--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -193,9 +193,29 @@
                                     </td>
                                     <td class="text-center">
                                         {% if message.audio_url %}
-                                        <a class="btn btn-sm btn-outline-primary" href="{{ message.audio_url }}" target="_blank" rel="noopener">
-                                            <i class="fas fa-play"></i> Play
-                                        </a>
+                                        <div class="d-flex flex-column align-items-center gap-2">
+                                            <audio controls preload="none" class="w-100" style="max-width: 220px;">
+                                                <source src="{{ message.audio_url }}" type="audio/wav">
+                                                Your browser does not support audio playback.
+                                            </audio>
+                                            <div class="d-flex gap-2 flex-wrap justify-content-center">
+                                                <a class="btn btn-sm btn-outline-primary" href="{{ message.audio_url }}" target="_blank" rel="noopener">
+                                                    <i class="fas fa-external-link-alt"></i> Open
+                                                </a>
+                                                <a class="btn btn-sm btn-outline-secondary" href="{{ message.audio_url }}?download=1">
+                                                    <i class="fas fa-download"></i> Download
+                                                </a>
+                                            </div>
+                                            {% if message.eom_url %}
+                                            <div class="w-100">
+                                                <div class="small text-muted">EOM Burst</div>
+                                                <audio controls preload="none" class="w-100" style="max-width: 220px;">
+                                                    <source src="{{ message.eom_url }}" type="audio/wav">
+                                                    Your browser does not support audio playback.
+                                                </audio>
+                                            </div>
+                                            {% endif %}
+                                        </div>
                                         {% else %}
                                         <span class="text-muted">Unavailable</span>
                                         {% endif %}

--- a/webapp/admin/audio/files.py
+++ b/webapp/admin/audio/files.py
@@ -7,7 +7,7 @@ import json
 
 from flask import abort, jsonify, request, send_file
 
-from app_core.models import CAPAlert, EASMessage
+from app_core.models import CAPAlert, EASMessage, ManualEASActivation
 from app_core.eas_storage import load_or_cache_audio_data, load_or_cache_summary_payload
 
 
@@ -84,3 +84,45 @@ def register_file_routes(app, logger) -> None:
             download_name=filename,
             max_age=0,
         )
+
+    @app.route('/manual_eas/<int:event_id>/audio/<string:component>', methods=['GET'])
+    def manual_eas_audio(event_id: int, component: str):
+        component_key = (component or '').strip().lower()
+        component_map = {
+            'composite': 'composite_audio_data',
+            'full': 'composite_audio_data',
+            'primary': 'composite_audio_data',
+            'same': 'same_audio_data',
+            'attention': 'attention_audio_data',
+            'tts': 'tts_audio_data',
+            'narration': 'tts_audio_data',
+            'eom': 'eom_audio_data',
+        }
+
+        attr_name = component_map.get(component_key)
+        if not attr_name:
+            abort(404, description='Unsupported manual audio component.')
+
+        activation = ManualEASActivation.query.get_or_404(event_id)
+        blob = getattr(activation, attr_name)
+        if not blob:
+            abort(404, description='Audio not available for this component.')
+
+        download_flag = (request.args.get('download') or '').strip().lower()
+        as_attachment = download_flag in {'1', 'true', 'yes', 'download'}
+
+        filename = f'manual_eas_{activation.id}_{component_key or "audio"}.wav'
+
+        file_obj = io.BytesIO(blob)
+        file_obj.seek(0)
+        response = send_file(
+            file_obj,
+            mimetype='audio/wav',
+            as_attachment=as_attachment,
+            download_name=filename,
+            max_age=0,
+        )
+        response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, private'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
+        return response


### PR DESCRIPTION
## Summary
- add inline audio players to the audio archive table so primary and EOM clips can be reviewed in the browser
- expose a manual EAS audio endpoint that serves stored component audio blobs directly from the database

## Testing
- pytest tests/test_eas_decode.py

------
https://chatgpt.com/codex/tasks/task_e_6904fa1533008320b5b08014888b1c16