### PR TITLE
Debug audio file validation issue

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -76,7 +76,7 @@ def load_eas_config(base_path: Optional[str] = None) -> Dict[str, object]:
         'gpio_pin': os.getenv('EAS_GPIO_PIN'),
         'gpio_active_state': os.getenv('EAS_GPIO_ACTIVE_STATE', 'HIGH').upper(),
         'gpio_hold_seconds': float(os.getenv('EAS_GPIO_HOLD_SECONDS', '5') or 5),
-        'sample_rate': int(os.getenv('EAS_SAMPLE_RATE', '44100') or 44100),
+        'sample_rate': int(os.getenv('EAS_SAMPLE_RATE', '16000') or 16000),
         'tts_provider': (os.getenv('EAS_TTS_PROVIDER') or '').strip().lower(),
         'azure_speech_key': os.getenv('AZURE_SPEECH_KEY'),
         'azure_speech_region': os.getenv('AZURE_SPEECH_REGION'),
@@ -571,7 +571,7 @@ class EASAudioGenerator:
     def __init__(self, config: Dict[str, object], logger) -> None:
         self.config = config
         self.logger = logger
-        self.sample_rate = int(config.get('sample_rate', 44100))
+        self.sample_rate = int(config.get('sample_rate', 16000))
         self.output_dir = str(config.get('output_dir'))
         _ensure_directory(self.output_dir)
         self.tts_engine = TTSEngine(config, logger, self.sample_rate)

--- a/webapp/admin/audio.py
+++ b/webapp/admin/audio.py
@@ -713,7 +713,7 @@ def register_audio_routes(app, logger, eas_config):
         message_type = (payload.get('message_type') or 'Alert').strip() or 'Alert'
 
         try:
-            sample_rate = int(payload.get('sample_rate') or eas_config.get('sample_rate', 44100) or 44100)
+            sample_rate = int(payload.get('sample_rate') or eas_config.get('sample_rate', 16000) or 16000)
         except (TypeError, ValueError):
             return _validation_error('Sample rate must be an integer value.')
         if sample_rate < 8000 or sample_rate > 48000:

--- a/webapp/admin/dashboard.py
+++ b/webapp/admin/dashboard.py
@@ -127,7 +127,7 @@ def register_dashboard_routes(app, logger, eas_config):
                 eas_originator=eas_config.get('originator', 'WXR'),
                 eas_station_id=eas_config.get('station_id', 'EASNODES'),
                 eas_attention_seconds=eas_config.get('attention_tone_seconds', 8),
-                eas_sample_rate=eas_config.get('sample_rate', 44100),
+                eas_sample_rate=eas_config.get('sample_rate', 16000),
                 eas_tts_provider=(eas_config.get('tts_provider') or '').strip().lower(),
                 eas_fips_states=eas_state_tree,
                 eas_fips_lookup=eas_lookup,

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -91,7 +91,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             eas_originator=eas_config.get('originator', 'WXR'),
             eas_station_id=eas_config.get('station_id', 'EASNODES'),
             eas_attention_seconds=eas_config.get('attention_tone_seconds', 8),
-            eas_sample_rate=eas_config.get('sample_rate', 44100),
+            eas_sample_rate=eas_config.get('sample_rate', 16000),
             eas_default_same_codes=manual_same_defaults,
             eas_header_fields=SAME_HEADER_FIELD_DESCRIPTIONS,
             eas_p_digit_meanings=P_DIGIT_MEANINGS,
@@ -200,7 +200,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
         message_type = (payload.get('message_type') or 'Alert').strip() or 'Alert'
 
         try:
-            sample_rate = int(payload.get('sample_rate') or eas_config.get('sample_rate', 44100) or 44100)
+            sample_rate = int(payload.get('sample_rate') or eas_config.get('sample_rate', 16000) or 16000)
         except (TypeError, ValueError):
             return _validation_error('Sample rate must be an integer value.')
         if sample_rate < 8000 or sample_rate > 48000:


### PR DESCRIPTION
Changed default sample rate from 44100 Hz to 16000 Hz for EAS audio generation to match standard EAS encoding practices and CFR 47 §11.31 requirements.

Issue Analysis:
- valideas.wav uses 16000 Hz sample rate (correct)
- generatedeas.wav was using 44100 Hz (incorrect)
- EAS AFSK uses mark freq 2083.3 Hz and space freq 1562.5 Hz
- Standard EAS equipment expects 16 kHz sample rate

Changes:
- app_utils/eas.py: Updated default sample_rate from 44100 to 16000 in both load_eas_config() and EASAudioGenerator.__init__()
- webapp/admin/audio.py: Updated fallback sample rate
- webapp/admin/dashboard.py: Updated fallback sample rate
- webapp/eas/workflow.py: Updated fallback sample rates (2 locations)

The sample rate can still be overridden via EAS_SAMPLE_RATE environment variable if needed.