### PR TITLE
Remove .env volume mount to fix persistent Portainer deployment issue

### DIFF
--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -4,7 +4,7 @@
 
 ### Portainer Deployment (Recommended)
 
-The repository now includes an empty `.env` file, making Portainer deployments seamless:
+The repository includes an empty `.env` file that the setup wizard can write to:
 
 1. **Deploy the stack in Portainer**
    - Add the Git repository
@@ -17,7 +17,16 @@ The repository now includes an empty `.env` file, making Portainer deployments s
 
 3. **Restart the stack** in Portainer after saving configuration
 
-That's it! The `.env` file is now included in the repository and will persist your configuration.
+**Important:** Configuration persists across container restarts but NOT across redeployments from Git (which resets the container). For permanent configuration:
+
+- **Option 1 (Recommended):** After configuring via the wizard, copy your values into Portainer's "Environment variables" section:
+  - Edit your stack in Portainer
+  - Scroll to "Environment variables"
+  - Add: `SECRET_KEY=your-generated-key`, `POSTGRES_PASSWORD=your-password`, etc.
+
+- **Option 2:** Edit the stack's docker-compose file in Portainer to include your environment values directly
+
+This approach ensures your configuration persists across Git redeployments.
 
 ### Docker Compose (Command Line)
 
@@ -68,22 +77,23 @@ The web-based setup wizard provides:
 
 ### Error: ".env was created as a directory by Docker"
 
-This should no longer occur with the latest repository version (which includes .env).
+**This issue is fixed in the latest version** by removing the volume mount.
 
-If you deployed from an older version and see this error:
+If you see this error, you're on an older commit. To fix:
 
 **Portainer:**
-1. Stop and remove the stack in Portainer
-2. Redeploy from the latest Git repository
-3. The .env file is now included automatically
+1. Stop and remove the stack completely
+2. Update the Git reference to the latest commit on your branch
+3. Redeploy from the latest Git repository
 
 **Docker Compose:**
 ```bash
 docker-compose down
-rm -rf .env
 git pull
 docker-compose up -d
 ```
+
+The `.env` file now lives in the container (from the Git repo) instead of being mounted from the host.
 
 ### Configuration Not Persisting
 

--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -50,9 +50,6 @@ services:
       - SYS_RAWIO
     security_opt:
       - no-new-privileges:true
-    volumes:
-      # Mount .env file so setup wizard can persist configuration
-      - ./.env:/app/.env
 
   poller:
     image: eas-station:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,6 @@ services:
       - SYS_RAWIO
     security_opt:
       - no-new-privileges:true
-    volumes:
-      # Mount .env file so setup wizard can persist configuration
-      - ./.env:/app/.env
 
   poller:
     image: eas-station:latest


### PR DESCRIPTION
The bind mount (./.env:/app/.env) was causing persistent issues in Portainer deployments where a previously created .env directory on the host would be reused even after stack removal and redeployment. Removing the volume mount completely solves this issue.

**Changes:**

1. **Removed .env volume mounts from docker-compose files**
   - Removed from docker-compose.yml
   - Removed from docker-compose.embedded-db.yml
   - .env file now lives in container filesystem (from Git repo)
   - No host filesystem involvement = no persistence issues

2. **Updated SETUP_INSTRUCTIONS.md**
   - Documented new deployment model
   - Configuration persists across container restarts
   - For permanent config across redeployments, use Portainer environment variables
   - Added clear instructions for both options

**How This Works Now:**

1. .env file is in the Git repository (committed in previous commit)
2. When container starts, .env is in /app/.env (from Dockerfile COPY)
3. Setup wizard writes to /app/.env in container
4. Changes persist across container restarts (same container instance)
5. Changes reset on Git redeployment (new container from repo)

**For Permanent Configuration:**

Users should use Portainer's environment variables feature:
- Configure via setup wizard first (validates values, provides dropdowns)
- Copy generated values to Portainer environment variables
- Environment variables override .env values
- Configuration persists across all redeployments

**Benefits:**
- No volume mount = no directory creation issues
- Works seamlessly in Portainer from Git
- No host filesystem dependencies
- Clean deployment every time
- Users can choose persistence method

**Trade-off:**
Configuration doesn't auto-persist across Git redeployments, but this is acceptable because:
1. Setup wizard makes initial configuration easy
2. Portainer environment variables provide permanent persistence
3. Most users don't redeploy frequently
4. Clean deployments are actually desirable for production

This is the correct approach for container-native deployments.

Fixes: "Device or resource busy" error in Portainer
Fixes: .env directory persisting across redeployments
Fixes: Cannot remove .env directory issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with enhanced Portainer deployment guidance and Docker error troubleshooting procedures
  * Clarified configuration persistence options and their limitations across container restarts and Git redeployments

* **Configuration Updates**
  * Adjusted configuration persistence mechanism; environment files no longer persist through local volume mounts
  * Environment configuration now embedded within the deployed container from the repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->