### PR TITLE
Fix missing database column in location settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -877,8 +877,12 @@ def create_app(config=None):
     if config:
         app.config.update(config)
 
-    with app.app_context():
-        initialize_database()
+    # Skip initialization if running migrations
+    # This prevents the chicken-and-egg problem where migrations need to add
+    # columns that the initialization code tries to query
+    if not os.environ.get("SKIP_DB_INIT"):
+        with app.app_context():
+            initialize_database()
 
     return app
 

--- a/app_core/migrations/env.py
+++ b/app_core/migrations/env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from logging.config import fileConfig
 from typing import Any
 
@@ -25,6 +26,10 @@ def _get_configured_url() -> str:
     url = config.get_main_option("sqlalchemy.url", "")
     if url:
         return url
+
+    # Skip database initialization during migrations to prevent chicken-and-egg issues
+    # where migrations need to add columns that the initialization code tries to query
+    os.environ["SKIP_DB_INIT"] = "1"
 
     app = create_app()
     with app.app_context():


### PR DESCRIPTION
The migration process was failing because create_app() unconditionally called initialize_database(), which tried to query the location_settings table for the fips_codes column before the migration could add it.

Changes:
- Modified create_app() to respect the SKIP_DB_INIT environment variable
- Set SKIP_DB_INIT in the migration env.py to ensure it's always set
- This prevents the chicken-and-egg problem where migrations need to add columns that the initialization code tries to query

The docker-entrypoint.sh already sets SKIP_DB_INIT=1, but create_app() wasn't checking for it. Now the initialization is properly skipped during migration runs.