### PR TITLE
Document dependency attribution in docs and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ tracks releases under the 2.x series.
 - Distributed a `docker-compose.embedded-db.yml` overlay so application services
   can either rely on the bundled `alerts-db` PostGIS container or connect to an
   existing deployment without editing the primary compose file.
+- Documented open-source dependency attributions in the docs and surfaced
+  maintainers, licenses, and usage details on the in-app About page.
 ### Changed
 - Documented the release governance workflow across the README, ABOUT page, Terms of Use, master roadmap, and site footer so version numbering, changelog discipline, and regression verification remain mandatory for every contribution.
 - Suppressed automatic EAS generation for Special Weather Statements and Dense Fog Advisories to align with standard activation practices.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ EAS Station is not just an alert monitor—it's a **complete emergency broadcast
 - [⚖️ Terms of Use](TERMS_OF_USE.md) – Development-only license terms, acceptable use, and critical safety disclaimers.
 - [🛡️ Privacy Policy](PRIVACY_POLICY.md) – Guidance for handling configuration data, test records, and optional integrations.
 - [🗂️ Master Implementation Roadmap](docs/master_todo.md) – Drop-in replacement requirements with implementation plans that map the path to hardware parity and production readiness.
+- [📦 Open-Source Dependency Attribution](docs/dependency_attribution.md) – Maintainer, license, and usage overview for every Python library bundled with the project.
 - In-app versions of both guides are reachable from the navigation bar via the new <strong>About</strong> and <strong>Help</strong> pages for quick operator reference.
 
 ---

--- a/docs/dependency_attribution.md
+++ b/docs/dependency_attribution.md
@@ -1,0 +1,33 @@
+# Open-Source Dependency Attribution
+
+The EAS Station application is built entirely on open-source libraries. The table below lists each Python dependency, its primary maintainers, licensing, and how the project uses it.
+
+| Library & Version | Upstream Project / Maintainers | License | Purpose in EAS Station |
+| --- | --- | --- | --- |
+| Flask 3.0.3 | Pallets Projects (founded by Armin Ronacher) | BSD-3-Clause | Core web framework powering the operator UI and REST API. |
+| Flask-SQLAlchemy 3.1.1 | Pallets Projects | BSD-3-Clause | Integrates SQLAlchemy ORM with Flask’s application context and configuration system. |
+| Werkzeug 3.0.6 | Pallets Projects | BSD-3-Clause | Supplies the WSGI utilities and request/response handling used by Flask. |
+| SQLAlchemy 2.0.44 | SQLAlchemy authors (led by Mike Bayer) | MIT | Object-relational mapper used for database models, queries, and migrations. |
+| psycopg2-binary 2.9.10 | Psycopg Project (Federico Di Gregorio, Daniele Varrazzo, et al.) | LGPL-3.0 with linking exception | PostgreSQL client driver connecting the application to PostGIS. |
+| GeoAlchemy2 0.15.2 | GeoAlchemy maintainers (Olivier Verdier & contributors) | MIT | Adds spatial column types and functions so PostGIS geometries can be queried through SQLAlchemy. |
+| Alembic 1.14.0 | Mike Bayer & SQLAlchemy community | MIT | Schema migration engine to version-control the database layout. |
+| requests 2.32.3 | Kenneth Reitz & Requests contributors | Apache-2.0 | Fetches CAP feeds, remote APIs, and supporting metadata over HTTP(S). |
+| pytz 2024.2 | Stuart Bishop | MIT | Provides the IANA time zone database for accurate scheduling and timestamps. |
+| psutil 6.1.1 | Giampaolo Rodolà & contributors | BSD-3-Clause | Collects CPU, memory, disk, and network metrics for the system health dashboard. |
+| python-dotenv 1.0.1 | Saurabh Kumar & python-dotenv contributors | BSD-3-Clause | Loads configuration values from the `.env` file during startup and CLI utilities. |
+| gunicorn 23.0.0 | Benoît Chesneau & Gunicorn maintainers | MIT | Production WSGI server that hosts the Flask application. |
+| pyttsx3 2.90 | `nateshmbhat` (Natesh M Bhat) & contributors | BSD-3-Clause | Offline text-to-speech engine used for narrated alert audio when the voice provider is enabled. |
+| scipy 1.11.4 | SciPy community | BSD-3-Clause | Supplies signal-processing helpers for audio resampling when ffmpeg is unavailable. |
+
+## Optional Providers
+
+The following packages are commented in `requirements.txt` and only required when their corresponding features are enabled.
+
+| Library & Version | Upstream Project / Maintainers | License | Optional Purpose |
+| --- | --- | --- | --- |
+| json5 0.9.14 | JSON5 community | MIT | Allows parsing of JSON5 configuration files when environments require them. |
+| python-dateutil 2.8.2 | Dateutil maintainers (led by Gustavo Niemeyer) | BSD-3-Clause | Enhances datetime parsing in integrations that require ISO8601 variations. |
+| azure-cognitiveservices-speech 1.38.0 | Microsoft Azure Cognitive Services team | MIT | Cloud-based speech synthesis provider for narrated alerts. |
+| flask-debugtoolbar 0.13.1 | Flask DebugToolbar maintainers | BSD-3-Clause | Development-only debugging overlay. |
+
+All dependencies are sourced from public repositories published under OSI-approved licenses. Ensure that attribution for BSD and MIT packages accompanies any redistribution of EAS Station binaries or container images.

