### PR TITLE
Fix Alembic migration chain with proper revision IDs and merge

### DIFF
--- a/app_core/migrations/versions/20251106_add_tts_error_tracking.py
+++ b/app_core/migrations/versions/20251106_add_tts_error_tracking.py
@@ -1,7 +1,7 @@
 """Add TTS error tracking to EASMessage model
 
 Revision ID: 20251106_add_tts_error_tracking
-Revises: 20251106_remove_stream_support
+Revises: 20251106_remove_stream_support_from_receivers
 Create Date: 2025-11-06
 
 Adds tts_warning and tts_provider columns to track TTS failures in automated alerts.
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '20251106_add_tts_error_tracking'
-down_revision = '20251106_remove_stream_support'
+down_revision = '20251106_remove_stream_support_from_receivers'
 branch_labels = None
 depends_on = None
 

--- a/app_core/migrations/versions/20251106_remove_stream_support_from_receivers.py
+++ b/app_core/migrations/versions/20251106_remove_stream_support_from_receivers.py
@@ -1,6 +1,6 @@
 """Remove stream support from radio receivers
 
-Revision ID: 20251106_remove_stream_support
+Revision ID: 20251106_remove_stream_support_from_receivers
 Revises: 20251106_add_display_screens
 Create Date: 2025-11-06
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '20251106_remove_stream_support'
+revision = '20251106_remove_stream_support_from_receivers'
 down_revision = '20251106_add_display_screens'
 branch_labels = None
 depends_on = None

--- a/app_core/migrations/versions/20251107_merge_radio_and_audio_changes.py
+++ b/app_core/migrations/versions/20251107_merge_radio_and_audio_changes.py
@@ -1,0 +1,26 @@
+"""Merge radio demodulation, audio segments, and TTS error tracking
+
+Revision ID: 20251107_merge_radio_and_audio
+Revises: 20251107_add_radio_demodulation_settings, 20251107_add_tone_and_narration, 20251106_add_tts_error_tracking
+Create Date: 2025-11-07
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20251107_merge_radio_and_audio'
+down_revision = ('20251107_add_radio_demodulation_settings', '20251107_add_tone_and_narration', '20251106_add_tts_error_tracking')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Merge migration - no changes needed."""
+    pass
+
+
+def downgrade():
+    """Merge migration - no changes needed."""
+    pass


### PR DESCRIPTION
Resolves KeyError for missing migration '20251106_remove_stream_support_from_receivers' by:
- Correcting revision ID from '20251106_remove_stream_support' to match filename
- Updating dependent migration references (add_tts_error_tracking)
- Creating merge migration to handle three-way branch properly

The migration chain now correctly merges:
- 20251107_add_radio_demodulation_settings
- 20251107_add_tone_and_narration
- 20251106_add_tts_error_tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database migration identifiers and structure to improve clarity and manage schema evolution.

---

**Note:** These are internal infrastructure updates with no direct impact on user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->