### PR TITLE
Fix KR8MER spelling in documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Timothy Kramer (K8R8MER)
+Copyright (c) 2025 Timothy Kramer (KR8MER)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ EAS Station is not just an alert monitor—it's a **complete emergency broadcast
 
 ## 🏛️ Governance & Contributions
 
-- **License:** Source code is provided under the [MIT License](LICENSE); copyright remains with Timothy Kramer (K8R8MER).
+- **License:** Source code is provided under the [MIT License](LICENSE); copyright remains with Timothy Kramer (KR8MER).
 - **Contribution workflow:** All commits must include a Developer Certificate of Origin sign-off (`Signed-off-by`) as described in the [CONTRIBUTING guide](docs/process/CONTRIBUTING.md).
 - **Roadmap alignment:** Issues and pull requests should call out which drop-in replacement requirement from [`docs/roadmap/master_todo.md`](docs/roadmap/master_todo.md) they advance to keep hardware parity measurable.
 - **Legal notices:** Review the [Terms of Use](docs/policies/TERMS_OF_USE.md) and [Privacy Policy](docs/policies/PRIVACY_POLICY.md) before deploying test systems or sharing data.

--- a/docs/policies/TERMS_OF_USE.md
+++ b/docs/policies/TERMS_OF_USE.md
@@ -30,7 +30,7 @@ _Last updated: January 30, 2025_
 - Those projects are governed by their respective licenses and are not endorsed by, nor affiliated with, EAS Station.
 
 ## 6. Licensing & Contributions
-- The EAS Station source code is released under the [MIT License](../../LICENSE). Copyright remains with Timothy Kramer (K8R8MER).
+- The EAS Station source code is released under the [MIT License](../../LICENSE). Copyright remains with Timothy Kramer (KR8MER).
 - By submitting code, documentation, or other content, contributors agree that their work is provided under the MIT License.
 - All commits must include a Developer Certificate of Origin (DCO) sign-off line (`Signed-off-by`) affirming that the contributor has the right to submit the work under the project license. Instructions are provided in [CONTRIBUTING.md](../process/CONTRIBUTING.md).
 

--- a/docs/process/CONTRIBUTING.md
+++ b/docs/process/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Be respectful and constructive. EAS Station is maintained by volunteers supporti
 
 ## Licensing and Copyright
 
-- The EAS Station source code is released under the [MIT License](../../LICENSE). Timothy Kramer (K8R8MER) retains the project copyright.
+- The EAS Station source code is released under the [MIT License](../../LICENSE). Timothy Kramer (KR8MER) retains the project copyright.
 - By contributing, you agree that your submissions will be licensed under the MIT License and may be redistributed under those terms.
 
 ## Developer Certificate of Origin (DCO)


### PR DESCRIPTION
## Summary
- replace outdated references to "K8R8MER" with the correct spelling "KR8MER" in licensing and documentation files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690644c95a348320a9a56da15a240531