### PR TITLE
Fix reserved 'metadata' column name in analytics models

### DIFF
--- a/app_core/analytics/aggregator.py
+++ b/app_core/analytics/aggregator.py
@@ -483,7 +483,7 @@ class MetricsAggregator:
                 aggregation_period=aggregation_period,
                 value=relay_rate,
                 sample_count=received_total,
-                metadata={
+                extra_metadata={
                     "received": received_total,
                     "relayed": relayed_total,
                     "auto_relayed": auto_relay_total,

--- a/app_core/analytics/anomaly_detector.py
+++ b/app_core/analytics/anomaly_detector.py
@@ -292,7 +292,7 @@ class AnomalyDetector:
                         baseline_mean=baseline_mean,
                         baseline_stddev=baseline_stddev,
                         description=description,
-                        metadata={
+                        extra_metadata={
                             "percent_change": percent_change * 100,
                             "previous_value": prev_snapshot.value,
                         },
@@ -511,7 +511,7 @@ class AnomalyDetector:
                     baseline_mean=baseline_mean,
                     baseline_stddev=baseline_stddev,
                     description=description,
-                    metadata={
+                    extra_metadata={
                         "previous_direction": previous_trend.trend_direction,
                         "current_direction": current_trend.trend_direction,
                     },

--- a/app_core/analytics/models.py
+++ b/app_core/analytics/models.py
@@ -51,7 +51,8 @@ class MetricSnapshot(db.Model):
     entity_type = db.Column(db.String(50))
 
     # Additional metadata (JSON)
-    metadata = db.Column(JSONB)
+    # NOTE: Using 'extra_metadata' instead of 'metadata' because 'metadata' is reserved by SQLAlchemy
+    extra_metadata = db.Column(JSONB)
 
     # Timestamps
     created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
@@ -92,7 +93,7 @@ class MetricSnapshot(db.Model):
             'sample_count': self.sample_count,
             'entity_id': self.entity_id,
             'entity_type': self.entity_type,
-            'metadata': self.metadata,
+            'metadata': self.extra_metadata,
             'created_at': self.created_at.isoformat() if self.created_at else None,
         }
 
@@ -156,7 +157,8 @@ class TrendRecord(db.Model):
     forecast_confidence = db.Column(db.Float)  # 0.0 to 1.0
 
     # Additional metadata (JSON)
-    metadata = db.Column(JSONB)
+    # NOTE: Using 'extra_metadata' instead of 'metadata' because 'metadata' is reserved by SQLAlchemy
+    extra_metadata = db.Column(JSONB)
 
     # Timestamps
     created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
@@ -209,7 +211,7 @@ class TrendRecord(db.Model):
             'forecast_days_ahead': self.forecast_days_ahead,
             'forecast_value': self.forecast_value,
             'forecast_confidence': self.forecast_confidence,
-            'metadata': self.metadata,
+            'metadata': self.extra_metadata,
             'created_at': self.created_at.isoformat() if self.created_at else None,
         }
 
@@ -281,7 +283,8 @@ class AnomalyRecord(db.Model):
     false_positive_reason = db.Column(db.Text)
 
     # Additional metadata (JSON)
-    metadata = db.Column(JSONB)
+    # NOTE: Using 'extra_metadata' instead of 'metadata' because 'metadata' is reserved by SQLAlchemy
+    extra_metadata = db.Column(JSONB)
 
     # Timestamps
     created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
@@ -343,7 +346,7 @@ class AnomalyRecord(db.Model):
             'resolution_notes': self.resolution_notes,
             'false_positive': self.false_positive,
             'false_positive_reason': self.false_positive_reason,
-            'metadata': self.metadata,
+            'metadata': self.extra_metadata,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/docs/SQLALCHEMY_RESERVED_NAMES.md
+++ b/docs/SQLALCHEMY_RESERVED_NAMES.md
@@ -1,0 +1,107 @@
+# SQLAlchemy Reserved Names and Common Pitfalls
+
+## ⚠️ CRITICAL: Reserved Column Names
+
+**DO NOT** use the following names as column names in SQLAlchemy models. These are reserved by SQLAlchemy's Declarative API and will cause `InvalidRequestError`:
+
+### Reserved Names (DO NOT USE)
+- `metadata` - Reserved by SQLAlchemy for database metadata
+- `query` - Reserved by Flask-SQLAlchemy for query operations
+- `registry` - Reserved by SQLAlchemy's declarative base
+
+### Safe Alternatives
+Instead of these reserved names, use descriptive alternatives:
+
+```python
+# ❌ WRONG - Will cause error
+class MyModel(db.Model):
+    metadata = db.Column(JSONB)  # ERROR: InvalidRequestError
+
+# ✅ CORRECT - Use alternative name
+class MyModel(db.Model):
+    extra_metadata = db.Column(JSONB)  # Safe
+    # OR
+    model_metadata = db.Column(JSONB)   # Safe
+    # OR
+    meta_data = db.Column(JSONB)        # Safe (different name)
+```
+
+## Error Messages
+
+If you use a reserved name, you'll see an error like:
+```
+sqlalchemy.exc.InvalidRequestError: Attribute name 'metadata' is reserved when using the Declarative API.
+```
+
+## Files That Were Fixed
+
+This issue has occurred in the following files (search these if the error resurfaces):
+
+1. **app_core/analytics/models.py**
+   - `MetricSnapshot.extra_metadata` (was `metadata`)
+   - `TrendRecord.extra_metadata` (was `metadata`)
+   - `AnomalyRecord.extra_metadata` (was `metadata`)
+
+## API Compatibility Note
+
+When renaming columns, the `to_dict()` method should still return the expected API key:
+
+```python
+class MetricSnapshot(db.Model):
+    # Database column uses safe name
+    extra_metadata = db.Column(JSONB)
+
+    def to_dict(self):
+        return {
+            # API key can still be 'metadata' for backwards compatibility
+            'metadata': self.extra_metadata,
+        }
+```
+
+This allows the database schema to use safe names while maintaining API compatibility.
+
+## Other SQLAlchemy Reserved Names
+
+While `metadata` is the most common issue, be aware of these other reserved names:
+
+- Any attribute starting with `_sa_` (SQLAlchemy internal)
+- `c` - Column collection shorthand
+- `columns` - Column collection
+- `mapper` - Model mapper
+- `table` - Table reference
+- `__tablename__` - Already used for table name definition
+- `__table__` - The actual table object
+- `__mapper__` - The mapper object
+
+## Best Practices
+
+1. **Prefix data columns** with descriptive names (e.g., `user_metadata`, `extra_metadata`, `config_metadata`)
+2. **Check for errors early** - Run migrations in development before pushing to production
+3. **Use migration scripts** - Always create Alembic migrations for schema changes
+4. **Test imports** - Ensure all models can be imported without errors before deployment
+
+## Quick Fix Checklist
+
+If you encounter the 'metadata' error:
+
+1. [ ] Find the model with the `metadata` column
+2. [ ] Rename column to `extra_metadata` (or similar)
+3. [ ] Update any code that accesses the column directly
+4. [ ] Update `to_dict()` method if present (map `extra_metadata` → `'metadata'` in output)
+5. [ ] Create an Alembic migration to rename the column in existing databases
+6. [ ] Test the migration
+7. [ ] Commit and push the fix
+
+## Related Documentation
+
+- [SQLAlchemy Declarative API](https://docs.sqlalchemy.org/en/14/orm/declarative_styles.html)
+- [Flask-SQLAlchemy Models](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/models/)
+- EAS Station: `docs/DATABASE.md` (if exists)
+
+## History
+
+- **2025-11-05**: Fixed `metadata` column issue in analytics models (commit: TBD)
+  - Changed `MetricSnapshot.metadata` → `MetricSnapshot.extra_metadata`
+  - Changed `TrendRecord.metadata` → `TrendRecord.extra_metadata`
+  - Changed `AnomalyRecord.metadata` → `AnomalyRecord.extra_metadata`
+  - Maintained API compatibility by mapping to 'metadata' key in `to_dict()`


### PR DESCRIPTION
CRITICAL FIX: Renamed 'metadata' column to 'extra_metadata' to avoid SQLAlchemy reserved name conflict.

SQLAlchemy's Declarative API reserves the name 'metadata' for internal use. Using it as a column name causes InvalidRequestError at model definition time, preventing the application from starting.

Changes:
- Renamed MetricSnapshot.metadata → extra_metadata
- Renamed TrendRecord.metadata → extra_metadata
- Renamed AnomalyRecord.metadata → extra_metadata
- Updated model instantiations in aggregator.py
- Updated model instantiations in anomaly_detector.py
- Maintained API compatibility (to_dict() still returns 'metadata' key)
- Added comprehensive documentation in docs/SQLALCHEMY_RESERVED_NAMES.md

The documentation file explains:
- Which names are reserved by SQLAlchemy
- Safe alternatives to use
- How to maintain API compatibility
- Quick fix checklist for future occurrences

This resolves the recurring "Attribute name 'metadata' is reserved" error that prevented database migrations and application startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Resolved internal database naming conflicts to improve system stability and compatibility with database framework requirements.

* **Documentation**
  * Added guidance documentation on naming best practices for database fields and handling reserved terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->