### PR TITLE
Add web stream connection status indicator

### DIFF
--- a/app_core/migrations/versions/20251106_remove_stream_support_from_receivers.py
+++ b/app_core/migrations/versions/20251106_remove_stream_support_from_receivers.py
@@ -1,0 +1,98 @@
+"""Remove stream support from radio receivers
+
+Revision ID: 20251106_remove_stream_support
+Revises: 20251106_add_display_screens
+Create Date: 2025-11-06
+
+Streams are now handled exclusively through the Audio Ingestion system.
+RadioReceiver is refocused on SDR hardware configuration only.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20251106_remove_stream_support'
+down_revision = '20251106_add_display_screens'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Remove stream support from radio_receivers table."""
+
+    # First, delete any stream-type receivers before removing the columns
+    # This prevents data loss issues
+    op.execute("""
+        DELETE FROM radio_receivers WHERE source_type = 'stream'
+    """)
+
+    # Remove stream-related columns
+    op.drop_column('radio_receivers', 'stream_url')
+    op.drop_column('radio_receivers', 'source_type')
+
+    # Restore NOT NULL constraints for SDR-required fields
+    # First update any null values to defaults
+    op.execute("""
+        UPDATE radio_receivers
+        SET driver = 'rtlsdr'
+        WHERE driver IS NULL
+    """)
+
+    op.execute("""
+        UPDATE radio_receivers
+        SET frequency_hz = 162550000
+        WHERE frequency_hz IS NULL
+    """)
+
+    op.execute("""
+        UPDATE radio_receivers
+        SET sample_rate = 2400000
+        WHERE sample_rate IS NULL
+    """)
+
+    # Now apply NOT NULL constraints
+    op.alter_column('radio_receivers', 'driver',
+        existing_type=sa.String(64),
+        nullable=False
+    )
+
+    op.alter_column('radio_receivers', 'frequency_hz',
+        existing_type=sa.Float(),
+        nullable=False
+    )
+
+    op.alter_column('radio_receivers', 'sample_rate',
+        existing_type=sa.Integer(),
+        nullable=False
+    )
+
+
+def downgrade():
+    """Re-add stream support to radio_receivers table."""
+
+    # Add source_type column (defaults to 'sdr' for existing records)
+    op.add_column('radio_receivers',
+        sa.Column('source_type', sa.String(16), nullable=False, server_default='sdr')
+    )
+
+    # Add stream_url column (nullable)
+    op.add_column('radio_receivers',
+        sa.Column('stream_url', sa.String(512), nullable=True)
+    )
+
+    # Make driver, frequency_hz, and sample_rate nullable again for streams
+    op.alter_column('radio_receivers', 'driver',
+        existing_type=sa.String(64),
+        nullable=True
+    )
+
+    op.alter_column('radio_receivers', 'frequency_hz',
+        existing_type=sa.Float(),
+        nullable=True
+    )
+
+    op.alter_column('radio_receivers', 'sample_rate',
+        existing_type=sa.Integer(),
+        nullable=True
+    )

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -534,18 +534,20 @@ class LocationSettings(db.Model):
 
 
 class RadioReceiver(db.Model):
-    """Persistent configuration for a hardware or virtual radio receiver."""
+    """Persistent configuration for SDR hardware receivers.
+
+    Note: For internet stream sources (HTTP/M3U), use the AudioSource system instead.
+    RadioReceiver is exclusively for SDR hardware like RTL-SDR and Airspy.
+    """
 
     __tablename__ = "radio_receivers"
 
     id = db.Column(db.Integer, primary_key=True)
     identifier = db.Column(db.String(64), nullable=False)
     display_name = db.Column(db.String(128), nullable=False)
-    source_type = db.Column(db.String(16), nullable=False, default='sdr')  # 'sdr' or 'stream'
-    driver = db.Column(db.String(64))  # Required for SDR, null for stream
-    stream_url = db.Column(db.String(512))  # Required for stream, null for SDR
-    frequency_hz = db.Column(db.Float)  # Required for SDR, optional for stream
-    sample_rate = db.Column(db.Integer)  # Required for SDR, optional for stream
+    driver = db.Column(db.String(64), nullable=False)
+    frequency_hz = db.Column(db.Float, nullable=False)
+    sample_rate = db.Column(db.Integer, nullable=False)
     gain = db.Column(db.Float)
     channel = db.Column(db.Integer)
     serial = db.Column(db.String(128))
@@ -576,15 +578,11 @@ class RadioReceiver(db.Model):
 
         from app_core.radio import ReceiverConfig
 
