### PR TITLE
Fix white space issue on admin page

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -12,19 +12,9 @@
             box-shadow: 0 4px 20px var(--shadow-color);
         }
 
-        
-
-        
-
-        
-            border-bottom: 3px solid var(--border-color);
-            background: var(--light-color);
-            border-radius: 12px 12px 0 0;
+        .tab-content {
+            padding: 1.5rem 2rem 2rem 2rem;
         }
-
-        
-
-        
 
         .form-control, .form-select {
             background-color: var(--bg-color);
@@ -180,15 +170,6 @@
         @media (max-width: 768px) {
             .stats-grid, .operation-grid {
                 grid-template-columns: 1fr;
-            }
-
-            
-                padding: 0.75rem 1rem;
-                font-size: 0.9rem;
-            }
-
-            
-                padding: 0.75rem 1rem 1rem 1rem;
             }
         }
 


### PR DESCRIPTION
This addresses the whitespace problems that persisted after PR #311's design system standardization and supersedes SuperNinja AI's earlier fix.

Issues fixed:
1. Remove broken CSS rules with no selectors (orphaned from PR #311)
   - Lines 15-28: Empty rules from removed custom classes
   - Lines 185-192: Orphaned media query rules with no selectors
2. Restore tab-content padding that was lost when .tab-content-custom was removed (padding: 1.5rem 2rem 2rem 2rem)

This eliminates excessive whitespace in the admin tabs while maintaining the Bootstrap standardization from PR #311.

Total cleanup: 19 lines of broken CSS removed, proper spacing restored.