### PR TITLE
Change default port mapping from 5000 to 80

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -13,7 +13,7 @@ services:
       alerts-db:
         condition: service_healthy
     ports:
-      - "5000:5000"
+      - "80:5000"
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         SOAPYSDR_DRIVERS: ${SOAPYSDR_DRIVERS:-rtlsdr,airspy}
     image: eas-station:latest
     ports:
-      - "5000:5000"
+      - "80:5000"
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:


### PR DESCRIPTION
Modified both docker-compose files to expose the application on port 80 instead of port 5000 for easier access without port specification.

Changes:
- docker-compose.yml: Changed ports from "5000:5000" to "80:5000"
- docker-compose.embedded-db.yml: Changed ports from "5000:5000" to "80:5000"

The application still runs on port 5000 inside the container, but is now accessible externally on port 80 (standard HTTP port).