### PR TITLE
Fix .env directory mount issue and add initialization script

### DIFF
--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -1,0 +1,149 @@
+# EAS Station Setup Instructions
+
+## Quick Start
+
+### First-Time Setup
+
+**Important:** Before starting the Docker containers, you must initialize the environment:
+
+```bash
+# 1. Initialize the environment (creates empty .env file)
+./init-env.sh
+
+# 2. Start the Docker stack
+docker-compose up -d
+
+# 3. Access the setup wizard in your browser
+# Navigate to: http://localhost/setup
+```
+
+The setup wizard will guide you through configuring your `.env` file without needing to edit it manually.
+
+### Why the init-env.sh Script?
+
+Docker creates the `.env` file as a directory if it doesn't exist on the host before mounting it. This causes the setup wizard to fail when trying to write configuration. The `init-env.sh` script ensures `.env` exists as a file before Docker starts.
+
+## Setup Wizard Features
+
+The web-based setup wizard provides:
+
+### Core Configuration
+- **SECRET_KEY** - One-click generation of secure 64-character token
+- **Database Connection** - PostgreSQL host, port, credentials
+- **Timezone** - Dropdown selection of US timezones
+- **Location** - State code dropdown, county name
+
+### EAS Broadcast Settings
+- **EAS Originator** - Dropdown of FCC-authorized codes (WXR, EAS, CIV, PEP)
+- **Station ID** - Validated to 8 characters, no dashes
+- **FIPS Codes** - Authorized county codes for manual broadcasts
+- **Zone Codes** - Auto-derive from FIPS codes with one click
+
+### Audio & TTS
+- **Audio Ingest** - Enable/disable SDR and ALSA sources
+- **TTS Provider** - Dropdown selection (pyttsx3, Azure, Azure OpenAI)
+
+### Hardware Integration
+- **LED Sign** - IP address configuration
+- **VFD Display** - Serial port configuration
+
+## Troubleshooting
+
+### Error: ".env was created as a directory by Docker"
+
+If you see this error in the logs:
+
+```bash
+# 1. Stop the containers
+docker-compose down
+
+# 2. Remove the .env directory
+rm -rf .env
+
+# 3. Run the initialization script
+./init-env.sh
+
+# 4. Start the containers again
+docker-compose up -d
+```
+
+### Configuration Not Persisting
+
+If changes in the setup wizard don't persist after restarting:
+
+1. Verify `.env` is a file, not a directory:
+   ```bash
+   ls -la .env
+   # Should show: -rw-r--r-- (file), not drwxr-xr-x (directory)
+   ```
+
+2. Check that the volume mount is working:
+   ```bash
+   docker-compose exec app ls -la /app/.env
+   # Should show a file, not a directory
+   ```
+
+3. After saving configuration, restart the stack:
+   ```bash
+   docker-compose restart
+   ```
+
+## Manual Configuration (Advanced)
+
+If you prefer to configure manually instead of using the web wizard:
+
+```bash
+# 1. Copy the example file
+cp .env.example .env
+
+# 2. Generate a secret key
+python3 -c "import secrets; print(secrets.token_hex(32))"
+
+# 3. Edit .env with your values
+nano .env
+
+# 4. Start the stack
+docker-compose up -d
+```
+
+## After Configuration
+
+Once configured, the `.env` file will contain your settings. To modify:
+
+1. **Using the Setup Wizard** (Recommended):
+   - Navigate to: http://localhost/setup
+   - Make changes
+   - Click "Save configuration"
+   - Restart: `docker-compose restart`
+
+2. **Manually Editing .env**:
+   - Edit the file: `nano .env`
+   - Restart: `docker-compose restart`
+
+## Auto-Derive Zone Codes
+
+The setup wizard can automatically derive NWS zone codes from FIPS county codes:
+
+1. Enter FIPS codes in "Authorized FIPS Codes" field (e.g., `039001,039003`)
+2. Click "Auto-Derive" button next to "Default Zone Codes"
+3. Zone codes will be populated automatically (e.g., `OHZ001,OHC001`)
+
+This uses the existing county-to-zone mapping logic to save you from manual lookup.
+
+## Validation Features
+
+The setup wizard validates your input:
+
+- **SECRET_KEY**: Minimum 32 characters
+- **EAS_STATION_ID**: Maximum 8 characters, no dashes
+- **DEFAULT_STATE_CODE**: Must be valid 2-letter state abbreviation
+- **Timezone**: Must be valid IANA timezone
+- **Port Numbers**: Must be 1-65535
+
+Clear error messages guide you to correct any issues.
+
+## Getting Help
+
+- **GitHub Issues**: https://github.com/KR8MER/eas-station/issues
+- **Documentation**: See `docs/` directory
+- **Setup Wizard Docs**: See `docs/SETUP_WIZARD.md`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,12 +3,21 @@ set -e
 
 echo "Starting EAS Station..."
 
