### PR TITLE
Fix SQLAlchemy reserved attribute name error

### DIFF
--- a/app_core/migrations/versions/20251103_rename_eas_messages_metadata.py
+++ b/app_core/migrations/versions/20251103_rename_eas_messages_metadata.py
@@ -1,0 +1,53 @@
+"""Rename eas_messages.metadata column to metadata_payload
+
+This migration renames the 'metadata' column in the eas_messages table to
+'metadata_payload' to avoid conflicts with SQLAlchemy's reserved 'metadata'
+attribute when using the Declarative API.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251103_rename_eas_messages_metadata"
+down_revision = "20241210_add_nws_zone_catalog"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Rename metadata column to metadata_payload in eas_messages table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Check if the table exists
+    if "eas_messages" in inspector.get_table_names():
+        columns = [col["name"] for col in inspector.get_columns("eas_messages")]
+
+        # Only rename if the old column exists and the new one doesn't
+        if "metadata" in columns and "metadata_payload" not in columns:
+            op.alter_column(
+                "eas_messages",
+                "metadata",
+                new_column_name="metadata_payload"
+            )
+
+
+def downgrade() -> None:
+    """Revert metadata_payload column back to metadata."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Check if the table exists
+    if "eas_messages" in inspector.get_table_names():
+        columns = [col["name"] for col in inspector.get_columns("eas_messages")]
+
+        # Only rename if the new column exists and the old one doesn't
+        if "metadata_payload" in columns and "metadata" not in columns:
+            op.alter_column(
+                "eas_messages",
+                "metadata_payload",
+                new_column_name="metadata"
+            )

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -209,7 +209,7 @@ class EASMessage(db.Model):
     buffer_audio_data = db.Column(db.LargeBinary)
     text_payload = db.Column(db.JSON, default=dict)
     created_at = db.Column(db.DateTime(timezone=True), default=utc_now)
-    metadata_payload = db.Column("metadata", db.JSON, default=dict)
+    metadata_payload = db.Column(db.JSON, default=dict)
 
     cap_alert = db.relationship(
         "CAPAlert",

--- a/noaa.sql
+++ b/noaa.sql
@@ -125,7 +125,7 @@ CREATE TABLE IF NOT EXISTS eas_messages (
     audio_data BYTEA,
     eom_audio_data BYTEA,
     text_payload JSONB DEFAULT '{}'::jsonb,
-    metadata JSONB DEFAULT '{}'::jsonb,
+    metadata_payload JSONB DEFAULT '{}'::jsonb,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
Resolves the InvalidRequestError that prevented application startup: "Attribute name 'metadata' is reserved when using the Declarative API"

Changes:
- Removed explicit column name "metadata" from EASMessage.metadata_payload definition in app_core/models.py (line 212)
- Created database migration to rename existing 'metadata' columns to 'metadata_payload' in production databases
- Updated noaa.sql schema to use 'metadata_payload' column name

The Python attribute name was already 'metadata_payload', but SQLAlchemy was mapping it to a database column named 'metadata', which conflicts with SQLAlchemy's reserved 'metadata' attribute on declarative base classes.

This fix ensures the database column name matches the Python attribute name, avoiding the reserved name conflict.