### PR TITLE
Fix broken migration chain references

### DIFF
--- a/app_core/migrations/versions/20251105_add_stream_support_to_receivers.py
+++ b/app_core/migrations/versions/20251105_add_stream_support_to_receivers.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '20251105_add_stream_support_to_receivers'
-down_revision = '20251104_audio_source_configs'
+down_revision = '20251104_add_audio_source_configs'
 branch_labels = None
 depends_on = None
 

--- a/app_core/migrations/versions/20251105_add_vfd_tables.py
+++ b/app_core/migrations/versions/20251105_add_vfd_tables.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect
 
 
 revision = "20251105_add_vfd_tables"
-down_revision = "20251104_add_serial_to_radio_receivers"
+down_revision = "20251104_radio_serial"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Fixed incorrect down_revision references in two migration files that were preventing the migration chain from working properly:

1. 20251105_add_vfd_tables.py: Changed down_revision from "20251104_add_serial_to_radio_receivers" to "20251104_radio_serial" to match the actual revision ID

2. 20251105_add_stream_support_to_receivers.py: Changed down_revision from "20251104_audio_source_configs" to "20251104_add_audio_source_configs" to match the actual revision ID

This fixes the error "column radio_receivers.source_type does not exist" by allowing the 20251105_add_stream_support_to_receivers migration to run properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration configuration dependencies to ensure proper upgrade and downgrade paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->