### PR TITLE
Remove apt upgrade step from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Install system dependencies required for psycopg2, GeoAlchemy, and SoapySDR
 RUN apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \


### PR DESCRIPTION
## Summary
- stop running `apt-get upgrade` during the Docker build to keep image builds fast and reliable in Portainer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907be845fa88320b61c3a2f0a098517