### PR TITLE
Add derived county UGC lookup from FIPS codes

### DIFF
--- a/app_core/location.py
+++ b/app_core/location.py
@@ -258,22 +258,37 @@ def describe_location_reference(
         if not info:
             missing_zones.append(code)
             continue
-        known_zones.append(
-            {
-                "code": info.code,
-                "state_code": info.state_code,
-                "zone_number": info.zone_number,
-                "zone_type": info.zone_type,
-                "name": info.name,
-                "short_name": info.short_name,
-                "label": info.formatted_label(),
-                "cwa": info.cwa,
-                "time_zone": info.time_zone,
-                "fe_area": info.fe_area,
-                "latitude": info.latitude,
-                "longitude": info.longitude,
-            }
-        )
+        zone_details = {
+            "code": info.code,
+            "state_code": info.state_code,
+            "zone_number": info.zone_number,
+            "zone_type": info.zone_type,
+            "name": info.name,
+            "short_name": info.short_name,
+            "label": info.formatted_label(),
+            "cwa": info.cwa,
+            "time_zone": info.time_zone,
+            "fe_area": info.fe_area,
+            "latitude": info.latitude,
+            "longitude": info.longitude,
+        }
+
+        if info.zone_type == "C":
+            same_code = info.same_code or ""
+            fips_code = info.fips_code or (same_code[1:] if len(same_code) == 6 else "")
+            state_fips = info.state_fips or (same_code[1:3] if len(same_code) == 6 else "")
+            county_fips = info.county_fips or (same_code[-3:] if len(same_code) == 6 else "")
+
+            zone_details.update(
+                {
+                    "same_code": same_code,
+                    "fips_code": fips_code,
+                    "state_fips": state_fips,
+                    "county_fips": county_fips,
+                }
+            )
+
+        known_zones.append(zone_details)
 
     same_lookup = get_same_lookup()
     known_fips: List[Dict[str, Any]] = []

--- a/tests/test_location_reference.py
+++ b/tests/test_location_reference.py
@@ -53,7 +53,7 @@ def test_describe_location_reference_includes_zone_and_fips_details(app_context)
             "state_code": "OH",
             "timezone": "America/New_York",
             "fips_codes": ["039137"],
-            "zone_codes": ["OHZ016"],
+            "zone_codes": ["OHZ016", "OHC137"],
             "area_terms": ["PUTNAM COUNTY", "OTTAWA"],
         }
 
@@ -63,10 +63,19 @@ def test_describe_location_reference_includes_zone_and_fips_details(app_context)
         assert snapshot["location"]["state_code"] == "OH"
 
         zones = snapshot["zones"]["known"]
-        assert len(zones) == 1
-        assert zones[0]["code"] == "OHZ016"
-        assert zones[0]["cwa"] == "CLE"
-        assert zones[0]["label"].startswith("OHZ016")
+        assert len(zones) == 2
+        zone_lookup = {zone["code"]: zone for zone in zones}
+
+        assert zone_lookup["OHZ016"]["cwa"] == "CLE"
+        assert zone_lookup["OHZ016"]["label"].startswith("OHZ016")
+
+        county_zone = zone_lookup["OHC137"]
+        assert county_zone["zone_type"] == "C"
+        assert county_zone["same_code"] == "039137"
+        assert county_zone["fips_code"] == "39137"
+        assert county_zone["state_fips"] == "39"
+        assert county_zone["county_fips"] == "137"
+        assert county_zone["label"].startswith("OHC137 – Putnam County")
 
         fips_entries = snapshot["fips"]["known"]
         assert len(fips_entries) == 1

--- a/tests/test_zone_catalog.py
+++ b/tests/test_zone_catalog.py
@@ -224,9 +224,9 @@ def test_zone_code_normalisation_and_lookup(app_context) -> None:
     assert invalid == ["BADCODE"]
 
     known, unknown = split_catalog_members(["ALZ019", "OHC137"])
-    assert known == ["ALZ019"]
-    assert unknown == ["OHC137"]
+    assert known == ["ALZ019", "OHC137"]
+    assert unknown == []
 
     formatted = format_zone_code_list(["ALZ019", "OHC137"])
     assert formatted[0].startswith("ALZ019 – Calhoun")
-    assert formatted[1] == "OHC137"
+    assert formatted[1].startswith("OHC137 – Putnam County")


### PR DESCRIPTION
## Summary
- derive county-based UGC zone entries from the FIPS catalog and merge them into the zone lookup
- surface county SAME and FIPS metadata when describing location references
- extend zone catalog tests to cover county UGC handling

## Testing
- PYTHONPATH=. pytest tests/test_zone_catalog.py tests/test_location_reference.py

------
https://chatgpt.com/codex/tasks/task_e_6906611881e08320a37294577ba9cb41