### PR TITLE
Add serial number support for proper SDR device identification

### DIFF
--- a/app_core/migrations/versions/20251104_add_serial_to_radio_receivers.py
+++ b/app_core/migrations/versions/20251104_add_serial_to_radio_receivers.py
@@ -1,0 +1,40 @@
+"""Add serial column to radio_receivers for device identification."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20251104_radio_serial"
+down_revision = "20251103_rename_eas_messages_metadata"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add serial column to radio_receivers table for proper SDR device identification."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Check if table exists
+    if "radio_receivers" in inspector.get_table_names():
+        # Check if column already exists
+        columns = [col["name"] for col in inspector.get_columns("radio_receivers")]
+        if "serial" not in columns:
+            op.add_column(
+                "radio_receivers",
+                sa.Column("serial", sa.String(length=128), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    """Remove serial column from radio_receivers table."""
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    if "radio_receivers" in inspector.get_table_names():
+        columns = [col["name"] for col in inspector.get_columns("radio_receivers")]
+        if "serial" in columns:
+            op.drop_column("radio_receivers", "serial")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -530,6 +530,7 @@ class RadioReceiver(db.Model):
     sample_rate = db.Column(db.Integer, nullable=False)
     gain = db.Column(db.Float)
     channel = db.Column(db.Integer)
+    serial = db.Column(db.String(128))
     auto_start = db.Column(db.Boolean, nullable=False, default=True)
     enabled = db.Column(db.Boolean, nullable=False, default=True)
     notes = db.Column(db.Text)
@@ -564,6 +565,7 @@ class RadioReceiver(db.Model):
             sample_rate=int(self.sample_rate),
             gain=self.gain,
             channel=self.channel,
+            serial=self.serial,
             enabled=bool(self.enabled and self.auto_start),
         )
 

--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -198,13 +198,21 @@ class _SoapySDRReceiver(ReceiverInterface):
         channel = self.config.channel if self.config.channel is not None else 0
 
         args: Dict[str, str] = {"driver": self.driver_hint}
+
+        # Use the device serial number if available for precise device identification
+        if self.config.serial:
+            args["serial"] = self.config.serial
+
+        # Use channel/device_id as fallback identification
+        if self.config.channel is not None:
+            args["device_id"] = str(self.config.channel)
+            # Only set serial from channel if no explicit serial was provided
+            if not self.config.serial:
+                args["serial"] = str(self.config.channel)
+
+        # Label is for human reference only, not device identification
         if self.config.identifier:
             args.setdefault("label", self.config.identifier)
-        # Provide optional hints that some Soapy drivers expect.
-        if self.config.channel is not None:
-            device_id = str(self.config.channel)
-            args.setdefault("device_id", device_id)
-            args.setdefault("serial", device_id)
 
         try:
             device = SoapySDR.Device(args)

--- a/app_core/radio/manager.py
+++ b/app_core/radio/manager.py
@@ -23,6 +23,7 @@ class ReceiverConfig:
     sample_rate: int
     gain: Optional[float] = None
     channel: Optional[int] = None
+    serial: Optional[str] = None
     enabled: bool = True
 
 

--- a/templates/settings/radio.html
+++ b/templates/settings/radio.html
@@ -227,6 +227,11 @@
                             <input type="number" class="form-control" id="receiverChannel" name="channel" min="0">
                         </div>
                         <div class="col-md-6">
+                            <label for="receiverSerial" class="form-label">Device Serial</label>
+                            <input type="text" class="form-control" id="receiverSerial" name="serial" placeholder="Hardware serial number">
+                            <small class="form-text text-muted">Optional: Serial number for precise device identification</small>
+                        </div>
+                        <div class="col-md-6">
                             <label for="receiverNotes" class="form-label">Notes</label>
                             <textarea class="form-control" id="receiverNotes" name="notes" rows="2"></textarea>
                         </div>
@@ -563,6 +568,7 @@
         document.getElementById('receiverSampleRate').value = receiver?.sample_rate ?? '';
         document.getElementById('receiverGain').value = receiver?.gain ?? '';
         document.getElementById('receiverChannel').value = receiver?.channel ?? '';
+        document.getElementById('receiverSerial').value = receiver?.serial ?? '';
         document.getElementById('receiverNotes').value = receiver?.notes ?? '';
         document.getElementById('receiverEnabled').checked = receiver?.enabled !== false;
         document.getElementById('receiverAutoStart').checked = receiver?.auto_start !== false;
@@ -1025,6 +1031,7 @@
         document.getElementById('receiverDisplayName').value = device.label || device.product || `${device.driver} Device`;
         document.getElementById('receiverIdentifier').value = device.serial || `${device.driver}_${deviceIndex}`;
         document.getElementById('receiverDriver').value = device.driver || 'rtlsdr';
+        document.getElementById('receiverSerial').value = device.serial || '';
 
         // Set defaults based on driver
         if (device.driver === 'rtlsdr') {

--- a/webapp/routes_settings_radio.py
+++ b/webapp/routes_settings_radio.py
@@ -29,6 +29,7 @@ def _receiver_to_dict(receiver: RadioReceiver) -> Dict[str, Any]:
         "sample_rate": receiver.sample_rate,
         "gain": receiver.gain,
         "channel": receiver.channel,
+        "serial": receiver.serial,
         "auto_start": receiver.auto_start,
         "enabled": receiver.enabled,
         "notes": receiver.notes,
@@ -121,6 +122,10 @@ def _parse_receiver_payload(payload: Dict[str, Any], *, partial: bool = False) -
                 data["channel"] = parsed_channel
             except Exception:
                 return None, "Channel must be a non-negative integer."
+
+    if "serial" in payload:
+        serial = payload.get("serial")
+        data["serial"] = str(serial).strip() if serial not in (None, "") else None
 
     if "auto_start" in payload or not partial:
         data["auto_start"] = _coerce_bool(payload.get("auto_start"), True)


### PR DESCRIPTION
Fixed SoapySDR device binding issues by adding support for hardware serial numbers throughout the radio receiver stack.

## Root Cause
The system was unable to identify specific SDR devices because:
1. Device discovery found serial numbers but didn't store them
2. ReceiverConfig and RadioReceiver model had no serial field
3. drivers.py incorrectly used channel number as serial (lines 205-207)
4. SoapySDR couldn't identify which specific device to bind to

## Changes

### Backend
- **app_core/radio/manager.py**: Added serial field to ReceiverConfig dataclass
- **app_core/radio/drivers.py**: Rewrote device args logic to:
  - Use serial number as primary device identifier
  - Fall back to channel/device_id if serial not available
  - Properly document that label is for human reference only
- **app_core/models.py**:
  - Added serial column to RadioReceiver model
  - Updated to_receiver_config() to pass serial to ReceiverConfig
- **app_core/migrations/versions/20251104_add_serial_to_radio_receivers.py**:
  - New migration to add serial column to radio_receivers table
  - Includes safe upgrade/downgrade with existence checks

### API
- **webapp/routes_settings_radio.py**:
  - Added serial to _receiver_to_dict() output
  - Added serial parsing to _parse_receiver_payload()
  - Handles serial as optional nullable string field

### Frontend
- **templates/settings/radio.html**:
  - Added "Device Serial" form field in receiver modal
  - Updated openModal() to populate serial field
  - Updated useDiscoveredDevice() to auto-fill serial from discovery
  - Added helpful placeholder text explaining serial's purpose

## Device Binding Logic (drivers.py)
The new binding logic prioritizes identification methods:
1. If serial provided -> use it (most reliable)
2. If channel provided -> use as device_id and fallback serial
3. Label only used for human reference (not device binding)

This ensures SoapySDR can reliably bind to the intended hardware device, preventing "device not found" and "already in use" binding errors.

## Migration
Run: flask db upgrade
The migration safely adds the nullable serial column to existing databases.