### PR TITLE
Fix manual EAS audio streaming endpoint registration

### DIFF
--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -193,9 +193,29 @@
                                     </td>
                                     <td class="text-center">
                                         {% if message.audio_url %}
-                                        <a class="btn btn-sm btn-outline-primary" href="{{ message.audio_url }}" target="_blank" rel="noopener">
-                                            <i class="fas fa-play"></i> Play
-                                        </a>
+                                        <div class="d-flex flex-column align-items-center gap-2">
+                                            <audio controls preload="none" class="w-100" style="max-width: 220px;">
+                                                <source src="{{ message.audio_url }}" type="audio/wav">
+                                                Your browser does not support audio playback.
+                                            </audio>
+                                            <div class="d-flex gap-2 flex-wrap justify-content-center">
+                                                <a class="btn btn-sm btn-outline-primary" href="{{ message.audio_url }}" target="_blank" rel="noopener">
+                                                    <i class="fas fa-external-link-alt"></i> Open
+                                                </a>
+                                                <a class="btn btn-sm btn-outline-secondary" href="{{ message.audio_url }}?download=1">
+                                                    <i class="fas fa-download"></i> Download
+                                                </a>
+                                            </div>
+                                            {% if message.eom_url %}
+                                            <div class="w-100">
+                                                <div class="small text-muted">EOM Burst</div>
+                                                <audio controls preload="none" class="w-100" style="max-width: 220px;">
+                                                    <source src="{{ message.eom_url }}" type="audio/wav">
+                                                    Your browser does not support audio playback.
+                                                </audio>
+                                            </div>
+                                            {% endif %}
+                                        </div>
                                         {% else %}
                                         <span class="text-muted">Unavailable</span>
                                         {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -299,26 +299,35 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('eas.workflow_home') }}" {% if current_user is not defined or not current_user.is_authenticated %}title="Sign in required to access the manual EAS workflow."{% endif %}>
+                            <i class="fas fa-broadcast-tower"></i> EAS Workflow
+                            {% if current_user is not defined or not current_user.is_authenticated %}
+                            <i class="fas fa-lock small ms-1"></i>
+                            {% endif %}
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('compliance_dashboard') }}" {% if current_user is not defined or not current_user.is_authenticated %}title="Sign in required to review compliance dashboards."{% endif %}>
+                            <i class="fas fa-clipboard-check"></i> Compliance
+                            {% if current_user is not defined or not current_user.is_authenticated %}
+                            <i class="fas fa-lock small ms-1"></i>
+                            {% endif %}
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('alert_verification') }}" {% if current_user is not defined or not current_user.is_authenticated %}title="Sign in required to access alert validation tools."{% endif %}>
+                            <i class="fas fa-shield-check"></i> Validation
+                            {% if current_user is not defined or not current_user.is_authenticated %}
+                            <i class="fas fa-lock small ms-1"></i>
+                            {% endif %}
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('led_control') }}">
                             <i class="fas fa-tv"></i> LED Control
                         </a>
                     </li>
                     {% if current_user is defined and current_user.is_authenticated %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('eas.workflow_home') }}">
-                            <i class="fas fa-broadcast-tower"></i> EAS Workflow
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('compliance_dashboard') }}">
-                            <i class="fas fa-clipboard-check"></i> Compliance
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('alert_verification') }}">
-                            <i class="fas fa-shield-check"></i> Verification
-                        </a>
-                    </li>
                     <li class="nav-item">
                         <span class="nav-link disabled text-nowrap">
                             <i class="fas fa-user-shield"></i> {{ current_user.username }}

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% block title %}Alert Verification & Analytics{% endblock %}
+{% block title %}Alert Validation & Analytics{% endblock %}
 
 {% block content %}
 <div class="container py-4">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
         <div>
-            <h1 class="h3 mb-1">Alert Verification &amp; Analytics</h1>
+            <h1 class="h3 mb-1">Alert Validation &amp; Analytics</h1>
             <p class="text-muted mb-0">
                 Monitoring window: last {{ window_days }} days · Generated
                 {% if payload.generated_at %}

--- a/templates/eas/workflow.html
+++ b/templates/eas/workflow.html
@@ -349,6 +349,7 @@
                                         <th scope="col">Component</th>
                                         <th scope="col">Duration</th>
                                         <th scope="col">Size</th>
+                                        <th scope="col" class="text-center">Preview</th>
                                         <th scope="col" class="text-center">Download</th>
                                     </tr>
                                 </thead>
