### PR TITLE
Fix modal z-index and lazy initialization issues

### DIFF
--- a/static/css/accessibility.css
+++ b/static/css/accessibility.css
@@ -282,7 +282,7 @@ select:focus,
 
 /* Modal Accessibility */
 .modal {
-    z-index: 1050;
+    z-index: 1055;
 }
 
 .modal-dialog {

--- a/templates/settings/radio.html
+++ b/templates/settings/radio.html
@@ -734,16 +734,14 @@
     // Device Discovery, Diagnostics, and Presets
     // ========================================================================
 
-    const discoveryModal = bootstrap.Modal.getOrCreateInstance(document.getElementById('discoveryModal'));
-    const diagnosticsModal = bootstrap.Modal.getOrCreateInstance(document.getElementById('diagnosticsModal'));
-    const presetsModal = bootstrap.Modal.getOrCreateInstance(document.getElementById('presetsModal'));
-
     const discoverDevicesBtn = document.getElementById('discoverDevicesBtn');
     const runDiagnosticsBtn = document.getElementById('runDiagnosticsBtn');
     const showPresetsBtn = document.getElementById('showPresetsBtn');
 
     // Device Discovery
     discoverDevicesBtn?.addEventListener('click', async () => {
+        const modalElement = document.getElementById('discoveryModal');
+        const discoveryModal = bootstrap.Modal.getOrCreateInstance(modalElement);
         const modalBody = document.getElementById('discoveryModalBody');
         modalBody.innerHTML = `
             <div class="text-center py-4">
@@ -833,6 +831,8 @@
 
     // Run Diagnostics
     runDiagnosticsBtn?.addEventListener('click', async () => {
+        const modalElement = document.getElementById('diagnosticsModal');
+        const diagnosticsModal = bootstrap.Modal.getOrCreateInstance(modalElement);
         const modalBody = document.getElementById('diagnosticsModalBody');
         modalBody.innerHTML = `
             <div class="text-center py-4">
@@ -939,6 +939,8 @@
 
     // Show Presets
     showPresetsBtn?.addEventListener('click', async () => {
+        const modalElement = document.getElementById('presetsModal');
+        const presetsModal = bootstrap.Modal.getOrCreateInstance(modalElement);
         const modalBody = document.getElementById('presetsModalBody');
         modalBody.innerHTML = `
             <div class="text-center py-4">
@@ -1014,7 +1016,10 @@
             return;
         }
 
-        discoveryModal.hide();
+        const discoveryModal = bootstrap.Modal.getInstance(document.getElementById('discoveryModal'));
+        if (discoveryModal) {
+            discoveryModal.hide();
+        }
 
         // Pre-fill the add receiver modal with discovered device info
         document.getElementById('receiverDisplayName').value = device.label || device.product || `${device.driver} Device`;
@@ -1046,7 +1051,10 @@
             return;
         }
 
-        presetsModal.hide();
+        const presetsModal = bootstrap.Modal.getInstance(document.getElementById('presetsModal'));
+        if (presetsModal) {
+            presetsModal.hide();
+        }
 
         // Pre-fill the add receiver modal with preset values
         document.getElementById('receiverDisplayName').value = preset.name;


### PR DESCRIPTION
Fixed two critical issues preventing modals from working on radio settings page:

1. **Z-index conflict (PRIMARY FIX)**: The .modal class in accessibility.css had z-index: 1050, which is the same as Bootstrap's .modal-backdrop. This caused the modal dialog to appear at the same layer or behind the backdrop, making it invisible and unclickable. Changed to z-index: 1055 to ensure modals appear above their backdrops.

2. **Modal initialization**: Changed from pre-initializing modal instances at script load to lazy initialization when buttons are clicked. This prevents timing issues and ensures modals are only created when needed. Updated:
   - discoveryModal (Discover Devices button)
   - diagnosticsModal (Run Diagnostics button)
   - presetsModal (Use Preset button)

   Also updated global functions useDiscoveredDevice() and applyPreset() to
   use getInstance() instead of referencing pre-initialized variables.

The z-index fix resolves the "grayed out unresponsive box" issue where users could see the backdrop but couldn't interact with or close the modal dialogs.