### PR TITLE
Fix purge action on audio archive page

### DIFF
--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -409,28 +409,48 @@ async function executePurge() {
     }
 
     try {
-        const response = await fetch('/admin/eas_messages/purge', {
+        const response = await fetch('/eas/messages/purge', {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
             },
             body: JSON.stringify(payload)
         });
 
-        const result = await response.json();
-
-        if (response.ok) {
-            showToast(`Successfully deleted ${result.deleted} audio messages`, 'success');
-            // Hide modal
-            const modal = bootstrap.Modal.getInstance(document.getElementById('purgeModal'));
-            modal.hide();
-            // Reload page after a short delay
-            setTimeout(() => {
-                window.location.reload();
-            }, 2000);
-        } else {
-            showToast(result.error || 'Failed to purge audio messages', 'error');
+        let result = {};
+        try {
+            result = await response.json();
+        } catch (parseError) {
+            console.error('Failed to parse purge response:', parseError);
         }
+
+        if (!response.ok) {
+            const errorMessage = result.error || 'Failed to purge audio messages';
+            showToast(errorMessage, 'error');
+            return;
+        }
+
+        const deletedCount = typeof result.deleted === 'number'
+            ? result.deleted
+            : Array.isArray(result.ids)
+                ? result.ids.length
+                : 0;
+        const message = result.message
+            || (deletedCount === 0
+                ? 'No audio messages matched the purge criteria.'
+                : `Successfully deleted ${deletedCount} audio messages.`);
+        const toastType = deletedCount === 0 ? 'info' : 'success';
+        showToast(message, toastType);
+
+        const modalElement = document.getElementById('purgeModal');
+        const modal = modalElement ? bootstrap.Modal.getInstance(modalElement) : null;
+        if (modal) {
+            modal.hide();
+        }
+        setTimeout(() => {
+            window.location.reload();
+        }, 1500);
     } catch (error) {
         console.error('Purge failed:', error);
         showToast('Failed to purge audio messages', 'error');

--- a/templates/base.html
+++ b/templates/base.html
@@ -367,9 +367,25 @@
         /* Toast notifications */
         .toast-container {
             position: fixed;
-            top: 80px;
+            top: 88px;
             right: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            align-items: flex-end;
+            width: min(360px, calc(100vw - 40px));
             z-index: 9999;
+        }
+
+        .toast-container .toast {
+            width: 100%;
+            max-width: 360px;
+            box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.2);
+            word-wrap: break-word;
+        }
+
+        .toast-container .toast .toast-body {
+            word-break: break-word;
         }
 
         /* Responsive design */


### PR DESCRIPTION
## Summary
- route the audio archive purge request through the authenticated /eas/messages API and improve the client feedback handling
- tweak toast styling to avoid navigation overlap when long error messages are shown

## Testing
- pytest tests/test_release_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_69061e18e21c8320b2a26b40650a4cde