### PR TITLE
Fix database migration bind parameter error

### DIFF
--- a/app_core/migrations/versions/20241205_add_location_fips_codes.py
+++ b/app_core/migrations/versions/20241205_add_location_fips_codes.py
@@ -45,11 +45,11 @@ def upgrade() -> None:
             text(
                 """
                 UPDATE location_settings
-                SET fips_codes = :default::jsonb
+                SET fips_codes = :fips_default::jsonb
                 WHERE fips_codes IS NULL
                    OR jsonb_array_length(fips_codes) = 0
                 """
-            ).bindparams(default=default_json)
+            ).bindparams(fips_default=default_json)
         )
 
 


### PR DESCRIPTION
The migration was using ':default' as a parameter name which conflicted with SQLAlchemy's parameter parsing when combined with PostgreSQL's '::jsonb' type cast syntax. Renamed the parameter to ':fips_default' to resolve the issue.

Fixes: sqlalchemy.exc.ArgumentError: This text() construct doesn't define a bound parameter named 'default'