### PR TITLE
Auto-populate county UGC codes from FIPS selections

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1197,6 +1197,7 @@
         let easLastResponse = null;
         let selectedSameCodes = [];
         let locationFipsSelection = [];
+        let locationDerivedZoneCodes = new Set();
 
         const sanitizeBoundaryTypeInput = (value) => {
             if (!value) {
@@ -2417,6 +2418,79 @@
             };
         }
 
+        function normalizeZoneCode(value) {
+            if (value === undefined || value === null) {
+                return '';
+            }
+            const trimmed = value.toString().trim().toUpperCase();
+            if (!trimmed) {
+                return '';
+            }
+            return trimmed.replace(/[^A-Z0-9]/g, '');
+        }
+
+        function deriveCountyZoneCodes(fipsCodes) {
+            const derived = new Set();
+            if (!Array.isArray(fipsCodes)) {
+                return Array.from(derived);
+            }
+            fipsCodes.forEach((code) => {
+                const details = getSameCodeDetails(code);
+                if (!details || !details.stateAbbr || !details.countyFips || details.isStatewide) {
+                    return;
+                }
+                const suffix = details.countyFips.replace(/[^0-9]/g, '').padStart(3, '0').slice(-3);
+                if (!suffix || suffix === '000') {
+                    return;
+                }
+                const stateAbbr = (details.stateAbbr || '').toUpperCase();
+                if (!/^[A-Z]{2}$/.test(stateAbbr)) {
+                    return;
+                }
+                derived.add(`${stateAbbr}C${suffix}`);
+            });
+            return Array.from(derived).sort();
+        }
+
+        function syncZoneCodeFieldWithDerived() {
+            const field = document.getElementById('locationZoneCodes');
+            if (!field) {
+                return;
+            }
+            const existingTokens = parseListInput(field.value);
+            const normalizedDerived = new Set(Array.from(locationDerivedZoneCodes).map(normalizeZoneCode).filter(Boolean));
+            const manualTokens = [];
+            const seenManual = new Set();
+
+            existingTokens.forEach((token) => {
+                const normalized = normalizeZoneCode(token);
+                if (!normalized || normalizedDerived.has(normalized)) {
+                    return;
+                }
+                if (!seenManual.has(normalized)) {
+                    seenManual.add(normalized);
+                    manualTokens.push(normalized);
+                }
+            });
+
+            const derivedTokens = Array.from(normalizedDerived).sort();
+            const combined = manualTokens.concat(derivedTokens);
+            field.value = combined.join('\n');
+
+            if (locationSettingsCache) {
+                locationSettingsCache.zone_codes = combined.slice();
+            }
+            if (window.APP_LOCATION) {
+                window.APP_LOCATION.zone_codes = combined.slice();
+            }
+        }
+
+        function refreshDerivedZoneCodesFromSelection() {
+            const derived = deriveCountyZoneCodes(locationFipsSelection);
+            locationDerivedZoneCodes = new Set(derived.map(normalizeZoneCode).filter(Boolean));
+            syncZoneCodeFieldWithDerived();
+        }
+
         function populatePortionOptions() {
             const portionSelect = document.getElementById('easPortionSelect');
             if (!portionSelect) {
@@ -3538,6 +3612,7 @@
                 window.APP_LOCATION.fips_codes = locationFipsSelection.slice();
                 window.APP_LOCATION.same_codes = locationFipsSelection.slice();
             }
+            refreshDerivedZoneCodesFromSelection();
         }
 
         function addLocationFipsCode(code) {
@@ -3559,6 +3634,7 @@
                 window.APP_LOCATION.fips_codes = locationFipsSelection.slice();
                 window.APP_LOCATION.same_codes = locationFipsSelection.slice();
             }
+            refreshDerivedZoneCodesFromSelection();
         }
 
         function removeLocationFipsCode(code) {
@@ -3576,6 +3652,7 @@
                 window.APP_LOCATION.fips_codes = locationFipsSelection.slice();
                 window.APP_LOCATION.same_codes = locationFipsSelection.slice();
             }
+            refreshDerivedZoneCodesFromSelection();
         }
 
         function populateLocationFipsStateOptions() {
@@ -4011,6 +4088,7 @@
             if (zoomField) zoomField.value = settings.map_default_zoom ?? '';
             if (ledField) ledField.value = (settings.led_default_lines || []).join('\n');
 
+            refreshDerivedZoneCodesFromSelection();
             updateLocationSettingsStatus('Loaded current configuration.', 'muted');
         }
 

--- a/tests/test_location_reference.py
+++ b/tests/test_location_reference.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import pytest
 from flask import Flask
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
 
 from app_core.extensions import db
