### PR TITLE
Fix bindparams syntax error in FIPS codes migration

### DIFF
--- a/app_core/migrations/versions/20241205_add_location_fips_codes.py
+++ b/app_core/migrations/versions/20241205_add_location_fips_codes.py
@@ -49,7 +49,8 @@ def upgrade() -> None:
                 WHERE fips_codes IS NULL
                    OR jsonb_array_length(fips_codes) = 0
                 """
-            ).bindparams(fips_default=default_json)
+            ),
+            {"fips_default": default_json}
         )
 
 


### PR DESCRIPTION
The bindparams() method was causing a KeyError. Changed to pass parameters as a dictionary to op.execute() which is the correct SQLAlchemy pattern for parameterized queries.