### PR TITLE
Permanently fix JSON/JSONB type mismatch in location_settings

### DIFF
--- a/app_core/migrations/versions/20241031_convert_location_json_to_jsonb.py
+++ b/app_core/migrations/versions/20241031_convert_location_json_to_jsonb.py
@@ -1,0 +1,95 @@
+"""Convert location_settings JSON columns to JSONB for better performance."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "20241031_convert_location_json_to_jsonb"
+down_revision = "20241205_add_location_fips_codes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Convert JSON columns to JSONB for better PostgreSQL performance and function support."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Check if table exists
+    if 'location_settings' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name']: col for col in inspector.get_columns('location_settings')}
+
+    # Convert zone_codes from JSON to JSONB if it exists
+    if 'zone_codes' in existing_columns:
+        with op.batch_alter_table("location_settings", schema=None) as batch:
+            batch.alter_column(
+                'zone_codes',
+                type_=JSONB,
+                existing_type=sa.JSON(),
+                postgresql_using='zone_codes::jsonb'
+            )
+
+    # Convert area_terms from JSON to JSONB if it exists
+    if 'area_terms' in existing_columns:
+        with op.batch_alter_table("location_settings", schema=None) as batch:
+            batch.alter_column(
+                'area_terms',
+                type_=JSONB,
+                existing_type=sa.JSON(),
+                postgresql_using='area_terms::jsonb'
+            )
+
+    # Convert led_default_lines from JSON to JSONB if it exists
+    if 'led_default_lines' in existing_columns:
+        with op.batch_alter_table("location_settings", schema=None) as batch:
+            batch.alter_column(
+                'led_default_lines',
+                type_=JSONB,
+                existing_type=sa.JSON(),
+                postgresql_using='led_default_lines::jsonb'
+            )
+
+    # Convert fips_codes from JSON to JSONB if it exists and is JSON type
+    if 'fips_codes' in existing_columns:
+        with op.batch_alter_table("location_settings", schema=None) as batch:
+            batch.alter_column(
+                'fips_codes',
+                type_=JSONB,
+                existing_type=sa.JSON(),
+                postgresql_using='fips_codes::jsonb'
+            )
+
+
+def downgrade() -> None:
+    """Convert JSONB columns back to JSON."""
+    with op.batch_alter_table("location_settings", schema=None) as batch:
+        batch.alter_column(
+            'fips_codes',
+            type_=sa.JSON(),
+            existing_type=JSONB,
+            postgresql_using='fips_codes::json'
+        )
+        batch.alter_column(
+            'zone_codes',
+            type_=sa.JSON(),
+            existing_type=JSONB,
+            postgresql_using='zone_codes::json'
+        )
+        batch.alter_column(
+            'area_terms',
+            type_=sa.JSON(),
+            existing_type=JSONB,
+            postgresql_using='area_terms::json'
+        )
+        batch.alter_column(
+            'led_default_lines',
+            type_=sa.JSON(),
+            existing_type=JSONB,
+            postgresql_using='led_default_lines::json'
+        )

--- a/app_core/migrations/versions/20241205_add_location_fips_codes.py
+++ b/app_core/migrations/versions/20241205_add_location_fips_codes.py
@@ -7,6 +7,7 @@ import json
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect, text, bindparam
+from sqlalchemy.dialects.postgresql import JSONB
 
 from app_utils.location_settings import DEFAULT_LOCATION_SETTINGS
 
@@ -34,7 +35,7 @@ def upgrade() -> None:
             batch.add_column(
                 sa.Column(
                     "fips_codes",
-                    sa.JSON(),
+                    JSONB,
                     nullable=False,
                     server_default=sa.text("'[]'::jsonb"),
                 )
@@ -47,7 +48,7 @@ def upgrade() -> None:
                 UPDATE location_settings
                 SET fips_codes = CAST(:fips_default AS jsonb)
                 WHERE fips_codes IS NULL
-                   OR jsonb_array_length(CAST(fips_codes AS jsonb)) = 0
+                   OR jsonb_array_length(fips_codes) = 0
                 """
             ).bindparams(bindparam("fips_default", value=default_json, type_=sa.String))
         )

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -18,6 +18,7 @@ from app_utils.location_settings import DEFAULT_LOCATION_SETTINGS
 
 from .extensions import db
 from sqlalchemy.engine.url import make_url
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 def _spatial_backend_supports_geometry() -> bool:
@@ -435,17 +436,17 @@ class LocationSettings(db.Model):
         default=DEFAULT_LOCATION_SETTINGS["timezone"],
     )
     fips_codes = db.Column(
-        db.JSON,
+        JSONB,
         nullable=False,
         default=lambda: list(DEFAULT_LOCATION_SETTINGS["fips_codes"]),
     )
     zone_codes = db.Column(
-        db.JSON,
+        JSONB,
         nullable=False,
         default=lambda: list(DEFAULT_LOCATION_SETTINGS["zone_codes"]),
     )
     area_terms = db.Column(
-        db.JSON,
+        JSONB,
         nullable=False,
         default=lambda: list(DEFAULT_LOCATION_SETTINGS["area_terms"]),
     )
@@ -465,7 +466,7 @@ class LocationSettings(db.Model):
         default=DEFAULT_LOCATION_SETTINGS["map_default_zoom"],
     )
     led_default_lines = db.Column(
-        db.JSON,
+        JSONB,
         nullable=False,
         default=lambda: list(DEFAULT_LOCATION_SETTINGS["led_default_lines"]),
     )


### PR DESCRIPTION
This is a comprehensive fix to resolve the recurring database migration errors:

Problem:
- SQLAlchemy JSON() creates 'json' type columns in PostgreSQL
- Migration was using jsonb_array_length() which requires 'jsonb' type
- This caused 'function jsonb_array_length(json) does not exist' errors

Solution:
1. Update LocationSettings model to use JSONB type for:
   - fips_codes
   - zone_codes
   - area_terms
   - led_default_lines

2. Update 20241205_add_location_fips_codes migration to use JSONB type

3. Add new migration 20241031_convert_location_json_to_jsonb to convert any existing JSON columns to JSONB using PostgreSQL's ::jsonb cast

Benefits:
- JSONB is more efficient in PostgreSQL (binary storage vs text)
- JSONB supports indexing and native functions
- No more type casting needed in queries
- Prevents future type mismatch errors