### PR TITLE
Fix massive whitespace: Close unclosed Page Header divs

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -464,10 +464,11 @@
             <div class="tab-content tab-content-custom" id="adminTabContent">
                 <!-- Upload Tab -->
                 <div class="tab-pane fade show active" id="upload" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-upload text-primary"></i> Upload Boundary Files</h4>
-                    <p class="text-muted">Upload GeoJSON files to add new boundary layers to the system.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-upload text-primary"></i> Upload Boundary Files</h4>
+                        <p class="text-muted">Upload GeoJSON files to add new boundary layers to the system.</p>
+                    </div>
 
                     <form id="uploadForm" enctype="multipart/form-data" class="mt-4">
                         <div class="row">
@@ -528,10 +529,11 @@
 
                 <!-- Preview Tab -->
                 <div class="tab-pane fade" id="preview" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-eye text-info"></i> Preview Data Extraction</h4>
-                    <p class="text-muted">Preview what data will be extracted from your GeoJSON file before uploading.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-eye text-info"></i> Preview Data Extraction</h4>
+                        <p class="text-muted">Preview what data will be extracted from your GeoJSON file before uploading.</p>
+                    </div>
 
                     <form id="previewForm" enctype="multipart/form-data" class="mt-4">
                         <div class="row">
@@ -592,10 +594,11 @@
 
                 <!-- Manage Tab -->
                 <div class="tab-pane fade" id="manage" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-tasks text-success"></i> Manage Boundary Data</h4>
-                    <p class="text-muted">View, edit, and delete existing boundary data in the system.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-tasks text-success"></i> Manage Boundary Data</h4>
+                        <p class="text-muted">View, edit, and delete existing boundary data in the system.</p>
+                    </div>
 
                     <div class="row mt-4">
                         <div class="col-md-8">
@@ -641,14 +644,14 @@
                         </div>
                     </div>
                 </div>
-                </div>
 
                 <!-- Operations Tab -->
                 <div class="tab-pane fade" id="operations" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-tools text-warning"></i> System Operations</h4>
-                    <p class="text-muted">Perform manual system operations and maintenance tasks.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-tools text-warning"></i> System Operations</h4>
+                        <p class="text-muted">Perform manual system operations and maintenance tasks.</p>
+                    </div>
 
                     <div class="operation-grid">
                         <div class="operation-card">
@@ -765,7 +768,6 @@
                         </div>
                     </div>
                 </div>
-                </div>
 
                 <!-- Alert Management Tab -->
                 <div class="tab-pane fade" id="alerts-mgmt" role="tabpanel">
@@ -869,10 +871,11 @@
 
                 <!-- User Management Tab -->
                 <div class="tab-pane fade" id="user-management" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-users-cog text-primary"></i> Administrator Accounts</h4>
-                    <p class="text-muted">Create, reset, and revoke access for control panel users.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-users-cog text-primary"></i> Administrator Accounts</h4>
+                        <p class="text-muted">Create, reset, and revoke access for control panel users.</p>
+                    </div>
 
                     <div class="row g-4 mt-2">
                         <div class="col-lg-5">
@@ -940,14 +943,15 @@
                         </div>
                     </div>
                 </div>
-                </div>
 
                 <!-- Location Settings Tab -->
                 <div class="tab-pane fade" id="location-settings" role="tabpanel">
-                       <!-- Page Header -->
-                       <div class="mb-4">
-                           <h4 class="mb-2"><i class="fas fa-map-marker-alt text-primary"></i> Location Configuration</h4>
-                    <p class="text-muted">Update the jurisdiction, timezone, and NOAA filters used by the system.</p>
+                    <!-- Page Header -->
+                    <div class="mb-4">
+                        <h4 class="mb-2"><i class="fas fa-map-marker-alt text-primary"></i> Location Configuration</h4>
+                        <p class="text-muted">Update the jurisdiction, timezone, and NOAA filters used by the system.</p>
+                    </div>
+
                     <div class="alert alert-warning d-flex align-items-start" role="alert">
                         <i class="fas fa-satellite-dish me-3 mt-1"></i>
                         <div>
@@ -1059,9 +1063,10 @@
                         </div>
                     </form>
                 </div>
-
-                </div>
-                <!-- End of tab-content -->
+            </div>
+            <!-- End of tab-content -->
+            </div>
+            <!-- End of tabs-container -->
 
         <!-- Operation Status -->
         <div id="operationStatus" class="mt-3" style="display: none;"></div>


### PR DESCRIPTION
SuperNinja AI's Phase 4 migration created a catastrophic whitespace issue by adding Page Header <div class="mb-4"> containers but never closing them. This caused each tab to accumulate massive vertical space, getting progressively worse from left to right.

Root cause:
- 6 tabs had unclosed Page Header divs (upload, preview, manage, operations, user-management, location-settings)
- Each unclosed div created a huge container extending down the page
- As you moved right through tabs, the whitespace accumulated

Fixes applied:
1. Properly closed all 6 Page Header divs by moving <p> tags inside and adding </div>
2. Removed 3 redundant closing divs I added earlier (were compensating for unclosed headers)
3. Added missing </div> for tabs-container
4. Fixed indentation throughout for proper structure

Current state: 310 opens / 314 closes (investigating remaining 4 extra closes)

This fixes the "3 page scrolls worth" of whitespace that got worse per tab.