### PR TITLE
Reduce excessive whitespace in admin tabs

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -68,7 +68,7 @@
         }
 
         .tab-content-custom {
-            padding: 2rem;
+            padding: 1rem 2rem 2rem 2rem;
             min-height: 400px;
         }
 
@@ -282,7 +282,7 @@
             }
 
             .tab-content-custom {
-                padding: 1rem;
+                padding: 0.75rem 1rem 1rem 1rem;
             }
         }
 


### PR DESCRIPTION
SuperNinja AI's Phase 4 migration added excessive padding (2rem = 32px) to the tab-content area, creating a huge gap between tab buttons and content.

Changes:
- Reduced top padding from 2rem to 1rem (32px → 16px) on desktop
- Reduced top padding from 1rem to 0.75rem on mobile
- Kept side/bottom padding at 2rem for adequate spacing

This provides better visual balance while maintaining readable spacing.