--- a/templates/about.html
+++ b/templates/about.html
@@ -368,6 +368,153 @@
                 </div>
             </div>
 
+            <!-- Open-Source Dependencies -->
+            <div class="card shadow-sm mb-4 border-0">
+                <div class="card-body p-4">
+                    <h2 class="h4 mb-3">
+                        <i class="fas fa-heart text-danger me-2"></i>Open-Source Libraries
+                    </h2>
+                    <p class="mb-4">Every core feature of EAS Station relies on open-source projects. We gratefully acknowledge the maintainers behind the libraries that power the platform.</p>
+                    <div class="table-responsive mb-4">
+                        <table class="table table-sm align-middle">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Library</th>
+                                    <th scope="col">Maintainers</th>
+                                    <th scope="col">License</th>
+                                    <th scope="col">Purpose</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th scope="row">Flask 3.0.3</th>
+                                    <td>Pallets Projects (Armin Ronacher &amp; team)</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Primary web framework for the operator dashboard and REST API.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Flask-SQLAlchemy 3.1.1</th>
+                                    <td>Pallets Projects</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Bridges SQLAlchemy sessions into the Flask application context.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Werkzeug 3.0.6</th>
+                                    <td>Pallets Projects</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>WSGI utilities that handle request routing, responses, and security helpers.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">SQLAlchemy 2.0.44</th>
+                                    <td>SQLAlchemy community (led by Mike Bayer)</td>
+                                    <td>MIT</td>
+                                    <td>ORM and query toolkit driving database models, relationships, and migrations.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">psycopg2-binary 2.9.10</th>
+                                    <td>Psycopg Project</td>
+                                    <td>LGPL-3.0 w/ linking exception</td>
+                                    <td>PostgreSQL/PostGIS driver for database connectivity.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">GeoAlchemy2 0.15.2</th>
+                                    <td>GeoAlchemy maintainers</td>
+                                    <td>MIT</td>
+                                    <td>Spatial column types and functions for PostGIS-backed geometry queries.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Alembic 1.14.0</th>
+                                    <td>Mike Bayer &amp; SQLAlchemy contributors</td>
+                                    <td>MIT</td>
+                                    <td>Migration engine that versions schema changes alongside application updates.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">requests 2.32.3</th>
+                                    <td>Kenneth Reitz &amp; contributors</td>
+                                    <td>Apache-2.0</td>
+                                    <td>Fetches NOAA, IPAWS, and auxiliary CAP feeds over HTTP(S).</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">pytz 2024.2</th>
+                                    <td>Stuart Bishop</td>
+                                    <td>MIT</td>
+                                    <td>Provides authoritative IANA timezone data for alert scheduling.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">psutil 6.1.1</th>
+                                    <td>Giampaolo Rodolà &amp; contributors</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Collects CPU, memory, disk, and network metrics for the system health view.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">python-dotenv 1.0.1</th>
+                                    <td>Saurabh Kumar &amp; community</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Loads configuration from the <code>.env</code> file for the web app and CLI tools.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">gunicorn 23.0.0</th>
+                                    <td>Benoît Chesneau &amp; maintainers</td>
+                                    <td>MIT</td>
+                                    <td>Production WSGI HTTP server that runs the Flask application.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">pyttsx3 2.90</th>
+                                    <td>Natesh M Bhat &amp; contributors</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Offline text-to-speech engine for narrated alert audio.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">SciPy 1.11.4</th>
+                                    <td>SciPy community</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Signal processing utilities used for audio resampling when ffmpeg is unavailable.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Optional Library</th>
+                                    <th scope="col">Maintainers</th>
+                                    <th scope="col">License</th>
+                                    <th scope="col">Optional Feature</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th scope="row">json5 0.9.14</th>
+                                    <td>JSON5 community</td>
+                                    <td>MIT</td>
+                                    <td>Parsing JSON5 configuration files when environments require relaxed JSON syntax.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">python-dateutil 2.8.2</th>
+                                    <td>python-dateutil maintainers</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Enhanced datetime parsing for integrations that emit ISO8601 variations.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">azure-cognitiveservices-speech 1.38.0</th>
+                                    <td>Microsoft Azure Cognitive Services</td>
+                                    <td>MIT</td>
+                                    <td>Neural cloud narration provider for optional Azure-based voiceovers.</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">flask-debugtoolbar 0.13.1</th>
+                                    <td>Flask DebugToolbar maintainers</td>
+                                    <td>BSD-3-Clause</td>
+                                    <td>Development-only diagnostics overlay for local debugging.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="small text-muted mb-0">All listed packages are published under OSI-approved licenses. Please include appropriate attribution when redistributing EAS Station binaries or container images.</p>
+                </div>
+            </div>
+
             <!-- Key Features -->
             <div class="card shadow-sm mb-4 border-0">
                 <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- add a dedicated dependency attribution document covering maintainers, licenses, and usage
- link the new attribution guide from the README for discoverability
- surface the same dependency and purpose details on the in-app About page for operator reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905f9e3c0688320857ab90218806d38