### PR TITLE
Fix SoapySDR Docker integration issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ RUN --mount=type=cache,target=/var/lib/apt \
     update-ca-certificates; \
     rm -rf /var/lib/apt/lists/*
 
+# Fix Python binding visibility for SoapySDR
+# Debian's python3-soapysdr installs to /usr/lib/python3/dist-packages
+# but /usr/local/bin/python3 doesn't search this path by default
+RUN mkdir -p /usr/local/lib/python3.11/site-packages \
+    && echo '/usr/lib/python3/dist-packages' > /usr/local/lib/python3.11/site-packages/_deb_distpackages.pth
+
 # Create and set working directory
 WORKDIR /app
 

--- a/app_core/radio/discovery.py
+++ b/app_core/radio/discovery.py
@@ -206,7 +206,8 @@ def check_soapysdr_installation() -> Dict[str, Any]:
         try:
             # Get drivers from enumerated devices
             devices = SoapySDR.Device.enumerate()
-            drivers = set(device.get("driver", "unknown") for device in devices)
+            # Fix: SoapySDRKwargs objects don't have .get() method - cast to dict first
+            drivers = set(dict(device).get("driver", "unknown") for device in devices)
             result["drivers_available"] = sorted(drivers)
             result["total_devices"] = len(devices)
         except Exception as exc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "5000:5000"
     env_file:
       - .env
+    environment:
+      - SDR_ARGS=${SDR_ARGS:-driver=airspy}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     devices:
@@ -22,6 +24,8 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      - SDR_ARGS=${SDR_ARGS:-driver=airspy}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     devices:
@@ -44,6 +48,7 @@ services:
     environment:
       CAP_POLLER_MODE: IPAWS
       CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
+      - SDR_ARGS=${SDR_ARGS:-driver=airspy}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     devices:


### PR DESCRIPTION
- Fix SoapySDRKwargs .get() AttributeError by casting to dict first
- Add .pth file to Dockerfile for Python binding visibility
- Add SDR_ARGS environment variable to docker-compose services
- Ensure Airspy device works correctly inside Docker container

Resolves issues with SoapySDR device enumeration and streaming in Docker