### PR TITLE
Fix Flask Markup import compatibility issue

### DIFF
--- a/webapp/documentation.py
+++ b/webapp/documentation.py
@@ -13,8 +13,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from flask import Flask, render_template, abort, Markup
-from markupsafe import escape
+from flask import Flask, render_template, abort
+from markupsafe import escape, Markup
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
In Flask 2.3+, the Markup class was removed from flask and is now only available in markupsafe. This change updates the import in documentation.py to import Markup from markupsafe instead of flask, resolving the ImportError that was preventing the application from starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency reorganization to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->