### PR TITLE
Fix overlapping sidebar cards on index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -505,6 +505,21 @@
             font-size: 1.35rem;
         }
     }
+
+.dashboard-sidebar {
+    display: flex;
+    flex-direction: column;
+}
+
+.dashboard-sidebar > .card + .card {
+    margin-top: var(--spacing-lg);
+}
+
+@media (max-width: 991px) {
+    .dashboard-sidebar > .card + .card {
+        margin-top: var(--spacing-md);
+    }
+}
 </style>
 {% endblock %}
 
@@ -580,7 +595,7 @@
     </div>
 
     <div class="row g-4 align-items-start">
-        <div class="col-lg-4 col-xxl-3 order-2 order-lg-1 d-flex flex-column gap-4">
+        <div class="col-lg-4 col-xxl-3 order-2 order-lg-1 dashboard-sidebar">
             <div class="card control-card sticky-card">
                 <div class="card-header">
                     <h5 class="card-title mb-1 d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- add a dedicated sidebar layout class on the index page
- ensure stacked cards keep consistent spacing across breakpoints to prevent overlap

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69063c15bea48320af60f5b3221ee25a