### PR TITLE
Fix environment configuration not persisting across restarts

### DIFF
--- a/webapp/admin/environment.py
+++ b/webapp/admin/environment.py
@@ -586,7 +586,12 @@ ENV_CATEGORIES = {
 
 def get_env_file_path() -> Path:
     """Get the path to the .env file."""
-    # Look for .env in the project root
+    # Check if CONFIG_PATH environment variable is set (for persistent storage)
+    config_path = os.environ.get('CONFIG_PATH')
+    if config_path:
+        return Path(config_path)
+
+    # Fallback to .env in the project root
     current_dir = Path(__file__).resolve().parent
     project_root = current_dir.parent.parent
     env_path = project_root / '.env'


### PR DESCRIPTION
The get_env_file_path() function was hardcoded to use the project root .env file, which doesn't persist in Docker deployments. The application loads from CONFIG_PATH (/app-config/.env in the persistent volume), but the web UI was writing to the non-persistent location.

This caused configuration changes made through the web UI to be lost on container restart.

Changes:
- Modified get_env_file_path() to check CONFIG_PATH environment variable
- Falls back to project root .env if CONFIG_PATH is not set
- This ensures web UI writes to the same persistent location the app reads from

Fixes: Azure OpenAI endpoint configuration not persisting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configuration management now supports custom environment file paths via the CONFIG_PATH environment variable, enabling flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->