-from app_core.location import describe_location_reference
-from app_core.models import NWSZone
+from app_core.location import describe_location_reference, update_location_settings
+from app_core.models import LocationSettings, NWSZone
 from app_core.zones import clear_zone_lookup_cache
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(element, compiler, **kw):
+    return "TEXT"
 
 
 @pytest.fixture
@@ -21,10 +28,12 @@ def app_context(tmp_path):
     with app.app_context():
         engine = db.engine
         NWSZone.__table__.create(bind=engine)
+        LocationSettings.__table__.create(bind=engine)
         clear_zone_lookup_cache()
         yield app
         db.session.remove()
         NWSZone.__table__.drop(bind=engine)
+        LocationSettings.__table__.drop(bind=engine)
     clear_zone_lookup_cache()
 
 
@@ -53,7 +62,7 @@ def test_describe_location_reference_includes_zone_and_fips_details(app_context)
             "state_code": "OH",
             "timezone": "America/New_York",
             "fips_codes": ["039137"],
-            "zone_codes": ["OHZ016"],
+            "zone_codes": ["OHZ016", "OHC137"],
             "area_terms": ["PUTNAM COUNTY", "OTTAWA"],
         }
 
@@ -63,10 +72,19 @@ def test_describe_location_reference_includes_zone_and_fips_details(app_context)
         assert snapshot["location"]["state_code"] == "OH"
 
         zones = snapshot["zones"]["known"]
-        assert len(zones) == 1
-        assert zones[0]["code"] == "OHZ016"
-        assert zones[0]["cwa"] == "CLE"
-        assert zones[0]["label"].startswith("OHZ016")
+        assert len(zones) == 2
+        zone_lookup = {zone["code"]: zone for zone in zones}
+
+        assert zone_lookup["OHZ016"]["cwa"] == "CLE"
+        assert zone_lookup["OHZ016"]["label"].startswith("OHZ016")
+
+        county_zone = zone_lookup["OHC137"]
+        assert county_zone["zone_type"] == "C"
+        assert county_zone["same_code"] == "039137"
+        assert county_zone["fips_code"] == "39137"
+        assert county_zone["state_fips"] == "39"
+        assert county_zone["county_fips"] == "137"
+        assert county_zone["label"].startswith("OHC137 – Putnam County")
 
         fips_entries = snapshot["fips"]["known"]
         assert len(fips_entries) == 1
@@ -81,6 +99,31 @@ def test_describe_location_reference_includes_zone_and_fips_details(app_context)
         sources = snapshot.get("sources", [])
         assert any(item.get("path") == "assets/pd01005007curr.pdf" for item in sources)
         assert any(item.get("url") == "https://www.weather.gov/gis/PublicZones" for item in sources)
+
+
+def test_update_location_settings_infers_county_zones(app_context):
+    with app_context.app_context():
+        clear_zone_lookup_cache()
+
+        result = update_location_settings(
+            {
+                "county_name": "Allen County",
+                "state_code": "OH",
+                "timezone": "America/New_York",
+                "fips_codes": ["039003", "039137"],
+                "zone_codes": [],
+                "area_terms": ["ALLEN COUNTY"],
+            }
+        )
+
+        assert "OHC003" in result["zone_codes"]
+        assert "OHC137" in result["zone_codes"]
+        assert result["zone_codes"].count("OHC137") == 1
+
+        stored = LocationSettings.query.first()
+        assert stored is not None
+        assert "OHC003" in stored.zone_codes
+        assert "OHC137" in stored.zone_codes
 
 
 def test_describe_location_reference_flags_unknown_zones(app_context):

--- a/tests/test_zone_catalog.py
+++ b/tests/test_zone_catalog.py
@@ -224,9 +224,9 @@ def test_zone_code_normalisation_and_lookup(app_context) -> None:
     assert invalid == ["BADCODE"]
 
     known, unknown = split_catalog_members(["ALZ019", "OHC137"])
-    assert known == ["ALZ019"]
-    assert unknown == ["OHC137"]
+    assert known == ["ALZ019", "OHC137"]
+    assert unknown == []
 
     formatted = format_zone_code_list(["ALZ019", "OHC137"])
     assert formatted[0].startswith("ALZ019 – Calhoun")
-    assert formatted[1] == "OHC137"
+    assert formatted[1].startswith("OHC137 – Putnam County")


### PR DESCRIPTION
## Summary
- derive county UGC codes from the selected SAME/FIPS counties when persisting location settings
- auto-populate the NOAA zone textarea in the admin console whenever counties are added or removed
- add regression coverage for the new derivation logic with a JSONB shim for sqlite-based tests

## Testing
- PYTHONPATH=. pytest tests/test_location_reference.py tests/test_zone_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_6906611881e08320a37294577ba9cb41