-        # Handle nullable fields for stream sources
-        frequency = float(self.frequency_hz) if self.frequency_hz is not None else 0.0
-        sample_rate = int(self.sample_rate) if self.sample_rate is not None else 0
-
         return ReceiverConfig(
             identifier=self.identifier,
-            driver=self.driver or "",
-            frequency_hz=frequency,
-            sample_rate=sample_rate,
+            driver=self.driver,
+            frequency_hz=float(self.frequency_hz),
+            sample_rate=int(self.sample_rate),
             gain=self.gain,
             channel=self.channel,
             serial=self.serial,

--- a/templates/settings/audio.html
+++ b/templates/settings/audio.html
@@ -20,8 +20,20 @@
                 <i class="fas fa-microphone fa-lg"></i>
             </div>
             <div>
-                <strong>Audio Sources:</strong> Configure multiple audio input sources including SDR receivers, ALSA/PulseAudio devices, and file inputs.
+                <strong>Audio Sources:</strong> Configure multiple audio input sources including SDR receivers, <strong>internet streams (HTTP/M3U)</strong>, ALSA/PulseAudio devices, and file inputs.
                 The system automatically selects the highest priority active source.
+            </div>
+        </div>
+    </div>
+
+    <div class="alert alert-success" role="alert">
+        <div class="d-flex">
+            <div class="me-3">
+                <i class="fas fa-stream fa-lg"></i>
+            </div>
+            <div>
+                <strong>Internet Streams:</strong> To add an HTTP/M3U stream source (for remote NOAA Weather Radio monitoring), click "Add Audio Source" above and select "Stream (HTTP)" as the source type.
+                Supports MP3, AAC, and OGG formats with automatic reconnection.
             </div>
         </div>
     </div>

--- a/templates/settings/radio.html
+++ b/templates/settings/radio.html
@@ -6,8 +6,8 @@
 <div class="container py-4">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4">
         <div>
-            <h1 class="h3 mb-1">Radio Receiver Configuration</h1>
-            <p class="text-muted mb-0">Manage SDR hardware receivers and internet stream sources for SAME monitoring.</p>
+            <h1 class="h3 mb-1">Multi-SDR Receiver Configuration</h1>
+            <p class="text-muted mb-0">Manage USB SDR front-ends used for SAME captures and monitoring.</p>
         </div>
         <button class="btn btn-primary mt-3 mt-md-0" id="addReceiverBtn">
             <i class="fas fa-plus"></i> Add Receiver
@@ -17,12 +17,24 @@
     <div class="alert alert-info" role="alert">
         <div class="d-flex">
             <div class="me-3">
-                <i class="fas fa-broadcast-tower fa-lg"></i>
+                <i class="fas fa-plug fa-lg"></i>
             </div>
             <div>
-                <strong>Source Types:</strong> Configure SDR hardware devices (RTL-SDR, Airspy) for direct RF monitoring, or add internet stream sources (HTTP/M3U) for remote monitoring.
-                For SDR hardware setup, follow the <a href="{{ url_for('static', filename='docs/radio_usb_passthrough.html') }}" target="_blank" rel="noopener">USB passthrough guide</a>
+                <strong>Hardware tip:</strong> map your USB interfaces into the container without privileged mode. Follow the
+                <a href="{{ url_for('static', filename='docs/radio_usb_passthrough.html') }}" target="_blank" rel="noopener">USB passthrough guide</a>
                 to expose <code>/dev/bus/usb</code> safely.
+            </div>
+        </div>
+    </div>
+
+    <div class="alert alert-primary" role="alert">
+        <div class="d-flex">
+            <div class="me-3">
+                <i class="fas fa-stream fa-lg"></i>
+            </div>
+            <div>
+                <strong>Looking for internet streams?</strong> HTTP/M3U stream sources are now configured through the
+                <a href="/settings/audio" class="alert-link">Audio Sources</a> page. This page is exclusively for SDR hardware configuration.
             </div>
         </div>
     </div>
@@ -114,8 +126,8 @@
                     <div class="d-flex align-items-center mb-3">
                         <div class="display-6 fw-bold text-success me-3" id="summaryLocked">0</div>
                         <div>
-                            <div class="fw-semibold">Connected/Locked</div>
-                            <div class="text-muted small">SDR receivers with signal lock or streams connected.</div>
+                            <div class="fw-semibold">Locked</div>
+                            <div class="text-muted small">Reporting carrier lock / valid samples.</div>
                         </div>
                     </div>
                     <div class="d-flex align-items-center">
@@ -227,23 +239,10 @@
                             <input type="text" class="form-control" id="receiverIdentifier" name="identifier" required>
                         </div>
                         <div class="col-md-6">
-                            <label for="receiverSourceType" class="form-label">Source Type</label>
-                            <select class="form-select" id="receiverSourceType" name="source_type">
-                                <option value="sdr">SDR (Hardware)</option>
-                                <option value="stream">Stream (M3U/HTTP)</option>
-                            </select>
-                            <small class="form-text text-muted">Choose between hardware SDR or internet stream</small>
-                        </div>
-                        <div class="col-md-6" id="receiverDriverField">
                             <label for="receiverDriver" class="form-label">Driver</label>
-                            <input type="text" class="form-control" id="receiverDriver" name="driver" placeholder="rtlsdr or airspy">
+                            <input type="text" class="form-control" id="receiverDriver" name="driver" placeholder="rtlsdr or airspy" required>
                         </div>
-                        <div class="col-md-12" id="receiverStreamUrlField" style="display: none;">
-                            <label for="receiverStreamUrl" class="form-label">Stream URL</label>
-                            <input type="text" class="form-control" id="receiverStreamUrl" name="stream_url" placeholder="https://example.com/stream.m3u or https://example.com/live.mp3">
-                            <small class="form-text text-muted">Enter M3U playlist URL or direct stream URL (MP3, AAC, OGG)</small>
-                        </div>
-                        <div class="col-md-6" id="receiverFrequencyField">
+                        <div class="col-md-6">
                             <label for="receiverFrequency" class="form-label">Frequency</label>
                             <div class="input-group">
                                 <input type="number" class="form-control" id="receiverFrequencyMHz" step="0.001" min="0.000001" placeholder="162.4" aria-label="Frequency in MHz">
@@ -487,21 +486,7 @@
         return numeric.toLocaleString();
     }
 
