### PR TITLE
Fix missing database column in location settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -776,8 +776,12 @@ if hasattr(app, "before_serving"):
 elif hasattr(app, "before_first_request"):
     app.before_first_request(initialize_database)
 else:
-    with app.app_context():
-        initialize_database()
+    # Skip initialization if running migrations
+    # This prevents the chicken-and-egg problem where migrations need to add
+    # columns that the initialization code tries to query
+    if not os.environ.get("SKIP_DB_INIT"):
+        with app.app_context():
+            initialize_database()
 
 
 # =============================================================================

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,9 @@ echo "Running database migrations..."
 max_attempts=5
 attempt=0
 
+# Set flag to skip database initialization during migrations
+export SKIP_DB_INIT=1
+
 while [ $attempt -lt $max_attempts ]; do
     if python -m alembic upgrade head; then
         echo "Migrations complete."
@@ -23,6 +26,9 @@ while [ $attempt -lt $max_attempts ]; do
         fi
     fi
 done
+
+# Unset the flag after migrations are complete
+unset SKIP_DB_INIT
 
 echo "Starting application..."
 


### PR DESCRIPTION
The application was failing to start because database migrations couldn't run due to a chicken-and-egg problem:
1. Migrations needed to run to add the fips_codes column
2. But when Alembic imported the app, it triggered database initialization
3. Database initialization tried to query LocationSettings with fips_codes
4. This failed because the column didn't exist yet

Solution:
- Set SKIP_DB_INIT=1 environment variable during migration runs
- Check this flag in app.py and skip initialization when set
- This allows migrations to complete before initialization runs

The initialization will still run normally when the application starts after migrations are complete.