### PR TITLE
Fix Python version compatibility for SoapySDR bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim-bookworm
+# Using Python 3.11 to match Debian bookworm's python3-soapysdr bindings
+FROM python:3.11-slim-bookworm
 
 # Prevent Python from writing pyc files and buffering stdout/stderr
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All documentation and tooling emphasise a guided setup process so integrators ca
 
 [![CI status](https://github.com/KR8MER/eas-station/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/KR8MER/eas-station/actions/workflows/build.yml)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue?logo=docker)](https://www.docker.com/)
-[![Python 3.12](https://img.shields.io/badge/Python-3.12-blue?logo=python)](https://www.python.org/)
+[![Python 3.11](https://img.shields.io/badge/Python-3.11-blue?logo=python)](https://www.python.org/)
 [![Flask](https://img.shields.io/badge/Flask-2.3-green?logo=flask)](https://flask.palletsprojects.com/)
 [![Gunicorn](https://img.shields.io/badge/Gunicorn-21.2-green?logo=gunicorn)](https://gunicorn.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-blue?logo=postgresql)](https://www.postgresql.org/)
@@ -311,8 +311,8 @@ Operators can trigger the same workflow from **Admin → System Operations** usi
 | Service | Purpose | Technology |
 |---------|---------|------------|
 | **app** | Web UI & REST API | Flask 2.3, Gunicorn, Bootstrap 5 |
-| **poller** | Background NOAA alert polling | Python 3.12, continuous daemon |
-| **ipaws-poller** | Dedicated IPAWS CAP feed polling | Python 3.12, continuous daemon |
+| **poller** | Background NOAA alert polling | Python 3.11, continuous daemon |
+| **ipaws-poller** | Dedicated IPAWS CAP feed polling | Python 3.11, continuous daemon |
 | *(external service)* | Spatial database | PostgreSQL/PostGIS |
 
 > **Deployment Note:** Host the PostgreSQL/PostGIS database outside of these containers (managed service, dedicated VM, or standalone container). Update the connection variables in `.env` so the application can reach it.
@@ -1148,7 +1148,7 @@ curl http://localhost:5000/health
 ## 📦 Technology Stack
 
 ### Backend
-- **Python 3.12** - Core programming language
+- **Python 3.11** - Core programming language (compatible with Debian bookworm SoapySDR bindings)
 - **Flask 2.3** - Web framework
 - **SQLAlchemy 2.0** - ORM and database toolkit
 - **GeoAlchemy2** - Spatial database extensions for SQLAlchemy
@@ -1171,13 +1171,13 @@ curl http://localhost:5000/health
 - **Docker Engine 24+** - Containerization platform
 - **Docker Compose V2** - Multi-container orchestration
 - **Debian 14 (Trixie) host** - Validated on Raspberry Pi 5 builds running Debian 14.2.0-19 with 64-bit kernel/userspace.
-- **Debian Bookworm slim base image** - Container runtime provided by `python:3.12-slim-bookworm` for reproducible multi-arch builds.
+- **Debian Bookworm slim base image** - Container runtime provided by `python:3.11-slim-bookworm` for reproducible multi-arch builds.
 
 ### Python Release Strategy
 
 - **Latest CPython release:** Python 3.13.0 is the newest upstream stable version.
-- **Why we remain on 3.12 for now:** Critical runtime dependencies such as `scipy==1.14.1` and `pyttsx3==2.90` (see [`requirements.txt`](requirements.txt)) still rely on pre-built wheels for Linux/ARM64. Those wheels have not been published for Python 3.13, so attempting to upgrade forces multi-hour source builds that require large toolchains (Fortran, Rust, and voice synthesis headers) and routinely exhaust Raspberry Pi 5 systems.
-- **Security posture:** The Docker base image tracks Python 3.12 patch releases, and dependency pins are refreshed as security advisories are disclosed. This keeps the runtime on the fully-supported CPython branch without sacrificing reproducible builds on Raspberry Pi hardware.
+- **Why we use Python 3.11:** The application uses Python 3.11 to maintain compatibility with Debian bookworm's pre-compiled SoapySDR bindings (`python3-soapysdr`). All critical dependencies including `scipy==1.14.1` and `pyttsx3==2.90` provide pre-built wheels for Python 3.11 on Linux/ARM64, avoiding multi-hour source builds that would require large toolchains (Fortran, Rust, and voice synthesis headers) and exhaust Raspberry Pi 5 systems.
+- **Security posture:** The Docker base image tracks Python 3.11 patch releases, and dependency pins are refreshed as security advisories are disclosed. This keeps the runtime on a fully-supported CPython branch without sacrificing reproducible builds or SDR functionality on Raspberry Pi hardware.
 
 ---
 

--- a/docs/reference/ABOUT.md
+++ b/docs/reference/ABOUT.md
@@ -4,13 +4,13 @@ EAS Station is a complete Emergency Alert System platform that automates the ing
 
 The long-term vision is to deliver a software-driven, off-the-shelf drop-in replacement for commercial encoder/decoder appliances. Every subsystem is being designed so commodity compute, SDR front-ends, and readily available interfaces can fulfill the same mission as the traditional rack units.
 
-EAS Station’s reference build centers on a Raspberry Pi 5 (4 GB RAM baseline, 8 GB recommended when narration and SDR verification share the host) with HATs that expose dry-contact GPIO relays, RS-232 automation ports, and balanced audio interfaces. HDMI confidence monitoring and paired SDR receivers complete the package, proving that inexpensive, fan-less hardware can shoulder the same responsibilities as the utilitarian “black boxes” sold today. Raspberry Pi 4 systems remain compatible for labs but no longer represent the documented baseline. Deployments are validated on Debian 14 (Trixie) 64-bit builds—specifically 14.2.0-19. The container image remains anchored to Debian Bookworm (`python:3.12-slim-bookworm`) for reproducible multi-architecture builds. The remaining gap is disciplined software integration, a predictable setup experience, long-haul reliability, and the evidence required to pursue FCC certification.
+EAS Station’s reference build centers on a Raspberry Pi 5 (4 GB RAM baseline, 8 GB recommended when narration and SDR verification share the host) with HATs that expose dry-contact GPIO relays, RS-232 automation ports, and balanced audio interfaces. HDMI confidence monitoring and paired SDR receivers complete the package, proving that inexpensive, fan-less hardware can shoulder the same responsibilities as the utilitarian “black boxes” sold today. Raspberry Pi 4 systems remain compatible for labs but no longer represent the documented baseline. Deployments are validated on Debian 14 (Trixie) 64-bit builds—specifically 14.2.0-19. The container image uses Debian Bookworm (`python:3.11-slim-bookworm`) for reproducible multi-architecture builds with native SoapySDR compatibility. The remaining gap is disciplined software integration, a predictable setup experience, long-haul reliability, and the evidence required to pursue FCC certification.
 
 ### Python Release Strategy
 
 - **Upstream status:** Python 3.13.0 is the newest general-availability CPython release.
-- **Current runtime:** The stack stays on Python 3.12 because key audio and narration dependencies (`scipy==1.14.1`, `pyttsx3==2.90`) only publish Linux/ARM64 wheels for CPython 3.12 and earlier. Attempting to upgrade forces from-source builds that pull heavy Fortran and speech synthesis toolchains, routinely exhausting Raspberry Pi 5 hosts.
-- **Mitigation:** The Docker base image is rebuilt whenever Python 3.12 patch releases land, and pinned dependencies are updated alongside security advisories so we keep receiving CVE fixes without destabilizing the hardware-specific build pipeline.
+- **Current runtime:** The stack uses Python 3.11 to maintain compatibility with Debian bookworm's pre-compiled SoapySDR bindings (`python3-soapysdr`). All key dependencies including `scipy==1.14.1` and `pyttsx3==2.90` provide Linux/ARM64 wheels for Python 3.11, avoiding from-source builds that would pull heavy Fortran and speech synthesis toolchains and exhaust Raspberry Pi 5 hosts.
+- **Mitigation:** The Docker base image is rebuilt whenever Python 3.11 patch releases land, and pinned dependencies are updated alongside security advisories so we keep receiving CVE fixes without destabilizing the hardware-specific build pipeline or SDR functionality.
 
 ## Safety Notice
 - **Development status:** The project remains experimental and has only been cross-checked against community tools like [multimon-ng](https://github.com/EliasOenal/multimon-ng) for decoding parity. All other implementations, workflows, and documentation are original and subject to change.
@@ -32,7 +32,7 @@ EAS Station’s reference build centers on a Raspberry Pi 5 (4 GB RAM baseli
 The application combines open-source tooling and optional cloud integrations. Versions below match the pinned dependencies in `requirements.txt` unless noted otherwise.
 
 ### Application Framework
-- Python 3.12 runtime
+- Python 3.11 runtime (compatible with Debian bookworm SoapySDR bindings)
 - Flask 3.0.3 web framework
 - Werkzeug 3.0.6 WSGI utilities
 - Flask-SQLAlchemy 3.1.1 ORM integration

--- a/templates/about.html
+++ b/templates/about.html
@@ -318,12 +318,13 @@
                             <div>
                                 <h3 class="h6 fw-bold mb-1 text-info">Python release cadence</h3>
                                 <p class="mb-0 small text-muted">
-                                    Python <strong>3.13.0</strong> is the latest upstream release, but EAS Station remains on
-                                    <strong>Python 3.12</strong> because critical dependencies such as <code>scipy==1.14.1</code>
-                                    and <code>pyttsx3==2.90</code> do not yet ship Linux/ARM64 wheels for CPython&nbsp;3.13. Upgrading
-                                    today would require compiling large Fortran and voice-synthesis toolchains on Raspberry Pi&nbsp;5
-                                    hardware, which routinely fails or takes hours. We instead track every Python&nbsp;3.12 patch
-                                    release inside the Docker base image so security fixes land without sacrificing reproducible builds.
+                                    Python <strong>3.13.0</strong> is the latest upstream release, but EAS Station uses
+                                    <strong>Python 3.11</strong> to maintain compatibility with Debian bookworm's pre-compiled
+                                    SoapySDR bindings (<code>python3-soapysdr</code>). All critical dependencies including
+                                    <code>scipy==1.14.1</code> and <code>pyttsx3==2.90</code> provide Linux/ARM64 wheels for
+                                    Python&nbsp;3.11, avoiding from-source builds that would pull heavy Fortran and voice-synthesis
+                                    toolchains and exhaust Raspberry Pi&nbsp;5 hardware. We track Python&nbsp;3.11 patch releases
+                                    inside the Docker base image so security fixes land without sacrificing reproducible builds or SDR functionality.
                                 </p>
                             </div>
                         </div>
@@ -335,7 +336,7 @@
                                 <i class="fas fa-server me-2"></i>Backend & Core Services
                             </h3>
                             <ul class="list-unstyled">
-                                <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>Python 3.12+</strong> - Core application language</li>
+                                <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>Python 3.11</strong> - Core application language (compatible with Debian bookworm SoapySDR)</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>Flask 3.x</strong> - Web framework with Werkzeug WSGI</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>Gunicorn</strong> - Production WSGI HTTP server</li>
                                 <li class="mb-2"><i class="fas fa-chevron-right text-muted me-2"></i><strong>SQLAlchemy 2.x</strong> - Database ORM and query builder</li>


### PR DESCRIPTION
Switch from Python 3.12 to Python 3.11 to resolve binary incompatibility with Debian bookworm's SoapySDR packages.

Issue: The python3-soapysdr package from Debian bookworm compiles bindings for Python 3.11, but the Docker image was using python:3.12-slim-bookworm. This caused import failures because only SoapySDR.cpython-311-*.so files were present, making them incompatible with Python 3.12.

Solution: Use python:3.11-slim-bookworm as the base image to match the system Python version that SoapySDR bindings are compiled against.

Changes:
- Dockerfile: Switch to python:3.11-slim-bookworm base image
- README.md: Update all Python version references and badges to 3.11
- docs/reference/ABOUT.md: Update Python version and runtime strategy
- templates/about.html: Update Python version in web UI documentation

All dependencies (scipy, pyttsx3, numpy, etc.) are fully compatible with Python 3.11 and provide pre-built wheels for Linux/ARM64, so this change has no negative impact on functionality while enabling native SDR support.