### PR TITLE
Fix metadata column mapping to prevent schema drift

### DIFF
--- a/app_core/models.py
+++ b/app_core/models.py
@@ -692,7 +692,8 @@ class AudioSourceMetrics(db.Model):
     timestamp = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False, index=True)
 
     # Additional metadata (JSON)
-    source_metadata = db.Column(JSONB)
+    # Map to existing 'metadata' column to avoid schema drift
+    source_metadata = db.Column('metadata', JSONB)
 
 
 class AudioHealthStatus(db.Model):
@@ -725,7 +726,8 @@ class AudioHealthStatus(db.Model):
     last_update = db.Column(db.DateTime(timezone=True), default=utc_now)
 
     # Additional metadata (JSON)
-    health_metadata = db.Column(JSONB)
+    # Map to existing 'metadata' column to avoid schema drift
+    health_metadata = db.Column('metadata', JSONB)
 
 
 class AudioAlert(db.Model):
@@ -763,7 +765,8 @@ class AudioAlert(db.Model):
     updated_at = db.Column(db.DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
     # Additional metadata (JSON)
-    alert_metadata = db.Column(JSONB)
+    # Map to existing 'metadata' column to avoid schema drift
+    alert_metadata = db.Column('metadata', JSONB)
 
 
 __all__ = [

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -293,7 +293,8 @@ except Exception as e:
         eom_audio_data = Column(LargeBinary)
         text_payload = Column(JSON)
         created_at = Column(DateTime, default=utc_now)
-        metadata_payload = Column('metadata', JSON)
+        # Use metadata_payload column name to match the migration
+        metadata_payload = Column(JSON)
 
     class RadioReceiver(Base):
         __tablename__ = 'radio_receivers'


### PR DESCRIPTION
The previous metadata attribute renaming introduced a critical schema mismatch that would break existing deployments:

1. Audio Models (AudioSourceMetrics, AudioHealthStatus, AudioAlert):
   - Attributes renamed to source_metadata/health_metadata/alert_metadata
   - BUT db.Column() was not mapping to existing 'metadata' column
   - SQLAlchemy would query non-existent columns (e.g., audio_source_metrics.source_metadata)
   - FIX: Map renamed attributes to existing 'metadata' column using db.Column('metadata', JSONB)

2. EASMessage Model in CAP Poller:
   - Previous code: metadata_payload = Column('metadata', JSON)
   - Migration renames column from 'metadata' to 'metadata_payload'
   - Poller would query non-existent 'metadata' column after migration
   - FIX: Use Column(JSON) to reference 'metadata_payload' column directly

This avoids breaking existing deployments and ensures consistency with the 20251103_rename_eas_messages_metadata migration.

Fixes #issue-with-metadata-column-mapping