### PR TITLE
Fix Alembic migration revision ID mismatch

### DIFF
--- a/app_core/migrations/versions/20251104_add_audio_source_configs.py
+++ b/app_core/migrations/versions/20251104_add_audio_source_configs.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect
 from sqlalchemy.dialects.postgresql import JSONB
 
 
-revision = "20251104_audio_source_configs"
+revision = "20251104_add_audio_source_configs"
 down_revision = "20251104_radio_serial"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
The revision ID in 20251104_add_audio_source_configs.py was incorrectly set to "20251104_audio_source_configs" (missing "add_" prefix), causing a KeyError when the next migration (20251105_add_stream_support_to_receivers) tried to reference it as "20251104_add_audio_source_configs".

This fix corrects the revision ID to match the filename and the expected reference, resolving the migration chain issue.