### PR TITLE
Make docker-compose.embedded-db.yml a complete standalone file for Po…

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -1,26 +1,93 @@
+# Complete standalone docker-compose file with embedded PostgreSQL database
+# This file can be used directly in Portainer or with: docker-compose -f docker-compose.embedded-db.yml up
+
 services:
   app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SOAPYSDR_DRIVERS: ${SOAPYSDR_DRIVERS:-rtlsdr,airspy}
+    image: eas-station:latest
     depends_on:
       alerts-db:
         condition: service_healthy
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    environment:
+      SDR_ARGS: ${SDR_ARGS:-driver=airspy}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+      - /dev/bus/usb/003/002:/dev/bus/usb/003/002
+    cap_add:
+      - SYS_RAWIO
+    security_opt:
+      - no-new-privileges:true
 
   poller:
+    image: eas-station:latest
     depends_on:
       app:
         condition: service_started
       alerts-db:
         condition: service_healthy
+    command: ["python", "poller/cap_poller.py", "--continuous"]
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SDR_ARGS: ${SDR_ARGS:-driver=airspy}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+    cap_add:
+      - SYS_RAWIO
+    security_opt:
+      - no-new-privileges:true
 
   ipaws-poller:
+    image: eas-station:latest
     depends_on:
       app:
         condition: service_started
       alerts-db:
         condition: service_healthy
+    command:
+      - python
+      - poller/cap_poller.py
+      - --continuous
+      - --interval
+      - "120"
+      - --log-level
+      - "${LOG_LEVEL:-INFO}"
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      CAP_POLLER_MODE: IPAWS
+      CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
+      SDR_ARGS: ${SDR_ARGS:-driver=airspy}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+    cap_add:
+      - SYS_RAWIO
+    security_opt:
+      - no-new-privileges:true
 
   alerts-db:
     image: ${ALERTS_DB_IMAGE:-postgis/postgis:17-3.4}
     restart: unless-stopped
+    networks:
+      default:
+        aliases:
+          - postgres
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-alerts}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
…rtainer

Converted docker-compose.embedded-db.yml from an override file to a complete standalone compose file that can be used directly in Portainer without requiring the base docker-compose.yml file.

Changes:
- Added full service definitions for app, poller, and ipaws-poller services
- Included all build contexts, images, and configuration settings
- Maintained proper service dependencies with health checks
- Removed profile restriction from alerts-db (this is the embedded-db file)
- Added explanatory comment at the top

This file now works as a complete, self-contained docker-compose configuration for running EAS Station with an embedded PostgreSQL database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration with improved build-time settings, environment management, and runtime controls
  * Enhanced security posture with access controls and privilege restrictions across services
  * Improved service orchestration with updated networking and device configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->