### PR TITLE
Fix HTML structure: Properly close admin-card and reorder endif

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1067,12 +1067,13 @@
             <!-- End of tab-content -->
             </div>
             <!-- End of tabs-container -->
+            {% endif %}
+        </div>
+        <!-- End of admin-card -->
 
         <!-- Operation Status -->
         <div id="operationStatus" class="mt-3" style="display: none;"></div>
     </div>
-
-    {% endif %}
 
     {% if not setup_mode %}
     <!-- Confirmation Modal -->


### PR DESCRIPTION
Moved {% endif %} to close before admin-card container closes. The admin-card that opened at line 363 was never being closed.

Structure now:
- admin-card opens (line 363)
- {% if setup_mode %} opens
  - setup content
- {% else %}
  - tabs-container opens
  - tab-content opens
  - tabs...
  - tab-content closes
  - tabs-container closes
- {% endif %} closes
- admin-card closes

This should fix the remaining structural issues causing whitespace.