### PR TITLE
Fix audio streaming dropouts by keeping HTTP connection alive

### DIFF
--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -639,8 +639,8 @@ class StreamSourceAdapter(AudioSourceAdapter):
                 return None
 
         try:
-            # Read data from stream (increased chunk size for better throughput)
-            chunk_size = self.config.buffer_size * 8  # Increased from 4x to 8x for better streaming
+            # Read data from stream (smaller chunks for more continuous flow)
+            chunk_size = self.config.buffer_size * 4  # Balanced size for low latency and efficiency
 
             try:
                 data = self._stream_response.raw.read(chunk_size)
@@ -707,8 +707,8 @@ class StreamSourceAdapter(AudioSourceAdapter):
             from pydub import AudioSegment
             import io
 
-            # Need minimum data to attempt decode (reduced from 4096 to 2048 for faster startup)
-            min_buffer_size = 2048
+            # Need minimum data to attempt decode (reduced to 1024 for faster, more continuous streaming)
+            min_buffer_size = 1024
             if len(self._buffer) < min_buffer_size:
                 return None
 


### PR DESCRIPTION
Critical fixes to resolve audio dropouts across all source types (streaming, line-level input, and SDR demodulation):

1. **HTTP Streaming Keep-Alive**:
   - Yield silence chunks when no audio data is available
   - Prevents browser from closing connection due to inactivity
   - Previous behavior: `continue` without yielding = stalled HTTP stream
   - New behavior: Yield 50ms silence chunks to keep stream flowing

2. **Reduced Latency**:
   - Reduced get_audio_chunk timeout: 0.5s → 0.05s
   - Faster response to data availability
   - Stops after 20 consecutive silent chunks (1 second) as safety

3. **Improved MP3 Decoding**:
   - Reduced minimum buffer size: 2048 → 1024 bytes
   - Allows decoder to start faster and produce more frequent chunks
   - Balanced stream read chunk size: 8x → 4x buffer size

4. **Better Flow Control**:
   - Continuous silence keeps HTTP alive without data loss
   - Resets silence counter when real audio arrives
   - Graceful handling of temporary source delays

This solves the "audio plays for 1 second then drops" issue by maintaining continuous data flow to the browser, even during brief gaps in source data.

Applies to all audio sources monitored in audio-monitor interface.