-# Ensure .env exists as a file (not a directory)
-# Docker may create it as a directory if it doesn't exist on the host
+# Check if .env is mounted as a directory (Docker does this if file doesn't exist on host)
 if [ -d "/app/.env" ]; then
-    echo "Removing .env directory created by Docker..."
-    rmdir /app/.env
+    echo "ERROR: .env was created as a directory by Docker."
+    echo "This happens when .env doesn't exist on the host before starting containers."
+    echo ""
+    echo "To fix this:"
+    echo "  1. Stop the containers: docker-compose down"
+    echo "  2. Create an empty .env file: touch .env"
+    echo "  3. Start the containers: docker-compose up -d"
+    echo ""
+    echo "After setup, the setup wizard will populate the .env file."
+    exit 1
 fi
+
+# Create .env file if it doesn't exist
 if [ ! -f "/app/.env" ]; then
     echo "Creating empty .env file..."
     touch /app/.env

--- a/init-env.sh
+++ b/init-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Initialize environment for EAS Station
+# Run this script before starting docker-compose for the first time
+
+set -e
+
+echo "Initializing EAS Station environment..."
+
+# Create .env file if it doesn't exist
+if [ ! -f ".env" ]; then
+    echo "Creating empty .env file..."
+    touch .env
+    echo "✓ Created .env file"
+else
+    echo "✓ .env file already exists"
+fi
+
+# Check if .env.example exists
+if [ ! -f ".env.example" ]; then
+    echo "⚠ Warning: .env.example not found"
+    echo "  Make sure you're running this script from the eas-station directory"
+    exit 1
+fi
+
+echo ""
+echo "Environment initialization complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Start the stack: docker-compose up -d"
+echo "  2. Access the setup wizard: http://localhost/setup"
+echo "  3. Complete the configuration in your browser"
+echo "  4. Restart the stack: docker-compose restart"
+echo ""


### PR DESCRIPTION
Docker creates .env as a directory when it doesn't exist on the host before mounting. This causes the "Device or resource busy" error and prevents the setup wizard from writing configuration.

**Changes:**

1. **Updated docker-entrypoint.sh**
   - Removed aggressive directory removal attempt (causes "resource busy" error)
   - Added clear error message when .env is a directory
   - Provides step-by-step instructions to fix the issue
   - Exits with error code to prevent silent failures

2. **Added init-env.sh script**
   - Creates empty .env file before docker-compose starts
   - Prevents Docker from creating .env as a directory
   - Simple, idempotent initialization
   - Provides next steps after initialization

3. **Added SETUP_INSTRUCTIONS.md**
   - Comprehensive setup documentation
   - Quick start guide with init-env.sh
   - Troubleshooting section for common issues
   - Explains why initialization is needed
   - Documents all setup wizard features

**Root Cause:**
When a Docker volume mount path doesn't exist on the host, Docker creates it as a directory. Our volume mount (./.env:/app/.env) was creating a directory when users didn't have .env file before starting containers.

**Solution:**
Users must run ./init-env.sh before docker-compose up -d to ensure .env exists as a file, not a directory.

**For Users Currently Experiencing This Error:**
```bash
docker-compose down
rm -rf .env
./init-env.sh
docker-compose up -d
```

Fixes: "Device or resource busy" error on container startup
Fixes: .env created as directory by Docker