### PR TITLE
Add detailed debug logging for Azure OpenAI TTS endpoint

### DIFF
--- a/app_utils/eas_tts.py
+++ b/app_utils/eas_tts.py
@@ -171,13 +171,18 @@ class TTSEngine:
                 self.logger.warning("Azure OpenAI TTS credentials not configured; skipping TTS voiceover.")
             return None
 
+        # Log endpoint for debugging
+        if self.logger:
+            self.logger.debug(f"Azure OpenAI TTS endpoint: {endpoint}")
+
         # Validate endpoint format and provide helpful hints
         if self.logger:
             if 'azure.com' in endpoint.lower():
                 if '/audio/speech' not in endpoint:
-                    self.logger.warning(
-                        "Azure OpenAI endpoint may be incomplete. "
-                        "Expected format: https://YOUR_RESOURCE.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT/audio/speech?api-version=2024-02-15-preview"
+                    self.logger.error(
+                        f"Azure OpenAI endpoint is incomplete: {endpoint}\n"
+                        "Expected full format: https://YOUR_RESOURCE.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT/audio/speech?api-version=2024-02-15-preview\n"
+                        "Your endpoint should include '/openai/deployments/YOUR_DEPLOYMENT/audio/speech?api-version=...'"
                     )
             elif 'api.openai.com' in endpoint.lower():
                 if endpoint != 'https://api.openai.com/v1/audio/speech':
@@ -202,9 +207,10 @@ class TTSEngine:
                     self.logger.debug(f"Extracted deployment name from endpoint: {deployment_name}")
             else:
                 if self.logger:
-                    self.logger.warning(
-                        "Could not extract deployment name from Azure endpoint. "
-                        "Using configured model name, which may cause errors if it doesn't match the deployment."
+                    self.logger.error(
+                        f"Could not extract deployment name from Azure endpoint: {endpoint}\n"
+                        f"The endpoint must include '/deployments/YOUR_DEPLOYMENT/' in the path.\n"
+                        f"Using configured model name '{model}' instead, which may cause errors if it doesn't match the deployment."
                     )
 
         # Use deployment name as model for Azure, or configured model for OpenAI


### PR DESCRIPTION
Added debug logging to show the actual endpoint URL being used, which will help diagnose configuration issues. Also improved error messages to show:
- The actual endpoint value that was configured
- Clear guidance on the expected format
- Specific error when deployment name cannot be extracted

This will help users identify if they've configured a partial endpoint URL (e.g., just the base URL) instead of the full endpoint path including /openai/deployments/NAME/audio/speech.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened endpoint validation for Azure OpenAI TTS with more explicit error messages when endpoint formats are incorrect or incomplete. The system now provides clearer feedback when required path components or deployment information are missing.

* **Improvements**
  * Enhanced debug logging for troubleshooting Azure OpenAI endpoint configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->