### PR TITLE
Fix duplicate column in database migration

### DIFF
--- a/app_core/migrations/versions/20240717_expand_alembic_version_column.py
+++ b/app_core/migrations/versions/20240717_expand_alembic_version_column.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20240717_expand_alembic_version"
@@ -13,15 +14,29 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Expand the alembic_version.version_num column from VARCHAR(32) to VARCHAR(255)
-    # This is needed because some migration names exceed 32 characters
-    op.alter_column(
-        "alembic_version",
-        "version_num",
-        existing_type=sa.String(length=32),
-        type_=sa.String(length=255),
-        existing_nullable=False,
-    )
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Check the current column type
+    columns = inspector.get_columns('alembic_version')
+    version_num_col = next((col for col in columns if col['name'] == 'version_num'), None)
+
+    # Only alter if the column exists and is still VARCHAR(32) or smaller
+    if version_num_col:
+        # Get the current length - check if it needs expansion
+        current_type = version_num_col['type']
+        # Check if it's a string type with length < 255
+        if hasattr(current_type, 'length') and current_type.length and current_type.length < 255:
+            # Expand the alembic_version.version_num column from VARCHAR(32) to VARCHAR(255)
+            # This is needed because some migration names exceed 32 characters
+            op.alter_column(
+                "alembic_version",
+                "version_num",
+                existing_type=sa.String(length=32),
+                type_=sa.String(length=255),
+                existing_nullable=False,
+            )
 
 
 def downgrade() -> None:

--- a/app_core/migrations/versions/20240718_expand_decoded_audio_segments.py
+++ b/app_core/migrations/versions/20240718_expand_decoded_audio_segments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20240718_expand_decoded_audio_segments"
@@ -13,12 +14,24 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Check existing columns
+    existing_columns = {col['name'] for col in inspector.get_columns('eas_decoded_audio')}
+
     with op.batch_alter_table("eas_decoded_audio", schema=None) as batch:
-        batch.add_column(sa.Column("segment_metadata", sa.JSON(), nullable=True))
-        batch.add_column(sa.Column("header_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("message_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("eom_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("buffer_audio_data", sa.LargeBinary(), nullable=True))
+        if 'segment_metadata' not in existing_columns:
+            batch.add_column(sa.Column("segment_metadata", sa.JSON(), nullable=True))
+        if 'header_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("header_audio_data", sa.LargeBinary(), nullable=True))
+        if 'message_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("message_audio_data", sa.LargeBinary(), nullable=True))
+        if 'eom_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("eom_audio_data", sa.LargeBinary(), nullable=True))
+        if 'buffer_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("buffer_audio_data", sa.LargeBinary(), nullable=True))
 
 
 def downgrade() -> None:

--- a/app_core/migrations/versions/20241112_add_eas_message_segments.py
+++ b/app_core/migrations/versions/20241112_add_eas_message_segments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
 revision = "20241112_add_eas_message_segments"
@@ -13,11 +14,22 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Get database connection and inspector
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Check existing columns
+    existing_columns = {col['name'] for col in inspector.get_columns('eas_messages')}
+
     with op.batch_alter_table("eas_messages", schema=None) as batch:
-        batch.add_column(sa.Column("same_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("attention_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("tts_audio_data", sa.LargeBinary(), nullable=True))
-        batch.add_column(sa.Column("buffer_audio_data", sa.LargeBinary(), nullable=True))
+        if 'same_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("same_audio_data", sa.LargeBinary(), nullable=True))
+        if 'attention_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("attention_audio_data", sa.LargeBinary(), nullable=True))
+        if 'tts_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("tts_audio_data", sa.LargeBinary(), nullable=True))
+        if 'buffer_audio_data' not in existing_columns:
+            batch.add_column(sa.Column("buffer_audio_data", sa.LargeBinary(), nullable=True))
 
 
 def downgrade() -> None:


### PR DESCRIPTION
…umn errors

This fixes the DuplicateColumn error by checking if columns already exist before attempting to add them. All migrations that add columns to existing tables now use SQLAlchemy's inspect() to check for existing columns.

Fixed migrations:
- 20240717_expand_alembic_version_column.py: Check column type length before altering
- 20240718_expand_decoded_audio_segments.py: Check for existing columns before adding to eas_decoded_audio
- 20241112_add_eas_message_segments.py: Check for existing columns before adding to eas_messages
- 20241205_add_location_fips_codes.py: Check for existing column before adding to location_settings

This follows the same pattern used in the table-creating migrations (20240229, 20240315, 20240510) which already check for existing tables before creating them.

Fixes: Column "same_audio_data" of relation "eas_messages" already exists error