### PR TITLE
Update all logo references to use new EAS SYSTEM wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="static/img/eas-station-logo.svg" alt="EAS Station" width="48" height="48" style="vertical-align: middle;"> EAS Station
+# <img src="static/img/eas-system-wordmark.svg" alt="EAS Station" width="48" height="48" style="vertical-align: middle;"> EAS Station
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-supported-blue.svg)](https://www.docker.com/)
@@ -251,7 +251,7 @@ Professional flowcharts and block diagrams illustrating system architecture and 
 <table>
 <tr>
 <td width="50%">
-<img src="static/img/eas-station-logo.svg" alt="Dashboard" />
+<img src="static/img/eas-system-wordmark.svg" alt="Dashboard" />
 <p align="center"><em>Main Dashboard</em></p>
 </td>
 <td width="50%">

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -3,7 +3,7 @@
     <div class="navbar-container">
         <!-- Brand Section -->
         <a href="{{ url_for('index') }}" class="navbar-brand">
-            <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station" class="brand-logo" width="42" height="42" loading="lazy">
+            <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station" class="brand-logo" width="42" height="42" loading="lazy">
             KR8MER CAP Emergency Alerts
 
             <!-- System Health Indicator -->

--- a/docs/development/AGENTS.md
+++ b/docs/development/AGENTS.md
@@ -34,7 +34,7 @@ When discussing or investigating bugs:
   - `templates/about.html` – System overview and feature descriptions
   - Relevant Markdown files in `docs/` directory
   - This ensures users always have current information about system capabilities
-- **Brand Consistency** – Use `static/img/eas-station-logo.svg` for hero sections, headers, and major UI cards when expanding documentation pages. The logo must remain accessible (include `alt` text).
+- **Brand Consistency** – Use `static/img/eas-system-wordmark.svg` for hero sections, headers, and major UI cards when expanding documentation pages. The logo must remain accessible (include `alt` text).
 - **Mermaid-Friendly Markdown** – GitHub-flavoured Mermaid diagrams are welcome in repository docs. Keep them accurate by naming real modules, packages, and endpoints.
 
 ### Modularity & File Size

--- a/docs/frontend/COMPONENT_LIBRARY.md
+++ b/docs/frontend/COMPONENT_LIBRARY.md
@@ -56,7 +56,7 @@ The primary navigation provides access to main application areas.
   <div class="container-fluid">
     <!-- Logo and Brand -->
     <a class="navbar-brand" href="/">
-      <img src="/static/img/eas-station-logo.svg" alt="EAS Station" height="32">
+      <img src="/static/img/eas-system-wordmark.svg" alt="EAS Station" height="32">
       <span class="brand-text">EAS Station</span>
     </a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,8 @@ docs_dir: docs
 theme:
   name: material
   language: en
-  logo: static/img/eas-station-logo.svg
-  favicon: static/img/eas-station-logo.svg
+  logo: static/img/eas-system-wordmark.svg
+  favicon: static/img/eas-system-wordmark.svg
   palette:
     # Light mode
     - media: "(prefers-color-scheme: light)"

--- a/templates/about.html
+++ b/templates/about.html
@@ -8,7 +8,7 @@
             <div class="card shadow-sm mb-4 border-0">
                 <div class="card-body p-4 p-md-5">
                     <div class="text-center mb-4">
-                        <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 240px;">
+                        <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 240px;">
                         <h1 class="display-5 fw-bold mb-3">About EAS Station</h1>
                         <p class="lead text-muted">Software-defined drop-in replacement for commercial EAS encoder/decoders built on Raspberry Pi-class hardware</p>
                     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,10 +7,10 @@
     <title>{% block title %}EAS Station - Emergency Alert System{% endblock %}</title>
 
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="mask-icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}" color="#204885">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="mask-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" color="#204885">
     <meta name="theme-color" content="#204885">
 
     <!-- Bootstrap CSS -->
@@ -70,7 +70,7 @@
         <div class="container-fluid">
             <div class="navbar-brand-group">
                 <a class="navbar-brand" href="/">
-                    <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station" class="brand-logo" width="42" height="42" loading="lazy">
+                    <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station" class="brand-logo" width="42" height="42" loading="lazy">
                     <span class="brand-text">
                         <span class="brand-title">EAS Station</span>
                         <span class="brand-subtitle">Emergency Alert Platform</span>

--- a/templates/base_new.html
+++ b/templates/base_new.html
@@ -7,10 +7,10 @@
     <title>{% block title %}EAS Station - Emergency Alert System{% endblock %}</title>
 
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}">
-    <link rel="mask-icon" href="{{ url_for('static', filename='img/eas-station-logo.svg') }}" color="#204885">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}">
+    <link rel="mask-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" color="#204885">
     <meta name="theme-color" content="#204885">
 
     <!-- Bootstrap CSS -->
@@ -69,10 +69,10 @@
         <div class="navbar-container">
             <!-- Brand -->
             <a class="navbar-brand" href="/" aria-label="EAS Station Home">
-                <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" 
-                     alt="" 
-                     class="navbar-brand-logo" 
-                     width="36" 
+                <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}"
+                     alt=""
+                     class="navbar-brand-logo"
+                     width="36"
                      height="36">
                 <span class="navbar-brand-text">
                     <span class="navbar-brand-title">EAS Station</span>

--- a/templates/help.html
+++ b/templates/help.html
@@ -7,7 +7,7 @@
             <!-- Header -->
             <div class="card shadow-sm mb-4 border-0">
                 <div class="card-body p-4 p-md-5 text-center">
-                    <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 160px;">
+                    <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 160px;">
                     <i class="fas fa-life-ring fa-3x text-primary mb-3 d-block"></i>
                     <h1 class="display-5 fw-bold mb-3">Help & Operations Guide</h1>
                     <p class="lead text-muted">Complete documentation for operating and maintaining your EAS Station</p>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -7,7 +7,7 @@
             <div class="card shadow-sm border-0 mb-4">
                 <div class="card-body p-4 p-md-5">
                     <div class="text-center mb-4">
-                        <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 140px;">
+                        <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 140px;">
                         <i class="fas fa-user-shield fa-3x text-primary mb-3 d-block"></i>
                         <h1 class="display-6 fw-bold">Privacy Policy</h1>
                         <p class="text-muted mb-0">Last updated: {{ current_time().strftime('%B %d, %Y') }}</p>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -7,7 +7,7 @@
             <div class="card shadow-sm border-0 mb-4">
                 <div class="card-body p-4 p-md-5">
                     <div class="text-center mb-4">
-                        <img src="{{ url_for('static', filename='img/eas-station-logo.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 140px;">
+                        <img src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}" alt="EAS Station logo" class="img-fluid mb-3" style="max-width: 140px;">
                         <i class="fas fa-scale-balanced fa-3x text-primary mb-3 d-block"></i>
                         <h1 class="display-6 fw-bold">Terms of Use</h1>
                         <p class="text-muted mb-0">Last updated: {{ current_time().strftime('%B %d, %Y') }}</p>


### PR DESCRIPTION
Replace eas-station-logo.svg with eas-system-wordmark.svg throughout:
- Front end templates (base.html, base_new.html, navbar component)
- Documentation pages (about, help, privacy, terms)
- README.md and mkdocs.yml
- Developer and component documentation

This ensures the new improved logo from PR #384 is consistently used across all documentation and user-facing interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual branding throughout the application and documentation by deploying a new wordmark asset. The refresh includes updates to the navigation bar, page headers, about/help/privacy/terms pages, documentation sections, and theme configuration. All branding elements have been updated while preserving application layout and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->