### PR TITLE
Add CI badge and document one-button upgrade flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ While the codebase remains hardware-agnostic, the following Raspberry Pi-based s
 
 All documentation and tooling emphasise a guided setup process so integrators can reproduce the build with off-the-shelf components instead of bespoke rack units.
 
+[![CI status](https://github.com/KR8MER/eas-station/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/KR8MER/eas-station/actions/workflows/build.yml)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue?logo=docker)](https://www.docker.com/)
 [![Python 3.12](https://img.shields.io/badge/Python-3.12-blue?logo=python)](https://www.python.org/)
 [![Flask](https://img.shields.io/badge/Flask-2.3-green?logo=flask)](https://flask.palletsprojects.com/)
@@ -165,6 +166,7 @@ EAS Station is not just an alert monitor—it's a **complete emergency broadcast
 - [🛡️ Privacy Policy](docs/policies/PRIVACY_POLICY.md) – Guidance for handling configuration data, test records, and optional integrations.
 - [🗂️ Master Implementation Roadmap](docs/roadmap/master_todo.md) – Drop-in replacement requirements with implementation plans that map the path to hardware parity and production readiness.
 - [📦 Open-Source Dependency Attribution](docs/reference/dependency_attribution.md) – Maintainer, license, and usage overview for every Python library bundled with the project.
+- [🔄 One-Button Upgrade Guide](docs/guides/one_button_upgrade.md) – Connect the CI badge to a single-action Docker refresh workflow for lab and field stations.
 - In-app versions of both guides are reachable from the navigation bar via the new <strong>About</strong> and <strong>Help</strong> pages for quick operator reference.
 
 ---

--- a/docs/guides/one_button_upgrade.md
+++ b/docs/guides/one_button_upgrade.md
@@ -1,0 +1,48 @@
+# One-Button Upgrade Powered by the Docker Build Pipeline
+
+The GitHub Actions workflow at [`.github/workflows/build.yml`](../../.github/workflows/build.yml) builds and publishes a fresh
+`kr8mer/eas-station:latest` image whenever commits reach the `main` branch. You can treat the passing run as the guardrail that
+unlocks a **one-button upgrade** experience for operators who maintain on-premises stations.
+
+## 1. Make sure the pipeline stays green
+
+1. Confirm the CI status badge at the top of the [README](../../README.md) is green before promoting a change.
+2. If the workflow fails, inspect the run logs for container build issues, dependency errors, or Docker Hub authentication
+   problems and fix them before shipping an upgrade.
+
+## 2. Provide a wrapped `docker compose pull` + restart command
+
+The default `docker-compose.yml` runs every service from the `eas-station:latest` tag for both the application and poller
+workers. A single command can refresh the containers to the newest image that Actions just pushed:
+
+```bash
+docker compose pull app poller ipaws-poller
+COMPOSE_PROFILES=embedded-db docker compose up -d --force-recreate app poller ipaws-poller
+```
+
+Wrap those commands in a shell script or a systemd service unit so field operators can execute it with a single click, a kiosk
+button, or a physical GPIO trigger. The script should surface the Git hash and timestamp reported by `docker compose images`
+after the upgrade so operators can confirm the version change.
+
+## 3. Gate upgrades on a passing workflow run
+
+Pair the upgrade button with the status badge link. Before allowing an operator to execute the upgrade script, check the latest
+workflow run using the GitHub REST API or the badge URL:
+
+- Green badge → latest image built successfully and is safe to pull.
+- Red badge → block the upgrade and direct the operator to contact the development team.
+
+## 4. Optional: Publish versioned tags for rollback
+
+The workflow currently ships only the `latest` tag. If you want the button to support rollbacks, extend the
+`docker/build-push-action` step with semantic version tags or short Git hashes. Update the upgrade script to accept a target tag:
+
+```bash
+TARGET_TAG=${1:-latest}
+docker compose pull --quiet "kr8mer/eas-station:${TARGET_TAG}"
+COMPOSE_PROFILES=embedded-db docker compose up -d --force-recreate \
+  --build app poller ipaws-poller
+```
+
+Exposing the tag as a parameter lets operators downgrade to the previous known-good build in one step while keeping the default
+experience to pull the `latest` image.


### PR DESCRIPTION
## Summary
- add the GitHub Actions build badge to the README badge stack
- document how to connect the passing workflow to a one-button Docker upgrade script
- link the new guide from the README documentation index

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690620a2f1e08320b374fdd0809204a1