### PR TITLE
Add web-based setup wizard for environment configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ tracks releases under the 2.x series.
 
 ## [Unreleased]
 ### Added
+- Added an interactive `.env` setup wizard available at `/setup`, with a CLI
+  companion (`tools/setup_wizard.py`), so operators can generate secrets,
+  database credentials, and location defaults before first launch without
+  editing text files by hand.
 - Added a repository `VERSION` manifest, shared resolver, and `tests/test_release_metadata.py` guardrail so version bumps and changelog updates stay synchronised for audit trails.
 - Added `tools/inplace_upgrade.py` for in-place upgrades that pull, rebuild, migrate, and restart services without destroying volumes, plus `tools/create_backup.py` to snapshot `.env`, compose files, and a Postgres dump with audit metadata before changes.
 - Introduced a compliance dashboard with CSV/PDF exports and automated

--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ docker compose up -d --build
 
 ### Configuration Before First Run
 
+You can configure the environment through the browser, fall back to the CLI wizard, or edit the file manually.
+
+#### Option A – Use the in-browser setup wizard (recommended)
+
+1. Start the containers with `docker compose up -d --build` if they are not already running.
+2. Visit [http://localhost:5000/setup](http://localhost:5000/setup) from your browser.
+3. Fill in the required secrets and database credentials, then click **Save configuration**.
+
+The page writes a fresh `.env` using `.env.example` as a template and will create a timestamped backup when updating an existing file.
+
+#### Option B – Run the CLI wizard
+
+```bash
+python tools/setup_wizard.py
+```
+
+The CLI wrapper prompts for the same values as the browser flow and produces identical output, which is useful in headless deployments.
+
+#### Option C – Configure manually
+
 1. **Copy and review the environment template:**
    Run `cp .env.example .env` (already done in the quick start commands above)
    and treat the result as your local configuration. The defaults mirror the
@@ -220,13 +240,13 @@ docker compose up -d --build
 3. **Edit `.env` and update:**
    - `SECRET_KEY` - Use the generated value
    - `POSTGRES_PASSWORD` - Change from defaults (the application builds `DATABASE_URL` automatically from the `POSTGRES_*` values)
-  - `POSTGRES_HOST` - Point at your existing PostGIS host (hostname or IP)
-  - `TZ`, `WATCHTOWER_*`, or other infrastructure metadata as needed
+   - `POSTGRES_HOST` - Point at your existing PostGIS host (hostname or IP)
+   - `TZ`, `WATCHTOWER_*`, or other infrastructure metadata as needed
 
 4. **Start the system:**
-  ```bash
-  docker compose up -d --build
-  ```
+   ```bash
+   docker compose up -d --build
+   ```
 
 ### In-Place Upgrades (Keep Containers Running)
 

--- a/app_utils/setup_wizard.py
+++ b/app_utils/setup_wizard.py
@@ -1,0 +1,311 @@
+"""Helpers for onboarding configuration via the setup wizard.
+
+This module centralises the logic for reading `.env.example`, merging it with
+an existing `.env` file, and validating the subset of configuration fields that
+bootstrap the application.  Both the web-based onboarding flow and the CLI tool
+reuse these utilities to avoid divergent behaviour between environments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+import secrets
+from dotenv import dotenv_values
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ENV_TEMPLATE_PATH = PROJECT_ROOT / ".env.example"
+ENV_OUTPUT_PATH = PROJECT_ROOT / ".env"
+
+
+class SetupWizardError(Exception):
+    """Base exception for setup wizard problems."""
+
+
+class SetupValidationError(SetupWizardError):
+    """Raised when submitted configuration fails validation."""
+
+    def __init__(self, errors: Dict[str, str]):
+        super().__init__("Submitted configuration was invalid")
+        self.errors = errors
+
+
+@dataclass(frozen=True)
+class WizardField:
+    """Metadata describing a field managed by the setup wizard."""
+
+    key: str
+    label: str
+    description: str
+    placeholder: Optional[str] = None
+    required: bool = True
+    input_type: str = "text"
+    widget: str = "input"
+    validator: Optional[Callable[[str], str]] = None
+    normalizer: Optional[Callable[[str], str]] = None
+
+    def clean(self, value: str) -> str:
+        """Validate and normalise the provided value."""
+
+        trimmed = value.strip()
+        if not trimmed:
+            if self.required:
+                raise ValueError("This field is required.")
+            return ""
+
+        if self.validator is not None:
+            trimmed = self.validator(trimmed)
+
+        if self.normalizer is not None:
+            trimmed = self.normalizer(trimmed)
+
+        return trimmed
+
+
+@dataclass(frozen=True)
+class WizardState:
+    """Current environment/template snapshot used by the wizard."""
+
+    template_lines: List[str]
+    template_values: Dict[str, str]
+    current_values: Dict[str, str]
+    env_file_present: bool
+
+    @property
+    def defaults(self) -> Dict[str, str]:
+        combined = dict(self.template_values)
+        combined.update(self.current_values)
+        return combined
+
+    @property
+    def env_exists(self) -> bool:
+        return self.env_file_present
+
+
+def _parse_env_lines(lines: Iterable[str]) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_val = line.split("=", 1)
+        values[key.strip()] = raw_val.strip()
+    return values
+
+
+def _validate_port(value: str) -> str:
+    try:
+        port = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError("Port must be an integer between 1 and 65535") from exc
+
+    if not 1 <= port <= 65535:
+        raise ValueError("Port must be between 1 and 65535")
+    return str(port)
+
+
+def _validate_timezone(value: str) -> str:
+    if "/" not in value:
+        raise ValueError("Use the canonical Region/City timezone format, e.g. 'America/New_York'.")
+    return value
+
+
+def _normalise_led_lines(value: str) -> str:
+    lines = [segment.strip() for segment in value.replace("\r", "").splitlines()]
+    cleaned = [segment for segment in lines if segment]
+    if not cleaned:
+        raise ValueError("Provide at least one LED display line.")
+    return ",".join(cleaned)
+
+
+def _validate_secret_key(value: str) -> str:
+    if len(value) < 32:
+        raise ValueError("SECRET_KEY should be at least 32 characters long.")
+    return value
+
+
+def format_led_lines_for_display(value: str) -> str:
+    """Convert comma-separated LED lines into a textarea-friendly format."""
+
+    if not value:
+        return ""
+    if "\n" in value:
+        return value
+    return "\n".join(part.strip() for part in value.split(",") if part.strip())
+
+
+WIZARD_FIELDS: List[WizardField] = [
+    WizardField(
+        key="SECRET_KEY",
+        label="Flask Secret Key",
+        description="Required for session security. Generate a unique 64 character token.",
+        validator=_validate_secret_key,
+    ),
+    WizardField(
+        key="POSTGRES_HOST",
+        label="PostgreSQL Host",
+        description="Hostname or IP address of the PostGIS database server.",
+    ),
+    WizardField(
+        key="POSTGRES_PORT",
+        label="PostgreSQL Port",
+        description="Default PostgreSQL port is 5432.",
+        validator=_validate_port,
+    ),
+    WizardField(
+        key="POSTGRES_DB",
+        label="Database Name",
+        description="Database schema that stores CAP alerts and station data.",
+    ),
+    WizardField(
+        key="POSTGRES_USER",
+        label="Database Username",
+        description="Account used by the application to connect to the database.",
+    ),
+    WizardField(
+        key="POSTGRES_PASSWORD",
+        label="Database Password",
+        description="Password for the configured database user.",
+        input_type="password",
+    ),
+    WizardField(
+        key="DEFAULT_TIMEZONE",
+        label="Default Timezone",
+        description="Pre-populates the admin UI location settings.",
+        validator=_validate_timezone,
+    ),
+    WizardField(
+        key="DEFAULT_COUNTY_NAME",
+        label="Default County Name",
+        description="Displayed in the admin UI and LED signage defaults.",
+    ),
+    WizardField(
+        key="DEFAULT_LED_LINES",
+        label="Default LED Lines",
+        description="Four comma-separated phrases shown on the LED sign when idle.",
+        widget="textarea",
+        normalizer=_normalise_led_lines,
+    ),
+]
+
+
+def load_wizard_state() -> WizardState:
+    """Load template and existing environment values for the wizard."""
+
+    if not ENV_TEMPLATE_PATH.exists():
+        raise FileNotFoundError(
+            ".env.example is missing. Ensure the repository includes the template before running the wizard."
+        )
+
+    template_lines = ENV_TEMPLATE_PATH.read_text(encoding="utf-8").splitlines()
+    template_values = _parse_env_lines(template_lines)
+
+    env_file_present = ENV_OUTPUT_PATH.exists()
+    current_values: Dict[str, str] = {}
+    if env_file_present:
+        raw_values = dotenv_values(str(ENV_OUTPUT_PATH))
+        current_values = {key: (value or "") for key, value in raw_values.items() if value is not None}
+
+    return WizardState(
+        template_lines=template_lines,
+        template_values=template_values,
+        current_values=current_values,
+        env_file_present=env_file_present,
+    )
+
+
+def generate_secret_key() -> str:
+    """Generate a 64-character hex token suitable for Flask's SECRET_KEY."""
+
+    return secrets.token_hex(32)
+
+
+def create_env_backup() -> Path:
+    """Create a timestamped backup of the current .env file."""
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    backup_path = ENV_OUTPUT_PATH.with_suffix(f".backup-{timestamp}")
+    data = ENV_OUTPUT_PATH.read_bytes()
+    backup_path.write_bytes(data)
+    return backup_path
+
+
+def build_env_content(
+    *,
+    state: WizardState,
+    updates: Dict[str, str],
+) -> str:
+    """Render environment content using the template with updated values."""
+
+    baseline = state.defaults
+    merged_updates = {key: value for key, value in updates.items() if value is not None}
+
+    result_lines: List[str] = []
+    seen_keys = set()
+    for raw in state.template_lines:
+        if "=" not in raw or raw.lstrip().startswith("#"):
+            result_lines.append(raw)
+            continue
+        key, _ = raw.split("=", 1)
+        key = key.strip()
+        seen_keys.add(key)
+        new_value = merged_updates.get(key, baseline.get(key, ""))
+        result_lines.append(f"{key}={new_value}")
+
+    for key, value in merged_updates.items():
+        if key not in seen_keys:
+            result_lines.append(f"{key}={value}")
+
+    return "\n".join(result_lines) + "\n"
+
+
+def write_env_file(*, state: WizardState, updates: Dict[str, str], create_backup: bool) -> Path:
+    """Persist updates to the .env file, optionally writing a backup first."""
+
+    backup_path: Optional[Path] = None
+    if create_backup and ENV_OUTPUT_PATH.exists():
+        backup_path = create_env_backup()
+
+    content = build_env_content(state=state, updates=updates)
+    ENV_OUTPUT_PATH.write_text(content, encoding="utf-8")
+    return backup_path if backup_path is not None else ENV_OUTPUT_PATH
+
+
+def clean_submission(raw_form: Dict[str, str]) -> Dict[str, str]:
+    """Validate and normalise form values from the wizard."""
+
+    errors: Dict[str, str] = {}
+    cleaned: Dict[str, str] = {}
+
+    for field in WIZARD_FIELDS:
+        raw_value = raw_form.get(field.key, "")
+        try:
+            cleaned[field.key] = field.clean(raw_value)
+        except ValueError as exc:
+            errors[field.key] = str(exc)
+
+    if errors:
+        raise SetupValidationError(errors)
+
+    return cleaned
+
+
+__all__ = [
+    "ENV_OUTPUT_PATH",
+    "ENV_TEMPLATE_PATH",
+    "WizardField",
+    "WizardState",
+    "WIZARD_FIELDS",
+    "SetupWizardError",
+    "SetupValidationError",
+    "build_env_content",
+    "clean_submission",
+    "create_env_backup",
+    "format_led_lines_for_display",
+    "generate_secret_key",
+    "load_wizard_state",
+    "write_env_file",
+]

--- a/templates/login.html
+++ b/templates/login.html
@@ -47,6 +47,11 @@
             <p class="text-center text-muted mt-3">
                 Need access? Contact a system administrator to create an account for you.
             </p>
+            <p class="text-center mt-2">
+                <a class="btn btn-link" href="{{ url_for('setup_wizard') }}">
+                    <i class="fas fa-wrench me-1"></i>Launch environment setup wizard
+                </a>
+            </p>
         </div>
     </div>
 </div>

--- a/templates/setup_wizard.html
+++ b/templates/setup_wizard.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+
+{% block title %}Setup Wizard - EAS Station{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+            <div class="card shadow border-0">
+                <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                    <div>
+                        <h3 class="mb-0"><i class="fas fa-satellite-dish me-2"></i>Initial Configuration</h3>
+                        <small class="text-white-50">Generate your .env file without leaving the browser.</small>
+                    </div>
+                    <span class="badge bg-light text-primary fw-semibold">Setup Wizard</span>
+                </div>
+                <div class="card-body p-4">
+                    {% if not env_exists %}
+                    <div class="alert alert-warning" role="alert">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        No existing <code>.env</code> file was detected. Completing this wizard will create one using
+                        the template defaults.
+                    </div>
+                    {% else %}
+                    <div class="alert alert-info" role="alert">
+                        <i class="fas fa-info-circle me-2"></i>
+                        Updating the form will rewrite <code>.env</code>. Enable the backup toggle below to keep a
+                        timestamped copy of the current file.
+                    </div>
+                    {% endif %}
+                    <form method="post" class="mt-4">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        {% for field in env_fields %}
+                        <div class="mb-4">
+                            <label class="form-label fw-semibold" for="field-{{ field.key }}">
+                                {{ field.label }}
+                                {% if field.required %}<span class="text-danger" title="Required">*</span>{% endif %}
+                            </label>
+                            {% if field.widget == 'textarea' %}
+                            <textarea class="form-control {% if errors.get(field.key) %}is-invalid{% endif %}"
+                                      id="field-{{ field.key }}"
+                                      name="{{ field.key }}"
+                                      rows="4"
+                                      placeholder="{{ field.placeholder or '' }}">{{ form_data.get(field.key, '') }}</textarea>
+                            {% else %}
+                            <div class="input-group">
+                                <input type="{{ field.input_type }}" class="form-control {% if errors.get(field.key) %}is-invalid{% endif %}"
+                                       id="field-{{ field.key }}"
+                                       name="{{ field.key }}"
+                                       value="{{ form_data.get(field.key, '') }}"
+                                       placeholder="{{ field.placeholder or '' }}">
+                                {% if field.key == 'SECRET_KEY' %}
+                                <button class="btn btn-outline-secondary" type="button" id="generate-secret">
+                                    <i class="fas fa-magic me-1"></i> Generate
+                                </button>
+                                {% endif %}
+                            </div>
+                            {% endif %}
+                            {% if errors.get(field.key) %}
+                            <div class="invalid-feedback d-block">
+                                {{ errors.get(field.key) }}
+                            </div>
+                            {% endif %}
+                            <small class="form-text text-muted">{{ field.description }}</small>
+                        </div>
+                        {% endfor %}
+                        <div class="form-check form-switch mb-4">
+                            <input class="form-check-input" type="checkbox" role="switch" id="backup-switch" name="create_backup" value="yes" checked>
+                            <label class="form-check-label" for="backup-switch">Create a timestamped backup before writing</label>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <a class="btn btn-outline-secondary" href="{{ url_for('login') }}">
+                                <i class="fas fa-arrow-left me-2"></i>Return to login
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save me-2"></i>Save configuration
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <p class="text-muted text-center mt-3 mb-0">
+                Changes take effect after restarting the Docker services or reloading the Flask process.
+            </p>
+        </div>
+    </div>
+</div>
+
+<script>
+const secretButton = document.getElementById('generate-secret');
+if (secretButton) {
+    secretButton.addEventListener('click', async () => {
+        secretButton.disabled = true;
+        secretButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Generating';
+        try {
+            const response = await fetch('{{ url_for('setup_generate_secret') }}', { method: 'POST' });
+            if (!response.ok) {
+                throw new Error('Failed to generate secret key.');
+            }
+            const data = await response.json();
+            const target = document.getElementById('field-SECRET_KEY');
+            if (target) {
+                target.value = data.secret_key;
+                target.classList.remove('is-invalid');
+            }
+        } catch (error) {
+            alert(error.message || 'Unable to generate a secret key.');
+        } finally {
+            secretButton.disabled = false;
+            secretButton.innerHTML = '<i class="fas fa-magic me-1"></i> Generate';
+        }
+    });
+}
+</script>
+{% endblock %}

--- a/tools/setup_wizard.py
+++ b/tools/setup_wizard.py
@@ -1,0 +1,105 @@
+"""Interactive CLI wrapper around the setup wizard helpers."""
+
+from __future__ import annotations
+
+import sys
+from typing import Dict
+
+from app_utils.setup_wizard import (
+    WIZARD_FIELDS,
+    clean_submission,
+    generate_secret_key,
+    load_wizard_state,
+    write_env_file,
+)
+
+
+class WizardAbort(RuntimeError):
+    """Raised when the operator explicitly aborts the wizard."""
+
+
+def _prompt(message: str, default: str | None = None) -> str:
+    suffix = f" [{default}]" if default else ""
+    while True:
+        response = input(f"{message}{suffix}: ").strip()
+        if not response and default:
+            return default
+        if response.lower() == "exit":
+            raise WizardAbort("Operator aborted the wizard")
+        if response:
+            return response
+        print("A value is required. Type 'exit' to cancel.")
+
+
+def _prompt_yes_no(message: str, default: bool = True) -> bool:
+    default_token = "Y/n" if default else "y/N"
+    while True:
+        response = input(f"{message} [{default_token}]: ").strip().lower()
+        if not response:
+            return default
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        if response == "exit":
+            raise WizardAbort("Operator aborted the wizard")
+        print("Please answer with 'y' or 'n'.")
+
+
+def _collect_answers(defaults: Dict[str, str]) -> Dict[str, str]:
+    answers: Dict[str, str] = {}
+    for field in WIZARD_FIELDS:
+        default_value = defaults.get(field.key, "")
+        if field.key == "SECRET_KEY" and (not default_value or "replace" in default_value.lower()):
+            if _prompt_yes_no("Generate a random Flask SECRET_KEY?", True):
+                default_value = generate_secret_key()
+                print("Generated SECRET_KEY; you may accept or overwrite it.")
+        prompt_message = f"{field.label}"
+        answers[field.key] = _prompt(prompt_message, default_value)
+    return answers
+
+
+def main() -> int:
+    try:
+        state = load_wizard_state()
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
+
+    print("EAS Station setup wizard (CLI)")
+    print("Type 'exit' at any prompt to cancel.\n")
+
+    defaults = state.defaults
+    answers = _collect_answers(defaults)
+
+    try:
+        cleaned = clean_submission(answers)
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        print(f"Validation failed: {exc}")
+        if hasattr(exc, "errors"):
+            for key, message in exc.errors.items():
+                print(f" - {key}: {message}")
+        return 1
+
+    create_backup = _prompt_yes_no("Backup existing .env if present?", True)
+
+    try:
+        destination = write_env_file(state=state, updates=cleaned, create_backup=create_backup)
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        print(f"Failed to write .env: {exc}")
+        return 1
+
+    if destination.name.startswith(".env.backup"):
+        print(f"Backup created at {destination}")
+        print("New configuration written to .env")
+    else:
+        print(f"Configuration written to {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except WizardAbort:
+        print("Setup wizard cancelled.")
+        raise SystemExit(1)

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -15,6 +15,7 @@ from . import (
     routes_led,
     routes_monitoring,
     routes_public,
+    routes_setup,
     template_helpers,
 )
 from .routes import alert_verification, eas_compliance
@@ -35,6 +36,7 @@ def iter_route_modules() -> Iterable[RouteModule]:
 
     yield RouteModule("template_helpers", template_helpers.register, requires_logger=False)
     yield RouteModule("routes_public", routes_public.register)
+    yield RouteModule("routes_setup", routes_setup.register)
     yield RouteModule("routes_monitoring", routes_monitoring.register)
     yield RouteModule("routes_alert_verification", alert_verification.register)
     yield RouteModule("routes_eas_compliance", eas_compliance.register)

--- a/webapp/routes_setup.py
+++ b/webapp/routes_setup.py
@@ -1,0 +1,87 @@
+"""Public routes for the web-based setup wizard."""
+
+from __future__ import annotations
+
+from flask import flash, jsonify, redirect, render_template, request, url_for
+
+from app_utils.setup_wizard import (
+    WIZARD_FIELDS,
+    SetupValidationError,
+    clean_submission,
+    format_led_lines_for_display,
+    generate_secret_key,
+    load_wizard_state,
+    write_env_file,
+)
+
+
+def register(app, logger):
+    """Register setup wizard routes on the Flask app."""
+
+    setup_logger = logger.getChild("setup")
+
+    @app.route("/setup", methods=["GET", "POST"])
+    def setup_wizard():
+        try:
+            state = load_wizard_state()
+        except FileNotFoundError as exc:
+            flash(str(exc))
+            return render_template(
+                "setup_wizard.html",
+                env_fields=WIZARD_FIELDS,
+                form_data={},
+                errors={},
+                env_exists=False,
+            )
+
+        defaults = {
+            key: (value or "")
+            for key, value in state.defaults.items()
+        }
+        defaults["DEFAULT_LED_LINES"] = format_led_lines_for_display(
+            defaults.get("DEFAULT_LED_LINES", "")
+        )
+
+        errors = {}
+        form_data = dict(defaults)
+
+        if request.method == "POST":
+            form_data = {
+                field.key: request.form.get(field.key, "")
+                for field in WIZARD_FIELDS
+            }
+            submitted = dict(form_data)
+            if "DEFAULT_LED_LINES" in submitted:
+                submitted["DEFAULT_LED_LINES"] = submitted["DEFAULT_LED_LINES"].replace("\r", "")
+
+            try:
+                cleaned = clean_submission(submitted)
+            except SetupValidationError as exc:
+                errors = exc.errors
+                flash("Please correct the highlighted issues and try again.")
+            else:
+                create_backup = request.form.get("create_backup", "yes") == "yes"
+                try:
+                    write_env_file(state=state, updates=cleaned, create_backup=create_backup)
+                except Exception as exc:  # pragma: no cover - unexpected filesystem errors
+                    setup_logger.exception("Failed to write .env from setup wizard")
+                    flash(f"Unable to update configuration: {exc}")
+                else:
+                    flash("Configuration saved. Restart the stack to load the new settings.")
+                    return redirect(url_for("setup_wizard"))
+
+        return render_template(
+            "setup_wizard.html",
+            env_fields=WIZARD_FIELDS,
+            form_data=form_data,
+            errors=errors,
+            env_exists=state.env_exists,
+        )
+
+    @app.route("/setup/generate-secret", methods=["POST"])
+    def setup_generate_secret():
+        token = generate_secret_key()
+        return jsonify({"secret_key": token})
+
+
+__all__ = ["register"]


### PR DESCRIPTION
## Summary
- expose a shared setup utility module and `/setup` route to collect configuration and write the `.env`
- build a browser-based wizard UI with secret generation, validation messaging, and optional backups
- document the new onboarding flow and surface the wizard link from the login screen

## Testing
- pytest tests/test_release_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_6905528a6bc08320ae562b60b105614b