### PR TITLE
Fix SECRET_KEY persistence by removing placeholder from stack.env

### DIFF
--- a/stack.env
+++ b/stack.env
@@ -6,16 +6,21 @@
 # For advanced options, see stack.env.example
 #
 # Quick Start:
-# 1. Generate a SECRET_KEY: python3 -c 'import secrets; print(secrets.token_hex(32))'
-# 2. Update your location settings below
-# 3. Deploy!
+# 1. Deploy the stack
+# 2. Navigate to http://localhost/setup to run the Setup Wizard
+# 3. The wizard will generate SECRET_KEY and save all config to persistent storage
+#
+# Note: SECRET_KEY is NOT configured here - it's managed by the Setup Wizard
+# and stored in the persistent volume to survive redeployments.
 #
 # ============================================================================
 
 # ----------------------------------------------------------------------------
 # REQUIRED: Security
 # ----------------------------------------------------------------------------
-SECRET_KEY=replace-with-a-long-random-string
+# SECRET_KEY is managed by the Setup Wizard and stored in persistent volume
+# Do NOT set it here - it will override the persistent configuration
+# SECRET_KEY=
 
 # ----------------------------------------------------------------------------
 # REQUIRED: Database Connection

--- a/stack.env.example
+++ b/stack.env.example
@@ -5,10 +5,14 @@
 # from a Git repository. Portainer will use these values as default environment
 # variables for the stack.
 #
-# IMPORTANT: Update these placeholder values before deploying your stack!
-# - Generate a secure SECRET_KEY
-# - Set your database credentials
-# - Configure location settings for your deployment
+# IMPORTANT: Configuration workflow
+# 1. Deploy the stack as-is (SECRET_KEY will be empty initially)
+# 2. Navigate to http://localhost/setup to run the Setup Wizard
+# 3. The wizard will generate SECRET_KEY and save to persistent volume
+# 4. Configuration persists across redeployments automatically
+#
+# Note: SECRET_KEY is NOT configured in this file - it's managed by the Setup Wizard
+# and stored in a persistent Docker volume to survive Git redeployments.
 #
 # For manual Docker Compose deployments, copy this file to `.env` instead.
 
@@ -16,8 +20,9 @@
 # CORE APPLICATION SETTINGS
 # =============================================================================
 
-# Flask secret key for session security (REQUIRED - generate with: python3 -c 'import secrets; print(secrets.token_hex(32))')
-SECRET_KEY=replace-with-a-long-random-string
+# Flask secret key for session security
+# MANAGED BY SETUP WIZARD - Do not set here or it will override persistent config
+# SECRET_KEY=
 
 # Application version
 APP_BUILD_VERSION=2.3.12


### PR DESCRIPTION
The root cause of the setup wizard configuration not persisting was that stack.env contained SECRET_KEY=replace-with-a-long-random-string, which was being loaded by Docker Compose and set as an environment variable.

Even though load_dotenv(override=True) was configured, the app.py code explicitly checks for placeholder values and treats them as invalid, triggering setup mode.

Changes:
- Removed SECRET_KEY from stack.env (commented out)
- Updated documentation to clarify that SECRET_KEY is managed by the Setup Wizard and stored in the persistent volume
- Updated stack.env.example with the same approach

Workflow:
1. Deploy stack (SECRET_KEY will be empty initially → setup mode)
2. Run setup wizard at /setup
3. Wizard generates SECRET_KEY and saves to /app-config/.env (persistent)
4. Restart container → SECRET_KEY loads from persistent volume → app starts

The persistent volume (/app-config) survives redeployments, so configuration only needs to be set once via the wizard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined setup workflow with automated secret key management. The Setup Wizard now handles secret key generation and storage instead of requiring manual configuration.
  * Secret key configuration automatically persists across redeployments, eliminating the need for manual re-entry during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->