### PR TITLE
Fix escapeHtml undefined error in RBAC management page

### DIFF
--- a/templates/admin/rbac_management.html
+++ b/templates/admin/rbac_management.html
@@ -272,6 +272,14 @@ let permissionsData = [];
 let usersData = [];
 let permissionsByCategory = {};
 
+// Get escapeHtml function from utils
+const escapeHtml = window.EASUtils?.escapeHtml || function(text) {
+    if (text === null || text === undefined) return '';
+    const div = document.createElement('div');
+    div.textContent = String(text);
+    return div.innerHTML;
+};
+
 // Load all data on page load
 document.addEventListener('DOMContentLoaded', async function() {
     await loadRoles();
@@ -444,17 +452,6 @@ function renderUsers() {
         tbody.innerHTML = '<tr><td colspan="5" class="text-muted">No users found</td></tr>';
         return;
     }
-
-    // Helper function to escape HTML to prevent XSS
-    const escapeHtml = (unsafe) => {
-        if (!unsafe) return '';
-        return unsafe
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;");
-    };
 
     tbody.innerHTML = usersData.map(user => `
         <tr class="user-row" style="cursor: pointer;" data-user-id="${user.id}" data-user-role-id="${user.role_id || ''}">


### PR DESCRIPTION
The roles page was failing with "Can't find variable: escapeHtml" because the function was being called directly instead of accessing it through window.EASUtils.escapeHtml. Fixed by adding a global reference to the function at the top of the script and removing the duplicate local definition in renderUsers().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated HTML sanitization logic into a centralized utility function, improving code consistency and maintainability across the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->