### PR TITLE
Fix POSTGRES_PASSWORD default to match docker-compose (postgres not c…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -84,7 +84,7 @@ POSTGRES_HOST=${POSTGRES_HOST:-alerts-db}
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
 POSTGRES_DB=${POSTGRES_DB:-alerts}
 POSTGRES_USER=${POSTGRES_USER:-postgres}
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-change-me}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
 
 # =============================================================================
 # ALERT POLLING


### PR DESCRIPTION
…hange-me)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default PostgreSQL password configuration used during Docker environment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->