### PR TITLE
Fix docker-compose files: add missing service dependencies

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -6,11 +6,15 @@ services:
 
   poller:
     depends_on:
+      app:
+        condition: service_started
       alerts-db:
         condition: service_healthy
 
   ipaws-poller:
     depends_on:
+      app:
+        condition: service_started
       alerts-db:
         condition: service_healthy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   poller:
     image: eas-station:latest
+    depends_on:
+      - app
     command: ["python", "poller/cap_poller.py", "--continuous"]
     restart: unless-stopped
     env_file:
@@ -41,6 +43,8 @@ services:
 
   ipaws-poller:
     image: eas-station:latest
+    depends_on:
+      - app
     command:
       - python
       - poller/cap_poller.py


### PR DESCRIPTION
The poller and ipaws-poller services were failing validation because they referenced the eas-station:latest image without proper dependencies on the app service that builds it.

Changes:
- docker-compose.yml: Add depends_on for poller and ipaws-poller to depend on app
- docker-compose.embedded-db.yml: Add app dependency with service_started condition alongside existing alerts-db dependency

This ensures the image is built before dependent services attempt to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment service initialization order to ensure proper startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->