### PR TITLE
Add merge migration to resolve multiple heads

### DIFF
--- a/app_core/migrations/versions/20251105_merge_heads.py
+++ b/app_core/migrations/versions/20251105_merge_heads.py
@@ -1,0 +1,26 @@
+"""Merge migration heads from VFD and stream support branches.
+
+Revision ID: 20251105_merge_heads
+Revises: 20251105_add_stream_support_to_receivers, 20251105_add_vfd_tables
+Create Date: 2025-11-05
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20251105_merge_heads'
+down_revision = ('20251105_add_stream_support_to_receivers', '20251105_add_vfd_tables')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Merge the two migration branches - no schema changes needed."""
+    pass
+
+
+def downgrade():
+    """Downgrade merge - no schema changes needed."""
+    pass


### PR DESCRIPTION
Created a merge migration to resolve the branching migration history caused by two migrations both depending on 20251104_radio_serial:
- 20251105_add_vfd_tables
- 20251105_add_stream_support_to_receivers (via 20251104_add_audio_source_configs)

This merge migration unifies the two branches, allowing Alembic to properly apply all migrations with 'alembic upgrade head'.