### PR TITLE
Update documentation and todo checklists

### DIFF
--- a/webapp/admin/maintenance.py
+++ b/webapp/admin/maintenance.py
@@ -439,7 +439,8 @@ def retrieve_noaa_alerts(
 def register_maintenance_routes(app, logger):
     """Attach administrative maintenance endpoints to the Flask app."""
 
-    repo_root = Path(app.root_path).resolve().parent
+    # app.root_path is /app inside the container, where stack.env is located
+    repo_root = Path(app.root_path).resolve()
 
     @app.route("/admin/operations/status", methods=["GET"])
     def get_operation_status():


### PR DESCRIPTION
The env_config endpoint was looking for stack.env in the wrong location (/stack.env instead of /app/stack.env) because it was incorrectly using .parent on app.root_path. Since Flask runs from /app inside the container, app.root_path is already /app, so we should not navigate to the parent directory.

This fixes the 404 errors when trying to edit environment variables via the web UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined how the application root directory is resolved during maintenance operations to use the root path directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->