### PR TITLE
Fix environment settings UI to read from environment variables

### DIFF
--- a/templates/settings/environment.html
+++ b/templates/settings/environment.html
@@ -235,17 +235,51 @@
 
     // Load categories and variables on page load
     async function loadSettings() {
+        console.log('Loading environment settings...');
         try {
             showLoading();
 
             // Load validation status
+            console.log('Fetching validation status...');
             const validationResp = await fetch('/api/environment/validate');
+            if (!validationResp.ok) {
+                console.error('Validation API failed:', validationResp.status, validationResp.statusText);
+            }
             const validation = await validationResp.json();
+            console.log('Validation result:', validation);
             displayValidation(validation);
 
             // Load all variables
+            console.log('Fetching environment variables...');
             const resp = await fetch('/api/environment/variables');
+            if (!resp.ok) {
+                console.error('Variables API failed:', resp.status, resp.statusText);
+                throw new Error(`API returned ${resp.status}: ${resp.statusText}`);
+            }
             categoriesData = await resp.json();
+            console.log('Loaded categories:', Object.keys(categoriesData));
+
+            // Check for metadata
+            if (categoriesData._meta) {
+                console.log('Environment metadata:', categoriesData._meta);
+                if (!categoriesData._meta.env_file_exists) {
+                    console.warn('.env file does not exist, reading from environment variables');
+
+                    // Show info banner
+                    const banner = document.getElementById('validation-banner');
+                    banner.innerHTML = `
+                        <div class="alert alert-info alert-dismissible fade show">
+                            <i class="fas fa-info-circle"></i>
+                            <strong>No .env File Found</strong>
+                            <p class="mb-0">Reading configuration from environment variables at <code>${categoriesData._meta.env_file_path}</code>.
+                            When you save changes, a .env file will be created automatically to persist your settings.</p>
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    `;
+                }
+                // Remove _meta from categories data
+                delete categoriesData._meta;
+            }
 
             // Store current values
             for (const [catId, catData] of Object.entries(categoriesData)) {
@@ -254,19 +288,38 @@
                 }
             }
 
+            console.log('Rendering UI...');
             renderCategoryNav();
             renderCategories();
 
             // Activate first category
             const firstCat = Object.keys(categoriesData)[0];
             if (firstCat) {
+                console.log('Activating first category:', firstCat);
                 activateCategory(firstCat);
             }
 
             hideLoading();
+            console.log('Environment settings loaded successfully');
         } catch (error) {
             console.error('Error loading settings:', error);
-            showToast('Error loading settings', 'danger');
+
+            // Show detailed error on page
+            const content = document.getElementById('settings-content');
+            if (content) {
+                content.innerHTML = `
+                    <div class="alert alert-danger">
+                        <h4><i class="fas fa-exclamation-triangle"></i> Error Loading Settings</h4>
+                        <p><strong>Error:</strong> ${error.message}</p>
+                        <p>Please check the browser console for more details.</p>
+                        <button class="btn btn-primary" onclick="loadSettings()">
+                            <i class="fas fa-redo"></i> Retry
+                        </button>
+                    </div>
+                `;
+            }
+
+            showToast('Error loading settings: ' + error.message, 'danger');
             hideLoading();
         }
     }

--- a/webapp/admin/environment.py
+++ b/webapp/admin/environment.py
@@ -593,13 +593,22 @@ def get_env_file_path() -> Path:
 
 
 def read_env_file() -> Dict[str, str]:
-    """Read all variables from .env file."""
+    """Read all variables from .env file, or from environment if .env doesn't exist."""
     env_path = get_env_file_path()
     env_vars = {}
 
     if not env_path.exists():
+        # If .env doesn't exist, read from current environment variables
+        # Get all variables we care about from our ENV_CATEGORIES
+        for cat_data in ENV_CATEGORIES.values():
+            for var_config in cat_data['variables']:
+                key = var_config['key']
+                value = os.environ.get(key, '')
+                if value:
+                    env_vars[key] = value
         return env_vars
 
+    # Read from .env file
     with open(env_path, 'r') as f:
         for line in f:
             line = line.strip()
@@ -677,8 +686,12 @@ def register_environment_routes(app, logger):
     @app.route('/api/environment/variables')
     def get_environment_variables():
         """Get all environment variables with current values."""
-        # Read current values from .env
+        # Read current values from .env or environment
         current_values = read_env_file()
+
+        # Check if .env file exists
+        env_path = get_env_file_path()
+        env_file_exists = env_path.exists()
 
         # Build response with categories and variables
         response = {}
@@ -688,8 +701,12 @@ def register_environment_routes(app, logger):
                 var_data = dict(var_config)
                 key = var_config['key']
 
-                # Get current value
-                current_value = current_values.get(key, var_config.get('default', ''))
+                # Get current value from .env file or environment
+                current_value = current_values.get(key, '')
+
+                # If not in .env, try getting from environment
+                if not current_value:
+                    current_value = os.environ.get(key, var_config.get('default', ''))
 
                 # Mask sensitive values
                 if var_config.get('sensitive') and current_value:
@@ -707,6 +724,13 @@ def register_environment_routes(app, logger):
                 'description': cat_data['description'],
                 'variables': variables,
             }
+
+        # Add metadata about .env file status
+        response['_meta'] = {
+            'env_file_exists': env_file_exists,
+            'env_file_path': str(env_path),
+            'reading_from': 'env_file' if env_file_exists else 'environment',
+        }
 
         return jsonify(response)
 
@@ -773,11 +797,21 @@ def register_environment_routes(app, logger):
         issues = []
         warnings = []
 
+        # Check if .env file exists
+        env_path = get_env_file_path()
+        if not env_path.exists():
+            warnings.append({
+                'severity': 'warning',
+                'variable': '.env file',
+                'message': f'.env file does not exist at {env_path}. Reading from environment variables. Create .env file to persist changes.',
+            })
+
         # Check required variables
         for cat_data in ENV_CATEGORIES.values():
             for var_config in cat_data['variables']:
                 key = var_config['key']
-                value = env_vars.get(key, '')
+                # Check both .env and environment
+                value = env_vars.get(key, '') or os.environ.get(key, '')
 
                 # Required field validation
                 if var_config.get('required') and not value:


### PR DESCRIPTION
- Handle case when .env file doesn't exist
- Read from current environment variables as fallback
- Add helpful banner when .env file is missing
- Add metadata to API response about .env file status
- Improve error handling and console logging for debugging
- Show detailed error messages in UI when API calls fail

Fixes: Empty environment settings page when .env file is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment settings now display an info banner indicating when configuration is read from system environment variables instead of a .env file.
  * Added detailed error panels with Retry buttons for improved error recovery.

* **Bug Fixes**
  * Improved validation warnings to clarify configuration sources when .env file is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->