### PR TITLE
Add stream support to Audio Sources UI

### DIFF
--- a/static/js/audio_monitoring.js
+++ b/static/js/audio_monitoring.js
@@ -304,6 +304,25 @@ function updateSourceTypeConfig() {
                 </div>
             `;
             break;
+        case 'stream':
+            html = `
+                <div class="mb-3">
+                    <label for="streamUrl" class="form-label">Stream URL <span class="text-danger">*</span></label>
+                    <input type="text" class="form-control" id="streamUrl" placeholder="https://example.com/stream.m3u or https://example.com/live.mp3" required>
+                    <small class="form-text text-muted">HTTP/HTTPS URL to M3U playlist or direct audio stream (MP3, AAC, OGG)</small>
+                </div>
+                <div class="mb-3">
+                    <label for="streamFormat" class="form-label">Stream Format</label>
+                    <select class="form-select" id="streamFormat">
+                        <option value="mp3" selected>MP3 (auto-detect)</option>
+                        <option value="aac">AAC</option>
+                        <option value="ogg">OGG Vorbis</option>
+                        <option value="raw">Raw PCM</option>
+                    </select>
+                    <small class="form-text text-muted">Format will be auto-detected from Content-Type if possible</small>
+                </div>
+            `;
+            break;
         case 'alsa':
             html = `
                 <div class="mb-3">
@@ -371,6 +390,18 @@ async function addAudioSource() {
                 return;
             }
             deviceParams.receiver_id = receiverId;
+            break;
+        case 'stream':
+            const streamUrl = document.getElementById('streamUrl')?.value;
+            const streamFormat = document.getElementById('streamFormat')?.value;
+            if (!streamUrl) {
+                showError('Stream URL is required for stream sources');
+                return;
+            }
+            deviceParams.stream_url = streamUrl;
+            if (streamFormat && streamFormat !== 'mp3') {
+                deviceParams.format = streamFormat;
+            }
             break;
         case 'alsa':
             const deviceName = document.getElementById('deviceName')?.value || 'default';

--- a/templates/settings/audio.html
+++ b/templates/settings/audio.html
@@ -32,8 +32,8 @@
                 <i class="fas fa-stream fa-lg"></i>
             </div>
             <div>
-                <strong>Internet Streams:</strong> To add an HTTP/M3U stream source (for remote NOAA Weather Radio monitoring), click "Add Audio Source" above and select "Stream (HTTP)" as the source type.
-                Supports MP3, AAC, and OGG formats with automatic reconnection.
+                <strong>Internet Streams:</strong> To add an HTTP/M3U stream source (for remote NOAA Weather Radio monitoring), click "Add Audio Source" above and select <strong>"Stream (HTTP/M3U)"</strong> as the source type.
+                Supports MP3, AAC, and OGG formats with automatic reconnection and M3U playlist parsing.
             </div>
         </div>
     </div>
@@ -160,6 +160,7 @@
                             <select class="form-select" id="sourceType" name="type" required>
                                 <option value="">Select type...</option>
                                 <option value="sdr">SDR (Software-Defined Radio)</option>
+                                <option value="stream">Stream (HTTP/M3U)</option>
                                 <option value="alsa">ALSA (Advanced Linux Sound Architecture)</option>
                                 <option value="pulse">PulseAudio</option>
                                 <option value="file">File (for testing)</option>


### PR DESCRIPTION
Fixes the missing stream option in the Audio Sources configuration page. While the backend fully supported HTTP/M3U streams via StreamSourceAdapter, the UI was missing the dropdown option and form fields.

UI Changes:
- Added "Stream (HTTP/M3U)" option to source type dropdown
- Added stream-specific configuration fields:
  * Stream URL input (required)
  * Stream format selector (MP3, AAC, OGG, Raw PCM)
  * Auto-detection note for format based on Content-Type

JavaScript Changes (audio_monitoring.js):
- Added 'stream' case to updateSourceTypeConfig() to render stream fields
- Added 'stream' case to addAudioSource() to extract stream parameters
- Maps form fields to correct device_params: stream_url and format

Template Changes (audio.html):
- Updated success alert to clarify "Stream (HTTP/M3U)" option name
- Added note about M3U playlist parsing support

Integration:
- Correctly passes stream_url and format to StreamSourceAdapter
- Works with existing StreamSourceAdapter features:
  * M3U playlist parsing
  * Automatic format detection from Content-Type
  * Auto-reconnection (5 attempts with 2s delay)
  * Support for MP3, AAC, OGG, and raw PCM formats

This completes the stream migration from RadioReceiver to Audio Sources. Users can now configure HTTP/M3U streams through the Audio Sources page.