### PR TITLE
Add pydub dependency for MP3/AAC stream decoding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,8 @@ pyttsx3==2.90  # Offline text-to-speech engine for the pyttsx3 provider
 
 # Audio processing for EAS decoding
 scipy==1.14.1  # Required for audio resampling when ffmpeg is not available
+pydub==0.25.1  # Audio stream decoding (MP3, AAC, OGG) for HTTP/Icecast streams
+# Note: pydub requires ffmpeg to be installed via system packages (libavcodec, libavformat)
 
 # SDR support for radio receivers
 numpy==2.2.1  # Required for SoapySDR sample processing


### PR DESCRIPTION
The StreamSourceAdapter needs pydub to decode audio from Icecast/HTTP streams. Added pydub==0.25.1 to requirements.txt with note that ffmpeg system package is also required for audio codec support (libavcodec, libavformat).

This fixes: 'pydub library not available for MP3 decoding' error when adding stream sources.