@@ -927,16 +928,21 @@ function renderComponents(components, activation) {
 
     const entries = Object.entries(components || {});
     if (entries.length === 0) {
-        tableBody.innerHTML = '<tr><td colspan="4" class="text-muted">No audio assets were generated.</td></tr>';
+        tableBody.innerHTML = '<tr><td colspan="5" class="text-muted">No audio assets were generated.</td></tr>';
     } else {
         for (const [name, component] of entries) {
             const duration = (component.duration_seconds ?? 0).toFixed(2);
             const size = component.size_bytes ? `${component.size_bytes.toLocaleString()} bytes` : '—';
+            const playbackUrl = component.stream_url || component.data_url || component.download_url || '';
+            const previewCell = playbackUrl
+                ? `<audio class="w-100" controls preload="none" src="${playbackUrl}"></audio>`
+                : '—';
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td class="text-uppercase fw-semibold">${name}</td>
                 <td>${duration}s</td>
                 <td>${size}</td>
+                <td class="text-center">${previewCell}</td>
                 <td class="text-center">
                     ${component.download_url ? `<a class="btn btn-sm btn-outline-primary" href="${component.download_url}" target="_blank" rel="noopener">Download</a>` : '—'}
                 </td>

--- a/templates/help.html
+++ b/templates/help.html
@@ -173,7 +173,7 @@
                                 <h3 class="h6 text-uppercase text-primary fw-bold mb-3">Alert Response</h3>
                                 <ol class="ps-3 small mb-0">
                                     <li class="mb-2">Monitor <strong>Active Alerts</strong> for new CAP messages requiring acknowledgement.</li>
-                                    <li class="mb-2">Use <a href="{{ url_for('alert_verification') }}" class="link-primary">Alert Verification</a> to confirm polygons, audio, and text are valid.</li>
+                                    <li class="mb-2">Use <a href="{{ url_for('alert_verification') }}" class="link-primary">Alert Validation</a> to confirm polygons, audio, and text are valid.</li>
                                     <li class="mb-2">Escalate to manual activation from the <a href="{{ url_for('admin') }}" class="link-primary">Admin Panel</a> if the broadcast chain needs to be triggered.</li>
                                     <li>Document the action and archive supporting media in the <a href="{{ url_for('compliance_dashboard') }}" class="link-primary">Compliance</a> area.</li>
                                 </ol>

--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -136,8 +136,9 @@
                                 </a>
                                 {% endif %}
                             </div>
-                            {% if comp.download_url %}
-                            <audio class="w-100 mt-2" controls src="{{ comp.download_url }}"></audio>
+                            {% set audio_src = comp.stream_url or comp.download_url %}
+                            {% if audio_src %}
+                            <audio class="w-100 mt-2" controls preload="none" src="{{ audio_src }}"></audio>
                             {% endif %}
                         </div>
                         {% endfor %}

--- a/webapp/admin/audio/files.py
+++ b/webapp/admin/audio/files.py
@@ -7,7 +7,7 @@ import json
 
 from flask import abort, jsonify, request, send_file
 
-from app_core.models import CAPAlert, EASMessage
+from app_core.models import CAPAlert, EASMessage, ManualEASActivation
 from app_core.eas_storage import load_or_cache_audio_data, load_or_cache_summary_payload
 
 
@@ -84,3 +84,45 @@ def register_file_routes(app, logger) -> None:
             download_name=filename,
             max_age=0,
         )
+
+    @app.route('/manual_eas/<int:event_id>/audio/<string:component>', methods=['GET'])
+    def manual_eas_audio(event_id: int, component: str):
+        component_key = (component or '').strip().lower()
+        component_map = {
+            'composite': 'composite_audio_data',
+            'full': 'composite_audio_data',
+            'primary': 'composite_audio_data',
+            'same': 'same_audio_data',
+            'attention': 'attention_audio_data',
+            'tts': 'tts_audio_data',
+            'narration': 'tts_audio_data',
+            'eom': 'eom_audio_data',
+        }
+
+        attr_name = component_map.get(component_key)
+        if not attr_name:
+            abort(404, description='Unsupported manual audio component.')
+
+        activation = ManualEASActivation.query.get_or_404(event_id)
+        blob = getattr(activation, attr_name)
+        if not blob:
+            abort(404, description='Audio not available for this component.')
+
+        download_flag = (request.args.get('download') or '').strip().lower()
+        as_attachment = download_flag in {'1', 'true', 'yes', 'download'}
+
+        filename = f'manual_eas_{activation.id}_{component_key or "audio"}.wav'
+
+        file_obj = io.BytesIO(blob)
+        file_obj.seek(0)
+        response = send_file(
+            file_obj,
+            mimetype='audio/wav',
+            as_attachment=as_attachment,
+            download_name=filename,
+            max_age=0,
+        )
+        response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, private'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
+        return response


### PR DESCRIPTION
## Summary
- add the manual EAS audio streaming route back to the admin audio module so inline players resolve correctly
- ensure all manual activation components map to their stored binary audio blobs and return cache-safe responses

## Testing
- pytest tests/test_eas_decode.py

------
https://chatgpt.com/codex/tasks/task_e_6904fa1533008320b5b08014888b1c16