### PR TITLE
Fix database connection hang by removing invalid POSTGRES_HOST

### DIFF
--- a/app.py
+++ b/app.py
@@ -440,6 +440,15 @@ os.environ.setdefault('DATABASE_URL', DATABASE_URL)
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+# Add connection timeout and pool settings to prevent startup hangs
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+    'connect_args': {
+        'connect_timeout': 10,  # 10 second timeout for initial connection
+    },
+    'pool_pre_ping': True,  # Verify connections before using them
+    'pool_recycle': 3600,   # Recycle connections after 1 hour
+}
+
 # Initialize database
 db.init_app(app)
 

--- a/stack.env
+++ b/stack.env
@@ -25,13 +25,19 @@
 # ----------------------------------------------------------------------------
 # REQUIRED: Database Connection
 # ----------------------------------------------------------------------------
-# Using embedded database? Set POSTGRES_HOST=alerts-db
-# Using external database? Set the host/port/credentials
-POSTGRES_HOST=host.docker.internal
-POSTGRES_PORT=5432
-POSTGRES_DB=alerts
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change-me
+# Using embedded database (docker-compose.embedded-db.yml)? Leave these commented out
+# The embedded database uses these defaults:
+#   POSTGRES_HOST=alerts-db
+#   POSTGRES_USER=postgres
+#   POSTGRES_PASSWORD=postgres
+#   POSTGRES_DB=alerts
+#
+# Using external database? Uncomment and set your credentials:
+# POSTGRES_HOST=your-database-host
+# POSTGRES_PORT=5432
+# POSTGRES_DB=alerts
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=change-me
 
 # ----------------------------------------------------------------------------
 # Location Settings (Defaults for Admin UI)


### PR DESCRIPTION
The container was hanging at startup because stack.env configured:
  POSTGRES_HOST=host.docker.internal

But the embedded database service is named "alerts-db", causing the app to try connecting to a non-existent database and hang indefinitely.

Changes:
1. Removed database configuration from stack.env
   - For embedded database: defaults in docker-compose.embedded-db.yml now apply
   - For external database: users can uncomment and configure

2. Added connection timeout to SQLAlchemy engine (10 seconds)
   - Prevents infinite hangs on database connection issues
   - Added pool_pre_ping for connection health checks
   - Added pool_recycle to avoid stale connections

With these changes:
- Embedded database deployments work out-of-the-box
- External database deployments have clear instructions
- Connection failures fail fast (10s timeout) instead of hanging forever

The POSTGRES_HOST defaults in docker-compose files:
- docker-compose.embedded-db.yml: POSTGRES_HOST=${POSTGRES_HOST:-alerts-db}
- docker-compose.yml: POSTGRES_HOST=${POSTGRES_HOST:-host.docker.internal}

So leaving stack.env empty allows the correct defaults to apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database connection handling to prevent startup delays and hangs

* **Chores**
  * Database configuration now requires explicit setup; clear guidance provided for embedded and external database options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->