### PR TITLE
Fix duplicate table error in database migration

### DIFF
--- a/app_core/migrations/versions/20240229_create_radio_tables.py
+++ b/app_core/migrations/versions/20240229_create_radio_tables.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20240229_radio"
@@ -13,51 +14,60 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "radio_receivers",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("identifier", sa.String(length=64), nullable=False),
-        sa.Column("display_name", sa.String(length=128), nullable=False),
-        sa.Column("driver", sa.String(length=64), nullable=False),
-        sa.Column("frequency_hz", sa.Float(), nullable=False),
-        sa.Column("sample_rate", sa.Integer(), nullable=False),
-        sa.Column("gain", sa.Float(), nullable=True),
-        sa.Column("channel", sa.Integer(), nullable=True),
-        sa.Column("auto_start", sa.Boolean(), nullable=False, server_default=sa.true()),
-        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
-        sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-    )
-    op.create_index(
-        "idx_radio_receivers_identifier",
-        "radio_receivers",
-        ["identifier"],
-        unique=True,
-    )
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
 
-    op.create_table(
-        "radio_receiver_status",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("receiver_id", sa.Integer(), nullable=False),
-        sa.Column("reported_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("locked", sa.Boolean(), nullable=False, server_default=sa.false()),
-        sa.Column("signal_strength", sa.Float(), nullable=True),
-        sa.Column("last_error", sa.Text(), nullable=True),
-        sa.Column("capture_mode", sa.String(length=16), nullable=True),
-        sa.Column("capture_path", sa.String(length=255), nullable=True),
-        sa.ForeignKeyConstraint(["receiver_id"], ["radio_receivers.id"], ondelete="CASCADE"),
-    )
-    op.create_index(
-        "idx_radio_receiver_status_receiver_id",
-        "radio_receiver_status",
-        ["receiver_id"],
-    )
-    op.create_index(
-        "idx_radio_receiver_status_reported_at",
-        "radio_receiver_status",
-        ["reported_at"],
-    )
+    # Only create radio_receivers table if it doesn't exist
+    if "radio_receivers" not in existing_tables:
+        op.create_table(
+            "radio_receivers",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("identifier", sa.String(length=64), nullable=False),
+            sa.Column("display_name", sa.String(length=128), nullable=False),
+            sa.Column("driver", sa.String(length=64), nullable=False),
+            sa.Column("frequency_hz", sa.Float(), nullable=False),
+            sa.Column("sample_rate", sa.Integer(), nullable=False),
+            sa.Column("gain", sa.Float(), nullable=True),
+            sa.Column("channel", sa.Integer(), nullable=True),
+            sa.Column("auto_start", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        )
+        op.create_index(
+            "idx_radio_receivers_identifier",
+            "radio_receivers",
+            ["identifier"],
+            unique=True,
+        )
+
+    # Only create radio_receiver_status table if it doesn't exist
+    if "radio_receiver_status" not in existing_tables:
+        op.create_table(
+            "radio_receiver_status",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("receiver_id", sa.Integer(), nullable=False),
+            sa.Column("reported_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("locked", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("signal_strength", sa.Float(), nullable=True),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("capture_mode", sa.String(length=16), nullable=True),
+            sa.Column("capture_path", sa.String(length=255), nullable=True),
+            sa.ForeignKeyConstraint(["receiver_id"], ["radio_receivers.id"], ondelete="CASCADE"),
+        )
+        op.create_index(
+            "idx_radio_receiver_status_receiver_id",
+            "radio_receiver_status",
+            ["receiver_id"],
+        )
+        op.create_index(
+            "idx_radio_receiver_status_reported_at",
+            "radio_receiver_status",
+            ["reported_at"],
+        )
 
 
 def downgrade() -> None:

--- a/app_core/migrations/versions/20240315_alert_delivery_reports.py
+++ b/app_core/migrations/versions/20240315_alert_delivery_reports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20240315_alert_delivery_reports"
@@ -13,35 +14,42 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "alert_delivery_reports",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("scope", sa.String(length=16), nullable=False),
-        sa.Column("originator", sa.String(length=64), nullable=True),
-        sa.Column("station", sa.String(length=128), nullable=True),
-        sa.Column("total_alerts", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("delivered_alerts", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("delayed_alerts", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("average_latency_seconds", sa.Integer(), nullable=True),
-    )
-    op.create_index(
-        "idx_alert_delivery_reports_scope_window",
-        "alert_delivery_reports",
-        ["scope", "window_start", "window_end"],
-    )
-    op.create_index(
-        "idx_alert_delivery_reports_originator",
-        "alert_delivery_reports",
-        ["originator"],
-    )
-    op.create_index(
-        "idx_alert_delivery_reports_station",
-        "alert_delivery_reports",
-        ["station"],
-    )
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    # Only create alert_delivery_reports table if it doesn't exist
+    if "alert_delivery_reports" not in existing_tables:
+        op.create_table(
+            "alert_delivery_reports",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("scope", sa.String(length=16), nullable=False),
+            sa.Column("originator", sa.String(length=64), nullable=True),
+            sa.Column("station", sa.String(length=128), nullable=True),
+            sa.Column("total_alerts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("delivered_alerts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("delayed_alerts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("average_latency_seconds", sa.Integer(), nullable=True),
+        )
+        op.create_index(
+            "idx_alert_delivery_reports_scope_window",
+            "alert_delivery_reports",
+            ["scope", "window_start", "window_end"],
+        )
+        op.create_index(
+            "idx_alert_delivery_reports_originator",
+            "alert_delivery_reports",
+            ["originator"],
+        )
+        op.create_index(
+            "idx_alert_delivery_reports_station",
+            "alert_delivery_reports",
+            ["station"],
+        )
 
 
 def downgrade() -> None:

--- a/app_core/migrations/versions/20240510_eas_audio_decodes.py
+++ b/app_core/migrations/versions/20240510_eas_audio_decodes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20240510_eas_audio_decodes"
@@ -13,16 +14,23 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "eas_decoded_audio",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.Column("original_filename", sa.String(length=255), nullable=True),
-        sa.Column("content_type", sa.String(length=128), nullable=True),
-        sa.Column("raw_text", sa.Text(), nullable=True),
-        sa.Column("same_headers", sa.JSON(), nullable=True),
-        sa.Column("quality_metrics", sa.JSON(), nullable=True),
-    )
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    # Only create eas_decoded_audio table if it doesn't exist
+    if "eas_decoded_audio" not in existing_tables:
+        op.create_table(
+            "eas_decoded_audio",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("original_filename", sa.String(length=255), nullable=True),
+            sa.Column("content_type", sa.String(length=128), nullable=True),
+            sa.Column("raw_text", sa.Text(), nullable=True),
+            sa.Column("same_headers", sa.JSON(), nullable=True),
+            sa.Column("quality_metrics", sa.JSON(), nullable=True),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
The migration system was failing when trying to create tables that already existed in the database. This occurred because the database state was out of sync with the Alembic migration history.

Changes:
- Added table existence checks in 20240229_create_radio_tables.py
- Added table existence checks in 20240315_alert_delivery_reports.py
- Added table existence checks in 20240510_eas_audio_decodes.py
- Migrations now use SQLAlchemy inspector to check for existing tables
- Only create tables if they don't already exist

This fix ensures migrations can run successfully even when tables were previously created outside of the migration system or when the migration history is incomplete.