### PR TITLE
Fix environment settings page rendering issue

### DIFF
--- a/templates/settings/environment.html
+++ b/templates/settings/environment.html
@@ -214,7 +214,7 @@
             </div>
         </div>
 
-        {% if current_user and not has_permission('system.configure') %}
+        {% if not can_configure %}
         <div class="alert alert-warning">
             <i class="fas fa-eye"></i>
             <strong>Read-Only Mode:</strong> You have view-only access to environment settings. All fields are disabled. Contact your administrator to request the <code>system.configure</code> permission if you need to make changes.
@@ -253,7 +253,7 @@
     {% else %}
     console.log('No current user');
     {% endif %}
-    console.log('Has configure permission:', {{ 'true' if current_user and has_permission('system.configure') else 'false' }});
+    console.log('Has configure permission:', {{ 'true' if can_configure else 'false' }});
 
     // Ensure required utility functions are available
     if (typeof showLoading !== 'function' || typeof hideLoading !== 'function' || typeof showToast !== 'function') {
@@ -267,8 +267,8 @@
     let categoriesData = {};
     let currentValues = {};
     let hasChanges = false;
-    // Default to true (editable) for administrators
-    const canEdit = {{ 'true' if current_user and has_permission('system.configure') else 'false' }};
+    // Permission check passed from backend
+    const canEdit = {{ 'true' if can_configure else 'false' }};
     console.log('canEdit =', canEdit);
 
     // Load categories and variables on page load

--- a/webapp/admin/environment.py
+++ b/webapp/admin/environment.py
@@ -873,17 +873,22 @@ def register_environment_routes(app, logger):
     @require_permission('system.view_config')
     def environment_settings():
         """Render environment settings management page."""
+        from app_core.auth.roles import has_permission
+
         try:
             location_settings = get_location_settings()
+            can_configure = has_permission('system.configure')
             return render_template(
                 'settings/environment.html',
                 location_settings=location_settings,
+                can_configure=can_configure,
             )
         except Exception as exc:
             logger.error(f'Error rendering environment settings: {exc}')
             return render_template(
                 'settings/environment.html',
                 location_settings=None,
+                can_configure=False,
             )
 
     @app.route('/admin/environment/download-env')


### PR DESCRIPTION
The page was completely blank because has_permission() was being called directly in the Jinja template, which could cause template rendering errors.

Changes:
- Modified environment_settings() route to call has_permission() in Python
- Pass can_configure boolean to template instead of the function
- Updated template to use can_configure variable instead of calling function
- This prevents any template rendering errors from breaking the page

The issue was that calling has_permission('system.configure') in Jinja could fail silently and break the entire page rendering, resulting in a blank page with only the header visible.

Fixes the issue shown in bugs/IMG_4398.png where category navigation and input fields were not rendering at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment settings access control to ensure consistent behavior based on user permissions; the UI correctly displays read-only mode with an info banner or enables edit controls based on configuration access level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->