### PR TITLE
Update wordmark logo to EAS-STATION and remove frame

### DIFF
--- a/static/img/eas-system-wordmark.svg
+++ b/static/img/eas-system-wordmark.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 600" role="img" aria-label="EAS SYSTEM — Professional Wordmark">
-  <title>EAS SYSTEM Wordmark</title>
-  <desc>Professional emergency alert system wordmark with technical visualization</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 600" role="img" aria-label="EAS-STATION — Professional Wordmark">
+  <title>EAS-STATION Wordmark</title>
+  <desc>Professional emergency alert station wordmark with technical visualization</desc>
 
   <defs>
     <!-- Brand color gradients -->
@@ -83,14 +83,6 @@
     <line x1="1200" y1="0" x2="1200" y2="600"/>
   </g>
 
-  <!-- Corner brackets - modern UI -->
-  <g stroke="url(#accentGrad)" stroke-width="3" fill="none" opacity="0.5" stroke-linecap="round">
-    <path d="M 40,80 L 40,40 L 80,40"/>
-    <path d="M 1520,40 L 1560,40 L 1560,80"/>
-    <path d="M 1560,520 L 1560,560 L 1520,560"/>
-    <path d="M 80,560 L 40,560 L 40,520"/>
-  </g>
-
   <!-- Wordmark with enhanced styling -->
   <g transform="translate(100,180) scale(0.82)" filter="url(#emboss)">
 
@@ -118,51 +110,54 @@
       </g>
     </g>
 
-    <!-- Divider with accent -->
-    <g transform="translate(400,40)">
-      <rect x="0" y="0" width="4" height="60" rx="2" fill="url(#accentGrad)" opacity="0.7">
-        <animate attributeName="opacity" values="0.7;1;0.7" dur="3s" repeatCount="indefinite"/>
+    <!-- Hyphen -->
+    <g transform="translate(400,59)">
+      <rect x="0" y="0" width="40" height="22" rx="4" fill="url(#accentGrad)" opacity="0.8">
+        <animate attributeName="opacity" values="0.8;1;0.8" dur="3s" repeatCount="indefinite"/>
       </rect>
     </g>
 
-    <!-- SYSTEM -->
+    <!-- STATION -->
     <g fill="url(#primaryGrad)">
       <!-- S -->
-      <g transform="translate(432,0)">
-        <path d="M112,28 C112,10 94,0 70,0 H44 C18,0 0,12 0,30 s18,30 44,30 h26 c24,0 42,12 42,30
-                 s-18,30-42,30H44 C18,120 0,140 0,140 h26 c26,0 52,0 68,0 c22,0 44-16 44-38
-                 s-22-38-48-38 H60 C34,64 16,52 16,34 s18-34 44-34h26 c16,0 26,4 26,28z"/>
-      </g>
-
-      <!-- Y -->
-      <g transform="translate(572,0)">
-        <path d="M0,0 H28 L48,44 L68,0 H96 L60,74 V140 H32 V74 Z"/>
-      </g>
-
-      <!-- S -->
-      <g transform="translate(688,0)">
+      <g transform="translate(468,0)">
         <path d="M112,28 C112,10 94,0 70,0 H44 C18,0 0,12 0,30 s18,30 44,30 h26 c24,0 42,12 42,30
                  s-18,30-42,30H44 C18,120 0,140 0,140 h26 c26,0 52,0 68,0 c22,0 44-16 44-38
                  s-22-38-48-38 H60 C34,64 16,52 16,34 s18-34 44-34h26 c16,0 26,4 26,28z"/>
       </g>
 
       <!-- T -->
-      <g transform="translate(828,0)">
+      <g transform="translate(608,0)">
         <rect x="0" y="0" width="128" height="22"/>
         <rect x="52" y="22" width="24" height="118"/>
       </g>
 
-      <!-- E -->
-      <g transform="translate(972,0)">
-        <path d="M0,0 h24 v140 h-24 z"/>
-        <rect x="0" y="0" width="96" height="22"/>
-        <rect x="0" y="59" width="76" height="22"/>
-        <rect x="0" y="118" width="96" height="22"/>
+      <!-- A -->
+      <g transform="translate(764,0)">
+        <path d="M0,140 L42,0 H74 L116,140 H86 L74,100 H42 L30,140 Z"/>
+        <rect x="44" y="80" width="36" height="14"/>
       </g>
 
-      <!-- M -->
+      <!-- T -->
+      <g transform="translate(908,0)">
+        <rect x="0" y="0" width="128" height="22"/>
+        <rect x="52" y="22" width="24" height="118"/>
+      </g>
+
+      <!-- I -->
+      <g transform="translate(1064,0)">
+        <rect x="0" y="0" width="24" height="140"/>
+      </g>
+
+      <!-- O -->
       <g transform="translate(1116,0)">
-        <path d="M0,140 V0 H24 L64,70 L104,0 H128 V140 H104 V52 L64,104 L24,52 V140 Z"/>
+        <path d="M0,70 C0,20 25,0 58,0 C91,0 116,20 116,70 C116,120 91,140 58,140 C25,140 0,120 0,70 Z
+                 M24,70 C24,105 35,118 58,118 C81,118 92,105 92,70 C92,35 81,22 58,22 C35,22 24,35 24,70 Z"/>
+      </g>
+
+      <!-- N -->
+      <g transform="translate(1260,0)">
+        <path d="M0,140 V0 H24 V104 L88,0 H112 V140 H88 V36 L24,140 Z"/>
       </g>
     </g>
   </g>
@@ -309,13 +304,5 @@
       <animate attributeName="y" values="100;500;100" dur="5s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0;0.25;0" dur="5s" repeatCount="indefinite"/>
     </rect>
-  </g>
-
-  <!-- Hexagonal tech elements -->
-  <g stroke="#64748b" stroke-width="1.5" fill="none" opacity="0.3">
-    <polygon points="120,500 140,488 160,500 160,524 140,536 120,524"/>
-    <polygon points="1440,500 1460,488 1480,500 1480,524 1460,536 1440,524"/>
-    <polygon points="120,76 140,64 160,76 160,100 140,112 120,100"/>
-    <polygon points="1440,76 1460,64 1480,76 1480,100 1460,112 1440,100"/>
   </g>
 </svg>


### PR DESCRIPTION
- Changed text from "EAS SYSTEM" to "EAS-STATION"
- Replaced divider with animated hyphen
- Added STATION letters (S, T, A, T, I, O, N)
- Removed corner brackets and hexagonal frame elements
- Clean text-focused design with animations intact