-    function renderStatusBadge(receiver) {
-        const status = receiver.latest_status;
-        const isStream = receiver.source_type === 'stream';
-
-        // For stream receivers without status, show a stream-specific placeholder
-        if (!status && isStream) {
-            return `
-                <span class="badge bg-info" id="stream-status-${receiver.id}">
-                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-                    Checking...
-                </span>
-            `;
-        }
-
-        // For SDR receivers without status, show the traditional message
+    function renderStatusBadge(status) {
         if (!status) {
             return '<span class="badge bg-secondary">No samples</span>';
         }
@@ -539,39 +524,6 @@
             ${error}
             ${timestamp}
         `;
-    }
-
-    async function checkStreamConnection(receiver) {
-        try {
-            const response = await fetch(`/api/radio/stream/check/${receiver.id}`);
-            const data = await response.json();
-
-            const statusElement = document.getElementById(`stream-status-${receiver.id}`);
-            if (!statusElement) {
-                return;
-            }
-
-            if (data.connected) {
-                statusElement.className = 'badge bg-success';
-                statusElement.innerHTML = `
-                    <i class="fas fa-check-circle"></i> Connected
-                    <div class="small mt-1">${escapeHtml(data.content_type)}</div>
-                `;
-            } else {
-                statusElement.className = 'badge bg-danger';
-                statusElement.innerHTML = `
-                    <i class="fas fa-times-circle"></i> Disconnected
-                    <div class="small mt-1">${escapeHtml(data.message)}</div>
-                `;
-            }
-        } catch (error) {
-            console.error(`Failed to check stream connection for receiver ${receiver.id}:`, error);
-            const statusElement = document.getElementById(`stream-status-${receiver.id}`);
-            if (statusElement) {
-                statusElement.className = 'badge bg-warning text-dark';
-                statusElement.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Check failed';
-            }
-        }
     }
 
     function updateSummary() {
@@ -613,18 +565,9 @@
             const row = document.createElement('tr');
             const displayName = escapeHtml(receiver.display_name || '—');
             const identifier = escapeHtml(receiver.identifier || '—');
-            const isStream = receiver.source_type === 'stream';
-
-            // Show different info based on type
-            const driver = isStream
-                ? '<span class="badge bg-info"><i class="fas fa-stream"></i> Stream</span>'
-                : escapeHtml(receiver.driver || '—');
-            const frequency = isStream
-                ? '<span class="text-muted">—</span>'
-                : formatFrequency(receiver.frequency_hz);
-            const sampleRate = isStream && !receiver.sample_rate
-                ? '<span class="text-muted">Auto</span>'
-                : formatSampleRate(receiver.sample_rate);
+            const driver = escapeHtml(receiver.driver || '—');
+            const frequency = formatFrequency(receiver.frequency_hz);
+            const sampleRate = formatSampleRate(receiver.sample_rate);
 
             row.innerHTML = `
                 <td class="fw-semibold">${displayName}</td>
@@ -632,7 +575,7 @@
                 <td>${driver}</td>
                 <td class="text-end">${frequency}</td>
                 <td class="text-end">${sampleRate}</td>
-                <td>${renderStatusBadge(receiver)}</td>
+                <td>${renderStatusBadge(receiver.latest_status)}</td>
                 <td class="text-end">
                     <div class="btn-group btn-group-sm" role="group">
                         <button type="button" class="btn btn-outline-secondary" data-action="edit" data-id="${receiver.id}">
@@ -646,11 +589,6 @@
             `;
 
             tableBody.appendChild(row);
-
-            // For stream receivers without status, check connectivity
-            if (isStream && !receiver.latest_status) {
-                checkStreamConnection(receiver);
-            }
         });
 
         updateSummary();
@@ -660,61 +598,12 @@
         return receivers.find((item) => String(item.id) === String(id));
     }
 
-    function updateSourceTypeFields() {
-        const sourceType = document.getElementById('receiverSourceType').value;
-        const driverField = document.getElementById('receiverDriverField');
-        const streamUrlField = document.getElementById('receiverStreamUrlField');
-        const frequencyField = document.getElementById('receiverFrequencyField');
-        const sampleRateField = document.getElementById('receiverSampleRateField');
-        const gainField = document.getElementById('receiverGainField');
-        const channelField = document.getElementById('receiverChannelField');
-        const serialField = document.getElementById('receiverSerialField');
-
-        if (sourceType === 'stream') {
-            // Hide SDR-specific fields
-            driverField.style.display = 'none';
-            frequencyField.style.display = 'none';
-            sampleRateField.style.display = 'none';
-            gainField.style.display = 'none';
-            channelField.style.display = 'none';
-            serialField.style.display = 'none';
-
-            // Show stream field
-            streamUrlField.style.display = 'block';
-
-            // Update required status
-            document.getElementById('receiverDriver').required = false;
-            document.getElementById('receiverStreamUrl').required = true;
-            document.getElementById('receiverFrequency').required = false;
-            document.getElementById('receiverSampleRate').required = false;
-        } else {
-            // Show SDR-specific fields
-            driverField.style.display = 'block';
-            frequencyField.style.display = 'block';
-            sampleRateField.style.display = 'block';
-            gainField.style.display = 'block';
-            channelField.style.display = 'block';
-            serialField.style.display = 'block';
-
-            // Hide stream field
-            streamUrlField.style.display = 'none';
-
-            // Update required status
-            document.getElementById('receiverDriver').required = true;
-            document.getElementById('receiverStreamUrl').required = false;
-            document.getElementById('receiverFrequency').required = true;
-            document.getElementById('receiverSampleRate').required = true;
-        }
-    }
-
     function openModal(receiver = null) {
         form.reset();
         document.getElementById('receiverId').value = receiver?.id || '';
         document.getElementById('receiverDisplayName').value = receiver?.display_name || '';
         document.getElementById('receiverIdentifier').value = receiver?.identifier || '';
-        document.getElementById('receiverSourceType').value = receiver?.source_type || 'sdr';
         document.getElementById('receiverDriver').value = receiver?.driver || '';
-        document.getElementById('receiverStreamUrl').value = receiver?.stream_url || '';
 
         // Handle frequency - convert Hz to MHz for display
         const freqHz = receiver?.frequency_hz;
@@ -737,14 +626,8 @@
         document.getElementById('receiverIdentifier').disabled = Boolean(receiver);
         document.getElementById('radioReceiverModalLabel').textContent = receiver ? 'Edit Receiver' : 'Add Receiver';
 
-        // Update field visibility based on source type
-        updateSourceTypeFields();
-
         receiverModal.show();
     }
-
-    // Add event listener for source type changes
-    document.getElementById('receiverSourceType')?.addEventListener('change', updateSourceTypeFields);
 
     // Frequency MHz to Hz conversion
     const freqMHzInput = document.getElementById('receiverFrequencyMHz');
@@ -813,12 +696,6 @@
             receivers = data;
             renderReceivers();
             setLastUpdated(deriveLatestStatusTimestamp() || new Date());
-
-            // Check stream connections for all stream receivers during refresh
-            receivers.filter(r => r.source_type === 'stream' && !r.latest_status).forEach(receiver => {
-                checkStreamConnection(receiver);
-            });
-
             if (!silent) {
                 setStatus('Receiver status updated.', 'info');
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed internet streaming support from SDR receiver configuration; HTTP/M3U streams should now be configured via Audio Sources.
  * Simplified receiver configuration form by removing source type selector.
  * Frequency and sample rate are now required fields for all receivers.
  * Added receiver status tracking with auto-start and enabled flags, plus timestamp tracking.

* **Documentation**
  * Updated settings pages to clarify HTTP/M3U stream configuration location and supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->