### PR TITLE
Add logo and legal warnings to the about page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -8,7 +8,7 @@
             <div class="card shadow-sm mb-4 border-0">
                 <div class="card-body p-4 p-md-5">
                     <div class="text-center mb-4">
-                        <i class="fas fa-broadcast-tower fa-4x text-primary mb-3"></i>
+                        <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 240px;">
                         <h1 class="display-5 fw-bold mb-3">About EAS Station</h1>
                         <p class="lead text-muted">Software-defined drop-in replacement for commercial EAS encoder/decoders built on Raspberry Pi-class hardware</p>
                     </div>
@@ -19,6 +19,24 @@
                             commercial encoder/decoders but remains experimental. It is <em>not yet</em> FCC-certified, is <em>not</em>
                             ready for production deployment, and must only be evaluated in controlled lab and training
                             environments until certification paths are explored.
+                        </div>
+                    </div>
+                    <div class="alert alert-danger d-flex align-items-start" role="alert">
+                        <i class="fas fa-person-circle-exclamation fa-lg me-3"></i>
+                        <div>
+                            <strong>Legal Compliance Warning:</strong> EAS Station generates <em>valid</em> Emergency Alert System (EAS) SAME headers, attention tones, and audio. Broadcasting, transmitting, or otherwise leaking these signals on-air or over monitored paths without explicit authorization is a violation of FCC rules and may trigger Primary Entry Points, Local Primaries, and other downstream facilities. Always work inside shielded test environments and never connect experimental output to production RF, STL, or streaming chains.
+                        </div>
+                    </div>
+                    <div class="alert alert-secondary d-flex align-items-start" role="alert">
+                        <i class="fas fa-scale-balanced fa-lg me-3"></i>
+                        <div>
+                            <strong>Real-World Consequences:</strong> The FCC has repeatedly issued six-figure penalties for misusing EAS tones. In 2015, iHeartMedia paid a <a href="https://www.fcc.gov/document/iheartmedia-pays-1-million-misuse-eas-tones" class="link-dark" target="_blank" rel="noopener">$1&nbsp;million consent decree</a> after <em>The Bobby Bones Show</em> triggered false alerts. The trailer for <em>Olympus Has Fallen</em> led to a combined <a href="https://www.fcc.gov/document/companies-pay-19m-misuse-emergency-alert-system-tones" class="link-dark" target="_blank" rel="noopener">$1.9&nbsp;million settlement</a> across multiple national networks. Misuse is traceable, and enforcement actions can include equipment seizure and license revocation.
+                        </div>
+                    </div>
+                    <div class="alert alert-dark d-flex align-items-start" role="alert">
+                        <i class="fas fa-hand-paper fa-lg me-3"></i>
+                        <div>
+                            <strong>Ethics & Accountability:</strong> This project exists to strengthen public warning readiness—not to be weaponized. If you intend to exploit the system for malicious purposes, understand that the maintainer disclaims responsibility for your actions and will cooperate with authorities to ensure accountability. Use this tool responsibly, document your lab safeguards, and treat every generated signal with the gravity of a live alert.
                         </div>
                     </div>
                     <hr class="my-4">


### PR DESCRIPTION
## Summary
- display the new SVG project logo at the top of the About page
- add legal and ethical warnings highlighting that the software emits valid EAS signals
- document FCC enforcement examples to emphasize responsible operation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906b18650ac8320ad30c05875eef53c