### PR TITLE
Improve typography and footer contrast across site

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -88,9 +88,18 @@
 
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: 16px;
+            line-height: 1.6;
+            letter-spacing: 0.01em;
             background-color: var(--bg-color);
             color: var(--text-color);
+            text-rendering: optimizeLegibility;
+            -webkit-font-smoothing: antialiased;
             transition: background-color 0.3s ease, color 0.3s ease;
+        }
+
+        main {
+            padding: 2.5rem 1.5rem 3rem;
         }
 
         .navbar {
@@ -163,20 +172,77 @@
         }
 
         .footer {
-            background: linear-gradient(120deg, var(--primary-soft), var(--secondary-soft));
-            color: #f8f9ff;
-            padding: 20px 0;
-            margin-top: 50px;
-            border-top: 1px solid var(--border-color);
+            background: var(--dark-color);
+            color: var(--light-color);
+            padding: 32px 0;
+            margin-top: 60px;
+            border-top: 1px solid rgba(255, 255, 255, 0.08);
+            box-shadow: 0 -8px 24px var(--shadow-color);
         }
 
         .footer a {
-            color: #f8f9ff;
+            color: inherit;
+            text-decoration: underline;
+            text-decoration-color: rgba(248, 249, 255, 0.5);
         }
 
         .footer a:hover,
         .footer a:focus {
             color: var(--accent-color);
+            text-decoration-color: var(--accent-color);
+        }
+
+        .footer-content {
+            gap: 1.5rem;
+            flex-wrap: wrap;
+        }
+
+        .footer-meta {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .footer-brand {
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .footer-subtext {
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        .footer-clock,
+        .footer-version {
+            font-size: 0.95rem;
+            font-weight: 500;
+        }
+
+        .footer-clock i,
+        .footer-brand i {
+            color: var(--accent-color);
+        }
+
+        @media (max-width: 576px) {
+            main {
+                padding: 2rem 1rem 2.5rem;
+            }
+
+            .footer {
+                padding: 28px 0;
+            }
+
+            .footer-content {
+                gap: 1rem;
+            }
+
+            .footer-subtext,
+            .footer-clock,
+            .footer-version {
+                font-size: 0.9rem;
+            }
         }
 
         .navbar-brand {
@@ -411,15 +477,24 @@
 
     <!-- Footer -->
     <footer class="footer">
-        <div class="container-fluid text-center">
-            <small class="text-muted d-flex flex-column flex-sm-row align-items-center justify-content-center gap-2">
-                <span>
-                    <i class="fas fa-broadcast-tower"></i> 2025 EAS Station - Emergency Alert System |
-                    <i class="fas fa-shield-alt"></i> Public Safety Broadcasting |
-                    <i class="fas fa-clock"></i> <span id="current-time">Loading...</span>
-                </span>
-                <span class="text-uppercase fw-semibold">Version {{ system_version }}</span>
-            </small>
+        <div class="container-fluid">
+            <div class="footer-content d-flex flex-column flex-lg-row align-items-center justify-content-between text-center text-lg-start">
+                <div class="footer-meta">
+                    <div class="footer-brand">
+                        <i class="fas fa-broadcast-tower me-2"></i>2025 EAS Station
+                    </div>
+                    <div class="footer-subtext">
+                        <i class="fas fa-shield-alt me-2"></i>Emergency Alert System · Public Safety Broadcasting
+                    </div>
+                </div>
+                <div class="footer-clock d-flex align-items-center justify-content-center">
+                    <i class="fas fa-clock me-2"></i>
+                    <span id="current-time">Loading...</span>
+                </div>
+                <div class="footer-version text-uppercase fw-semibold">
+                    Version {{ system_version }}
+                </div>
+            </div>
         </div>
     </footer>
 

--- a/templates/ipaws_debug.html
+++ b/templates/ipaws_debug.html
@@ -21,6 +21,23 @@
         </div>
     {% endif %}
 
+    {% if debug_runs %}
+        <div class="alert alert-secondary border-start border-4 border-primary small shadow-sm">
+            <div class="fw-semibold mb-1">How to read this table</div>
+            <div class="d-flex flex-column flex-lg-row gap-2">
+                <div class="d-flex flex-wrap gap-2">
+                    <span class="badge rounded-pill text-bg-success">New + Saved</span>
+                    <span class="badge rounded-pill text-bg-info text-dark">Saved (existing)</span>
+                    <span class="badge rounded-pill text-bg-warning text-dark">Filtered</span>
+                    <span class="badge rounded-pill text-bg-danger">Parse issue</span>
+                </div>
+                <div class="text-muted">
+                    Rows inherit these highlight colors. Expand details to inspect captured payloads and geometry.
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     {% for run in debug_runs %}
         <div class="card mb-4 shadow-sm">
             <div class="card-header bg-light">
@@ -41,8 +58,11 @@
             </div>
             <div class="card-body">
                 <div class="table-responsive">
-                    <table class="table table-sm table-hover align-middle">
-                        <thead class="table-light">
+                    <table class="table table-hover table-bordered align-middle mb-0">
+                        <caption class="caption-top text-muted small">
+                            Detailed alert outcomes for this poll cycle.
+                        </caption>
+                        <thead class="table-light position-sticky top-0" style="z-index: 1;">
                             <tr>
                                 <th scope="col">Event</th>
                                 <th scope="col">Identifier</th>
@@ -65,15 +85,15 @@
                                 {% elif alert.was_saved %}
                                     {% set row_class = 'table-info' %}
                                 {% endif %}
-                                <tr class="{{ row_class }}">
-                                    <td>
+                                <tr class="{{ row_class }} align-top">
+                                    <td class="text-break">
                                         <div class="fw-semibold">{{ alert.alert_event or 'Unknown event' }}</div>
                                         <div class="text-muted small">{{ alert.source or 'Unknown source' }}</div>
                                         {% if alert.area_desc %}
-                                            <div class="small">{{ alert.area_desc }}</div>
+                                            <div class="small text-muted">{{ alert.area_desc }}</div>
                                         {% endif %}
                                     </td>
-                                    <td>
+                                    <td class="text-break">
                                         <div class="font-monospace small">{{ alert.alert_identifier or alert.identifier or 'n/a' }}</div>
                                         {% if alert.raw_xml_present %}
                                             <span class="badge bg-secondary mt-1">Raw XML</span>
@@ -82,7 +102,7 @@
                                             <div class="small text-muted">UGC: {{ alert.ugc_codes|join(', ') }}</div>
                                         {% endif %}
                                     </td>
-                                    <td>
+                                    <td class="text-break">
                                         {% if alert.is_relevant %}
                                             <span class="badge bg-success">Accepted</span>
                                         {% else %}
@@ -93,15 +113,17 @@
                                             <div class="small">{{ alert.relevance_matches|join(', ') }}</div>
                                         {% endif %}
                                     </td>
-                                    <td>
-                                        {% if alert.was_saved %}
-                                            <span class="badge bg-info text-dark">Saved</span>
-                                        {% else %}
-                                            <span class="badge bg-secondary">Not saved</span>
-                                        {% endif %}
-                                        {% if alert.was_new %}
-                                            <span class="badge bg-success ms-1">New</span>
-                                        {% endif %}
+                                    <td class="text-break">
+                                        <div class="d-flex flex-wrap gap-1">
+                                            {% if alert.was_saved %}
+                                                <span class="badge bg-info text-dark">Saved</span>
+                                            {% else %}
+                                                <span class="badge bg-secondary">Not saved</span>
+                                            {% endif %}
+                                            {% if alert.was_new %}
+                                                <span class="badge bg-success">New</span>
+                                            {% endif %}
+                                        </div>
                                         {% if alert.alert_db_id %}
                                             <div class="small text-muted">DB ID {{ alert.alert_db_id }}</div>
                                         {% endif %}
@@ -109,35 +131,33 @@
                                             <div class="text-danger small">{{ alert.parse_error }}</div>
                                         {% endif %}
                                     </td>
-                                    <td>
+                                    <td class="text-break">
                                         <div class="small">{{ alert.geometry_type or 'None' }}{% if alert.polygon_count %} ({{ alert.polygon_count }}){% endif %}</div>
                                         {% if alert.geometry_preview %}
                                             <details class="small mt-1">
-                                                <summary>Preview</summary>
-                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_preview | tojson(indent=2) }}</pre>
+                                                <summary class="fw-semibold">Preview</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded overflow-auto">{{ alert.geometry_preview | tojson(indent=2) }}</pre>
                                             </details>
                                         {% endif %}
                                         {% if alert.geometry_geojson %}
                                             <details class="small mt-2">
-                                                <summary>GeoJSON</summary>
-                                                <pre class="small bg-dark text-light p-2 rounded">{{ alert.geometry_geojson | tojson(indent=2) }}</pre>
+                                                <summary class="fw-semibold">GeoJSON</summary>
+                                                <pre class="small bg-dark text-light p-2 rounded overflow-auto">{{ alert.geometry_geojson | tojson(indent=2) }}</pre>
                                             </details>
                                         {% endif %}
                                     </td>
-                                    <td>
+                                    <td class="text-break">
                                         <div class="small">Sent: {{ alert.alert_sent_display or 'Unknown' }}</div>
                                         <div class="text-muted small">Captured: {{ alert.created_at_display or 'Unknown' }}</div>
                                     </td>
-                                    <td>
+                                    <td class="text-break">
                                         {% set note_text = alert.notes or '' %}
                                         {% if note_text %}
-                                            {% for line in note_text.split('\n') %}
-                                                <div class="small text-muted">{{ line }}</div>
-                                            {% endfor %}
+                                            <div class="small text-muted" style="white-space: pre-line;">{{ note_text }}</div>
                                         {% endif %}
                                         <details class="small mt-2">
-                                            <summary>Raw properties</summary>
-                                            <pre class="small bg-light border rounded p-2">{{ alert.raw_properties | tojson(indent=2) }}</pre>
+                                            <summary class="fw-semibold">Raw properties</summary>
+                                            <pre class="small bg-light border rounded p-2 overflow-auto">{{ alert.raw_properties | tojson(indent=2) }}</pre>
                                         </details>
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary
- increase base body typography metrics for better legibility across pages
- restyle the global footer with higher contrast colors and clearer layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690509c896088320b041879e0e0a4d3e