### PR TITLE
Prevent sidebar cards from overlapping sticky controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -154,6 +154,8 @@
     .sticky-card {
         position: sticky;
         top: 96px;
+        z-index: 2;
+        background-color: var(--surface-color);
     }
 
     .control-card .card-header,
@@ -505,6 +507,21 @@
             font-size: 1.35rem;
         }
     }
+
+.dashboard-sidebar {
+    display: flex;
+    flex-direction: column;
+}
+
+.dashboard-sidebar > .card + .card {
+    margin-top: var(--spacing-lg);
+}
+
+@media (max-width: 991px) {
+    .dashboard-sidebar > .card + .card {
+        margin-top: var(--spacing-md);
+    }
+}
 </style>
 {% endblock %}
 
@@ -580,7 +597,7 @@
     </div>
 
     <div class="row g-4 align-items-start">
-        <div class="col-lg-4 col-xxl-3 order-2 order-lg-1 d-flex flex-column gap-4">
+        <div class="col-lg-4 col-xxl-3 order-2 order-lg-1 dashboard-sidebar">
             <div class="card control-card sticky-card">
                 <div class="card-header">
                     <h5 class="card-title mb-1 d-flex align-items-center gap-2">


### PR DESCRIPTION
## Summary
- elevate the sticky sidebar card so it stays above other dashboard widgets
- ensure the map layers controls keep a solid background while pinned near the top of the viewport

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69063c15bea48320af60f5b3221ee25a