### PR TITLE
Fix database migration string length error

### DIFF
--- a/app_core/migrations/versions/20240717_expand_alembic_version_column.py
+++ b/app_core/migrations/versions/20240717_expand_alembic_version_column.py
@@ -1,0 +1,36 @@
+"""Expand alembic_version.version_num column to support longer migration names."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240717_expand_alembic_version"
+down_revision = "20240510_eas_audio_decodes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Expand the alembic_version.version_num column from VARCHAR(32) to VARCHAR(255)
+    # This is needed because some migration names exceed 32 characters
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Revert back to VARCHAR(32)
+    # Note: This may fail if there are version strings longer than 32 characters
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=32),
+        existing_nullable=False,
+    )

--- a/app_core/migrations/versions/20240718_expand_decoded_audio_segments.py
+++ b/app_core/migrations/versions/20240718_expand_decoded_audio_segments.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision = "20240718_expand_decoded_audio_segments"
-down_revision = "20240510_eas_audio_decodes"
+down_revision = "20240717_expand_alembic_version"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The alembic_version.version_num column was defined as VARCHAR(32) by default, but several migration names exceed this limit (e.g., '20240718_expand_decoded_audio_segments' is 38 characters). This caused migration failures with the error: "value too long for type character varying(32)"

Changes:
- Added new migration 20240717_expand_alembic_version to expand the version_num column from VARCHAR(32) to VARCHAR(255)
- Updated 20240718_expand_decoded_audio_segments to depend on the new migration
- The new migration name is 31 characters, which fits within the VARCHAR(32) limit

Migration chain:
20240510_eas_audio_decodes → 20240717_expand_alembic_version (NEW) → 20240718_expand_decoded_audio_segments

This ensures the column is expanded before any migration with a long name is applied.