### PR TITLE
Fix broken HTML structure causing massive spacing in admin tabs

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -384,17 +384,14 @@
                                 </div>
                             </div>
                         </div>
-                                            <div class="d-grid gap-2 d-md-flex">
-                                                <button type="submit" class="btn btn-primary">
-                                                    <i class="fas fa-upload"></i> Upload Boundaries
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </div>
-                                </div>
-
-                                <!-- Upload Status -->
-                                <div id="uploadStatus" class="mt-3"></div>
+                        <div class="d-grid gap-2 d-md-flex">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-upload"></i> Upload Boundaries
+                            </button>
+                        </div>
+                    </form>
+                    <!-- Upload Status -->
+                    <div id="uploadStatus" class="mt-3"></div>
                 </div>
 
                 <!-- Preview Tab -->
@@ -439,17 +436,14 @@
                                 </div>
                             </div>
                         </div>
-                                            <div class="d-grid gap-2 d-md-flex">
-                                                <button type="button" class="btn btn-info" onclick="previewExtraction()">
-                                                    <i class="fas fa-eye"></i> Preview Extraction
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </div>
-                                </div>
-
-                                <!-- Preview Results -->
-                                <div id="previewResults" class="mt-4"></div>
+                        <div class="d-grid gap-2 d-md-flex">
+                            <button type="button" class="btn btn-info" onclick="previewExtraction()">
+                                <i class="fas fa-eye"></i> Preview Extraction
+                            </button>
+                        </div>
+                    </form>
+                    <!-- Preview Results -->
+                    <div id="previewResults" class="mt-4"></div>
                 </div>
 
                 <!-- Manage Tab -->
@@ -724,8 +718,6 @@
                                     <small class="text-danger mt-2 d-block">⚠️ Permanently removes historical data</small>
                                 </div>
                             </div>
-                        </div>
-                    </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The actual issue was broken HTML structure, not blank lines. Extra closing divs after forms were prematurely closing tab-panes, causing content to render outside the proper containers and creating massive blank spacing.

Issues fixed:
1. Upload tab: Removed 2 extra closing divs after form, moved uploadStatus div inside the tab-pane where it belongs
2. Preview tab: Removed 2 extra closing divs after form, moved previewResults div inside the tab-pane where it belongs
3. Alert Management tab: Removed 2 orphaned closing divs that had no matching opening tags

The broken structure pattern was:
  </form>
      </div>  <!-- EXTRA - prematurely closes page header -->
  </div>  <!-- EXTRA - prematurely closes tab-pane -->
  <div id="status">...</div>  <!-- Now renders OUTSIDE the tab -->
  </div>  <!-- Tries to close already-closed tab -->

This caused the browser to render orphaned content outside tab containers, creating the massive gray spacing that got progressively worse in later tabs.

Total impact: 24 lines removed, proper HTML structure restored, spacing fixed.