### PR TITLE
Fix Docker Compose network label conflict with bridge network

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -14,8 +14,6 @@ services:
         condition: service_healthy
     ports:
       - "80:5000"
-    networks:
-      - default
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:
@@ -37,8 +35,6 @@ services:
         condition: service_healthy
     command: ["python", "poller/cap_poller.py", "--continuous"]
     restart: unless-stopped
-    networks:
-      - default
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:
@@ -66,8 +62,6 @@ services:
       - --log-level
       - "${LOG_LEVEL:-INFO}"
     restart: unless-stopped
-    networks:
-      - default
     environment:
       CAP_POLLER_MODE: IPAWS
       CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
@@ -102,8 +96,3 @@ services:
 
 volumes:
   alerts-db-data:
-
-networks:
-  default:
-    name: ${DOCKER_NETWORK:-bridge}
-    external: ${DOCKER_NETWORK_EXTERNAL:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     image: eas-station:latest
     ports:
       - "80:5000"
-    networks:
-      - default
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:
@@ -28,8 +26,6 @@ services:
       - app
     command: ["python", "poller/cap_poller.py", "--continuous"]
     restart: unless-stopped
-    networks:
-      - default
     environment:
       SDR_ARGS: ${SDR_ARGS:-driver=airspy}
     extra_hosts:
@@ -54,8 +50,6 @@ services:
       - --log-level
       - "${LOG_LEVEL:-INFO}"
     restart: unless-stopped
-    networks:
-      - default
     environment:
       CAP_POLLER_MODE: IPAWS
       CAP_ENDPOINTS: ${IPAWS_CAP_FEED_URLS:-}
@@ -92,8 +86,3 @@ services:
 
 volumes:
   alerts-db-data:
-
-networks:
-  default:
-    name: ${DOCKER_NETWORK:-bridge}
-    external: ${DOCKER_NETWORK_EXTERNAL:-false}


### PR DESCRIPTION
Removed custom network configuration that was causing conflicts with Docker's built-in bridge network. Docker Compose was trying to manage the existing "bridge" network with labels, which fails with error: "network bridge was found but has incorrect label com.docker.compose.network"

Changes:
- Removed networks section from both compose files
- Removed explicit network declarations from all services
- Docker Compose will now create its own default network automatically
- This network is properly managed with compose labels

For users who need custom networks, they can configure this through Portainer's network settings by connecting the stack to a specific network after deployment.

This fixes the deployment failure and allows the stack to work out-of-the-box without network configuration.