### PR TITLE
Debug data structure visibility issue

### DIFF
--- a/app_core/migrations/versions/20241205_add_location_fips_codes.py
+++ b/app_core/migrations/versions/20241205_add_location_fips_codes.py
@@ -47,7 +47,7 @@ def upgrade() -> None:
                 UPDATE location_settings
                 SET fips_codes = CAST(:fips_default AS jsonb)
                 WHERE fips_codes IS NULL
-                   OR jsonb_array_length(fips_codes) = 0
+                   OR jsonb_array_length(CAST(fips_codes AS jsonb)) = 0
                 """
             ).bindparams(bindparam("fips_default", value=default_json, type_=sa.String))
         )


### PR DESCRIPTION
Cast json column to jsonb before calling jsonb_array_length() function. PostgreSQL's jsonb_array_length() requires jsonb type, but fips_codes column is defined as json type in the schema.