### PR TITLE
Fix incorrect app_utils.timestamp import

### DIFF
--- a/app_core/auth/audit.py
+++ b/app_core/auth/audit.py
@@ -16,7 +16,7 @@ from flask import request, session, current_app
 from sqlalchemy import Column, Integer, String, DateTime, Text, JSON, Index
 
 from app_core.extensions import db
-from app_utils.timestamp import utc_now
+from app_utils import utc_now
 
 
 class AuditAction(Enum):

--- a/app_core/auth/mfa.py
+++ b/app_core/auth/mfa.py
@@ -26,7 +26,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask import current_app
 
 from app_core.extensions import db
-from app_utils.timestamp import utc_now
+from app_utils import utc_now
 
 
 class MFAManager:

--- a/app_core/auth/roles.py
+++ b/app_core/auth/roles.py
@@ -15,7 +15,7 @@ from sqlalchemy import Column, Integer, String, ForeignKey, Table, DateTime, Tex
 from sqlalchemy.orm import relationship
 
 from app_core.extensions import db
-from app_utils.timestamp import utc_now
+from app_utils import utc_now
 
 
 # Association table for many-to-many relationship


### PR DESCRIPTION
Fixed ModuleNotFoundError by correcting imports from non-existent 'app_utils.timestamp' to the correct 'app_utils' module.

The utc_now function is defined in app_utils/time.py and is re-exported from app_utils/__init__.py. The standard pattern in this codebase is to import it as 'from app_utils import utc_now'.

Changes:
- Updated import in app_core/auth/roles.py
- Updated import in app_core/auth/mfa.py
- Updated import in app_core/auth/audit.py

This resolves the second import error preventing the application from starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization updates with no impact to user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->