### PR TITLE
Fix navbar authentication endpoint errors

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -111,12 +111,7 @@
                             <li><h6 class="dropdown-header">{{ current_user.username }}</h6></li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
-                                <a class="dropdown-item" href="{{ url_for('auth.profile') }}">
-                                    <i class="fas fa-user"></i> Profile
-                                </a>
-                            </li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('auth.logout') }}">
+                                <a class="dropdown-item" href="{{ url_for('logout') }}">
                                     <i class="fas fa-sign-out-alt"></i> Sign Out
                                 </a>
                             </li>
@@ -124,7 +119,7 @@
                     </li>
                     {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('auth.login') }}">
+                        <a class="nav-link" href="{{ url_for('login') }}">
                             <i class="fas fa-sign-in-alt"></i>
                             <span class="d-none d-md-inline">Sign In</span>
                         </a>

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -111,12 +111,7 @@
                             <li><h6 class="dropdown-header">{{ current_user.username }}</h6></li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
-                                <a class="dropdown-item" href="{{ url_for('auth.profile') }}">
-                                    <i class="fas fa-user"></i> Profile
-                                </a>
-                            </li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('auth.logout') }}">
+                                <a class="dropdown-item" href="{{ url_for('logout') }}">
                                     <i class="fas fa-sign-out-alt"></i> Sign Out
                                 </a>
                             </li>
@@ -124,7 +119,7 @@
                     </li>
                     {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('auth.login') }}">
+                        <a class="nav-link" href="{{ url_for('login') }}">
                             <i class="fas fa-sign-in-alt"></i>
                             <span class="d-none d-md-inline">Sign In</span>
                         </a>


### PR DESCRIPTION
Fixed 500 errors caused by incorrect endpoint names in navbar:
- Changed url_for('auth.login') to url_for('login')
- Changed url_for('auth.logout') to url_for('logout')
- Removed non-existent Profile menu item (auth.profile endpoint doesn't exist)

Auth routes are registered directly on the app, not on a blueprint, so they don't use the 'auth.' prefix.