### PR TITLE
Fix database migration error in setup wizard

### DIFF
--- a/app.py
+++ b/app.py
@@ -671,6 +671,10 @@ def before_request():
     if (request.endpoint in CSRF_EXEMPT_ENDPOINTS) or (request.path in CSRF_EXEMPT_PATHS):
         return
 
+    # Exempt setup routes from CSRF validation when in setup mode
+    if setup_mode_active and request.path.startswith('/setup'):
+        return
+
     if request.method in CSRF_PROTECTED_METHODS:
         session_token = session.get(CSRF_SESSION_KEY)
         request_token = None

--- a/app_core/migrations/versions/20241112_add_eas_message_segments.py
+++ b/app_core/migrations/versions/20241112_add_eas_message_segments.py
@@ -18,6 +18,11 @@ def upgrade() -> None:
     conn = op.get_bind()
     inspector = inspect(conn)
 
+    # Check if the table exists first
+    if "eas_messages" not in inspector.get_table_names():
+        # Table doesn't exist yet, skip this migration
+        return
+
     # Check existing columns
     existing_columns = {col['name'] for col in inspector.get_columns('eas_messages')}
 


### PR DESCRIPTION
This commit resolves two critical issues affecting fresh installations:

1. Migration Failure (NoSuchTableError):
   - The 20241112_add_eas_message_segments migration was failing on fresh installations because it tried to inspect the eas_messages table without checking if it exists first
   - Added table existence check before attempting column inspection
   - Now gracefully skips the migration if the table doesn't exist yet

2. Setup Wizard 400 Bad Request:
   - Setup routes required CSRF tokens but sessions weren't initialized on first visit, causing the first POST request to fail with 400
   - Exempt /setup routes from CSRF validation during setup mode
   - This allows the setup wizard to work properly on first use without requiring a pre-existing session with CSRF token

Both fixes follow patterns established in other parts of the codebase and ensure a smooth initial setup experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved setup mode request handling to streamline initial configuration and system initialization.

* **Bug Fixes**
  * Enhanced database migration process with defensive table validation, preventing errors during updates and improving overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->