### PR TITLE
Add migration tools and documentation for missing source_type column

### DIFF
--- a/FIX_SOURCE_TYPE_COLUMN.md
+++ b/FIX_SOURCE_TYPE_COLUMN.md
@@ -1,0 +1,118 @@
+# Fix for Missing source_type Column Error
+
+## Problem
+
+The application is failing with the following error:
+
+```
+sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column radio_receivers.source_type does not exist
+```
+
+This error occurs because the database schema is missing the `source_type` column that was added to the `RadioReceiver` model to support both SDR and streaming radio sources.
+
+## Root Cause
+
+The Alembic migration `20251105_add_stream_support_to_receivers` exists in the codebase but has not been applied to the database. This migration adds:
+
+1. `source_type` column (VARCHAR(16), NOT NULL, default='sdr')
+2. `stream_url` column (VARCHAR(512), nullable)
+3. Makes `driver`, `frequency_hz`, and `sample_rate` columns nullable (since streaming sources don't need these)
+
+## Solutions
+
+You have three options to fix this issue:
+
+### Option 1: Run Alembic Migration (Recommended)
+
+If you're using Docker Compose, the migrations should run automatically on container startup via the `docker-entrypoint.sh` script.
+
+To manually run migrations:
+
+```bash
+# Using Docker Compose
+docker-compose exec app python -m alembic upgrade head
+
+# Or restart the containers to trigger automatic migration
+docker-compose restart app
+```
+
+### Option 2: Use the Standalone Migration Script
+
+A standalone Python script is provided that can apply the migration directly without using Alembic:
+
+```bash
+# Make sure you have database credentials set
+export POSTGRES_HOST=localhost  # or your database host
+export POSTGRES_PASSWORD=your_password
+
+# Run the migration script
+python3 apply_source_type_migration.py
+```
+
+The script will:
+- Check if the migration has already been applied
+- Apply the necessary ALTER TABLE statements
+- Update the alembic_version table
+
+### Option 3: Apply SQL Directly
+
+If you prefer to run the SQL manually, connect to your PostgreSQL database and execute:
+
+```sql
+-- Add source_type column (defaults to 'sdr' for existing records)
+ALTER TABLE radio_receivers
+ADD COLUMN source_type VARCHAR(16) NOT NULL DEFAULT 'sdr';
+
+-- Add stream_url column (nullable)
+ALTER TABLE radio_receivers
+ADD COLUMN stream_url VARCHAR(512);
+
+-- Make these columns nullable since streaming sources don't need them
+ALTER TABLE radio_receivers ALTER COLUMN driver DROP NOT NULL;
+ALTER TABLE radio_receivers ALTER COLUMN frequency_hz DROP NOT NULL;
+ALTER TABLE radio_receivers ALTER COLUMN sample_rate DROP NOT NULL;
+
+-- Update alembic version tracking (optional but recommended)
+DELETE FROM alembic_version;
+INSERT INTO alembic_version (version_num) VALUES ('20251105_add_stream_support_to_receivers');
+```
+
+## Verification
+
+After applying the fix, verify it worked:
+
+```bash
+# Connect to PostgreSQL
+psql -h localhost -U postgres -d alerts
+
+# Check the schema
+\d radio_receivers
+
+# You should see source_type and stream_url columns
+```
+
+Or restart your application - it should start without the "column does not exist" error.
+
+## Files Involved
+
+- **Model Definition**: `/home/user/eas-station/app_core/models.py:520-591` (RadioReceiver class)
+- **Alembic Migration**: `/home/user/eas-station/app_core/migrations/versions/20251105_add_stream_support_to_receivers.py`
+- **Standalone Script**: `/home/user/eas-station/apply_source_type_migration.py`
+- **Entrypoint**: `/home/user/eas-station/docker-entrypoint.sh` (runs migrations automatically)
+
+## Prevention
+
+To prevent this issue in the future:
+
+1. Always run `alembic upgrade head` after pulling new code with migrations
+2. Use the Docker Compose setup which automatically runs migrations on startup
+3. Check the logs when containers start to ensure migrations completed successfully
+
+## Support
+
+If you continue to experience issues:
+
+1. Check the application logs for detailed error messages
+2. Verify database connectivity with the credentials in your `.env` or `stack.env`
+3. Ensure PostgreSQL version is compatible (9.6 or later recommended)
+4. Check that PostGIS extension is installed if using spatial features

--- a/apply_source_type_migration.py
+++ b/apply_source_type_migration.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Standalone script to apply the source_type column migration to radio_receivers table.
+This fixes the error: column radio_receivers.source_type does not exist
+
+Usage:
+    python3 apply_source_type_migration.py
+
+Environment variables (reads from stack.env or can be set manually):
+    POSTGRES_HOST (default: localhost)
+    POSTGRES_PORT (default: 5432)
+    POSTGRES_DB (default: alerts)
+    POSTGRES_USER (default: postgres)
+    POSTGRES_PASSWORD (required)
+
+Or set DATABASE_URL directly:
+    DATABASE_URL=postgresql://user:pass@host:port/dbname python3 apply_source_type_migration.py
+"""
+
+import os
+import sys
+import psycopg2
+from psycopg2 import sql
+from dotenv import load_dotenv
+
+# Try to load from stack.env or .env
+if os.path.exists('stack.env'):
+    load_dotenv('stack.env')
+elif os.path.exists('.env'):
+    load_dotenv('.env')
+
+def get_db_connection():
+    """Get a database connection using environment variables."""
+
+    # Try DATABASE_URL first
+    database_url = os.getenv('DATABASE_URL')
+    if database_url:
+        return psycopg2.connect(database_url)
+
+    # Build from individual variables
+    host = os.getenv('POSTGRES_HOST', 'localhost')
+    port = os.getenv('POSTGRES_PORT', '5432')
+    database = os.getenv('POSTGRES_DB', 'alerts')
+    user = os.getenv('POSTGRES_USER', 'postgres')
+    password = os.getenv('POSTGRES_PASSWORD')
+
+    if not password:
+        print("ERROR: POSTGRES_PASSWORD environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Connecting to database: {user}@{host}:{port}/{database}")
+
+    return psycopg2.connect(
+        host=host,
+        port=port,
+        database=database,
+        user=user,
+        password=password
+    )
+
+def check_column_exists(cursor, table_name, column_name):
+    """Check if a column exists in a table."""
+    cursor.execute("""
+        SELECT EXISTS (
+            SELECT FROM information_schema.columns
+            WHERE table_name = %s
+            AND column_name = %s
+        )
+    """, (table_name, column_name))
+    return cursor.fetchone()[0]
+
+def check_migration_applied(cursor):
+    """Check if the migration has already been applied."""
+    # Check if source_type column exists
+    source_type_exists = check_column_exists(cursor, 'radio_receivers', 'source_type')
+    stream_url_exists = check_column_exists(cursor, 'radio_receivers', 'stream_url')
+
+    return source_type_exists and stream_url_exists
+
+def apply_migration(cursor):
+    """Apply the migration SQL."""
+
+    print("Applying migration: Add source_type and stream_url to radio_receivers...")
+
+    # Add source_type column (defaults to 'sdr' for existing records)
+    print("  - Adding source_type column...")
+    cursor.execute("""
+        ALTER TABLE radio_receivers
+        ADD COLUMN source_type VARCHAR(16) NOT NULL DEFAULT 'sdr'
+    """)
+
+    # Add stream_url column (nullable)
+    print("  - Adding stream_url column...")
+    cursor.execute("""
+        ALTER TABLE radio_receivers
+        ADD COLUMN stream_url VARCHAR(512)
+    """)
+
+    # Make driver nullable (since streams don't need it)
+    print("  - Making driver column nullable...")
+    cursor.execute("""
+        ALTER TABLE radio_receivers
+        ALTER COLUMN driver DROP NOT NULL
+    """)
+
+    # Make frequency_hz nullable
+    print("  - Making frequency_hz column nullable...")
+    cursor.execute("""
+        ALTER TABLE radio_receivers
+        ALTER COLUMN frequency_hz DROP NOT NULL
+    """)
+
+    # Make sample_rate nullable
+    print("  - Making sample_rate column nullable...")
+    cursor.execute("""
+        ALTER TABLE radio_receivers
+        ALTER COLUMN sample_rate DROP NOT NULL
+    """)
+
+    print("Migration applied successfully!")
+
+def update_alembic_version(cursor):
+    """Update the alembic_version table to mark this migration as applied."""
+
+    migration_id = '20251105_add_stream_support_to_receivers'
+
+    # Check if alembic_version table exists
+    cursor.execute("""
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_name = 'alembic_version'
+        )
+    """)
+
+    if not cursor.fetchone()[0]:
+        print("WARNING: alembic_version table does not exist. Migration tracking will not be updated.")
+        return
+
+    # Update or insert the version
+    print(f"Updating alembic_version to: {migration_id}")
+    cursor.execute("DELETE FROM alembic_version")
+    cursor.execute("INSERT INTO alembic_version (version_num) VALUES (%s)", (migration_id,))
+
+def main():
+    """Main execution function."""
+
+    print("=" * 70)
+    print("Radio Receivers Source Type Migration Script")
+    print("=" * 70)
+    print()
+
+    try:
+        # Connect to database
+        conn = get_db_connection()
+        cursor = conn.cursor()
+
+        # Check if migration is already applied
+        if check_migration_applied(cursor):
+            print("Migration has already been applied. Nothing to do.")
+            cursor.close()
+            conn.close()
+            return
+
+        # Apply the migration
+        apply_migration(cursor)
+
+        # Update alembic version
+        update_alembic_version(cursor)
+
+        # Commit changes
+        conn.commit()
+
+        print()
+        print("=" * 70)
+        print("SUCCESS: Migration completed successfully!")
+        print("=" * 70)
+
+        cursor.close()
+        conn.close()
+
+    except psycopg2.Error as e:
+        print()
+        print("=" * 70)
+        print("ERROR: Database error occurred")
+        print("=" * 70)
+        print(f"Error: {e}")
+        print()
+        print("Please check your database connection settings and try again.")
+        sys.exit(1)
+    except Exception as e:
+        print()
+        print("=" * 70)
+        print("ERROR: Unexpected error occurred")
+        print("=" * 70)
+        print(f"Error: {e}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit provides tools and documentation to fix the SQLAlchemy error: "column radio_receivers.source_type does not exist"

Changes:
- Add standalone migration script (apply_source_type_migration.py) that can apply the database migration without requiring Alembic
- Add comprehensive documentation (FIX_SOURCE_TYPE_COLUMN.md) explaining the issue, root cause, and three different solution approaches
- The Alembic migration file already exists at: app_core/migrations/versions/20251105_add_stream_support_to_receivers.py

The migration adds support for streaming radio sources by:
1. Adding source_type column (VARCHAR(16), default='sdr')
2. Adding stream_url column (VARCHAR(512), nullable)
3. Making driver, frequency_hz, and sample_rate nullable

Users can fix the issue by:
1. Running `alembic upgrade head` (recommended)
2. Using the standalone migration script
3. Applying the SQL manually

Fixes the database schema mismatch with the RadioReceiver model defined in app_core/models.py:520-591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing database column for radio receivers, enabling proper configuration and data handling.

* **Documentation**
  * Added comprehensive guide for applying the database schema update, including multiple remediation options, verification steps, and prevention guidance.

* **New Features**
  * Introduced migration utility to apply database updates with automatic validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->