### PR TITLE
Fix database migration execute argument error

### DIFF
--- a/app_core/migrations/versions/20241205_add_location_fips_codes.py
+++ b/app_core/migrations/versions/20241205_add_location_fips_codes.py
@@ -49,8 +49,7 @@ def upgrade() -> None:
                 WHERE fips_codes IS NULL
                    OR jsonb_array_length(fips_codes) = 0
                 """
-            ),
-            {"fips_default": default_json}
+            ).bindparams(fips_default=default_json)
         )
 
 


### PR DESCRIPTION
Changed from passing parameters as a separate dictionary argument to using .bindparams() method on the text() object, which is the correct Alembic API usage. op.execute() only accepts a single SQL statement argument, not additional parameter dictionaries.