### PR TITLE
Fix documentation 404 errors by correcting docs_root path

### DIFF
--- a/webapp/documentation.py
+++ b/webapp/documentation.py
@@ -184,7 +184,7 @@ def register_documentation_routes(app: Flask, logger_instance: Any) -> None:
     global logger
     logger = logger_instance
 
-    docs_root = Path(app.root_path).parent / 'docs'
+    docs_root = Path(app.root_path) / 'docs'
 
     @app.route('/docs')
     def docs_index():


### PR DESCRIPTION
The documentation routes were generating 404 errors because of an incorrect path calculation in register_documentation_routes(). The function was using `Path(app.root_path).parent / 'docs'` which resolved to `/home/user/docs` instead of the correct `/home/user/eas-station/docs`.

Changed line 187 from:
  docs_root = Path(app.root_path).parent / 'docs'
To:
  docs_root = Path(app.root_path) / 'docs'

This matches the path calculation used in _get_docs_structure() and ensures documentation files are found correctly at /docs and /docs/<path> routes.