### PR TITLE
Fix critical bug: Environment settings JavaScript never loads

### DIFF
--- a/templates/settings/environment.html
+++ b/templates/settings/environment.html
@@ -243,7 +243,7 @@
 </div>
 {% endblock %}
 
-{% block extra_js %}
+{% block scripts %}
 <script>
     // Debug logging
     console.log('Environment settings page loading...');


### PR DESCRIPTION
ROOT CAUSE:
The environment settings page was completely blank because the JavaScript was never included in the rendered HTML.

THE BUG:
- base.html defines {% block scripts %} for page-specific JavaScript
- environment.html was using {% block extra_js %} which DOESN'T EXIST
- Result: Entire <script> block was ignored by Jinja template engine
- Page loaded with header only, no category navigation or input fields

THE FIX:
Changed {% block extra_js %} to {% block scripts %} in environment.html

This was a pre-existing bug that was documented in KNOWN_BUGS.md line 437: "Page shows no settings - potential script loading failure"

Now the JavaScript will actually load and execute:
- loadSettings() will run on DOMContentLoaded
- Category navigation will render
- Input fields will appear
- Permission checks will work

Resolves issue shown in bugs/IMG_4398.png