### PR TITLE
Fix missing audio API endpoints returning 404 errors

### DIFF
--- a/webapp/admin/audio_ingest.py
+++ b/webapp/admin/audio_ingest.py
@@ -362,7 +362,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Check /api/audio/sources for available sources'
+                    }), 404
 
             return jsonify(_serialize_audio_source(source_name, adapter))
 
@@ -378,7 +389,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Check /api/audio/sources for available sources'
+                    }), 404
 
             config = adapter.config
             data = request.get_json()
@@ -487,7 +509,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Create the source first using POST /api/audio/sources'
+                    }), 404
 
             if adapter.status == AudioSourceStatus.RUNNING:
                 return jsonify({'message': 'Source is already running'}), 200
@@ -522,7 +555,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Create the source first using POST /api/audio/sources'
+                    }), 404
 
             if adapter.status == AudioSourceStatus.STOPPED:
                 return jsonify({'message': 'Source is already stopped'}), 200
@@ -839,7 +883,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Check /api/audio/sources for available sources'
+                    }), 404
 
             # Get waveform data from adapter
             waveform_data = adapter.get_waveform_data()
@@ -867,7 +922,18 @@ def register_audio_ingest_routes(app: Flask, logger_instance: Any) -> None:
             adapter = controller._sources.get(source_name)
 
             if not adapter:
-                return jsonify({'error': 'Source not found'}), 404
+                # Check if source exists in database but not loaded
+                db_config = AudioSourceConfigDB.query.filter_by(name=source_name).first()
+                if db_config:
+                    return jsonify({
+                        'error': 'Source exists in database but not loaded in memory',
+                        'hint': 'Restart the application to reload audio sources from database'
+                    }), 503  # Service Unavailable
+                else:
+                    return jsonify({
+                        'error': f'Audio source "{source_name}" not found',
+                        'hint': 'Check /api/audio/sources for available sources'
+                    }), 404
 
             # Get spectrogram data from adapter
             spectrogram_data = adapter.get_spectrogram_data()

--- a/webapp/routes_monitoring.py
+++ b/webapp/routes_monitoring.py
@@ -66,6 +66,12 @@ def register(app: Flask, logger) -> None:
                 500,
             )
 
+    @app.route("/api/health")
+    def api_health_check():
+        """API health check endpoint (alias for /health)."""
+        # Delegate to the main health check
+        return health_check()
+
     @app.route("/ping")
     def ping():
         """Simple ping endpoint."""


### PR DESCRIPTION
…ages

This commit addresses 404 errors for audio API endpoints by:

1. **Add missing /api/health endpoint**: Frontend was calling /api/health which didn't exist. Added it as an alias to the existing /health endpoint in routes_monitoring.py.

2. **Improve audio source error messages**: Enhanced all audio source endpoints (GET, PATCH, start, stop, waveform, spectrogram) to distinguish between two error cases:
   - Source doesn't exist at all (404 with helpful hint)
   - Source exists in DB but not loaded in memory (503 with restart hint)

The 404 errors for WNCI were legitimate - the source either doesn't exist or isn't loaded in the AudioIngestController. The improved error messages now make this clear and provide actionable guidance.

Modified files:
- webapp/routes_monitoring.py: Added /api/health endpoint
- webapp/admin/audio_ingest.py: Enhanced error handling for 6 endpoints