### PR TITLE
Fix Icecast container startup: Switch to moul/icecast image

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -165,34 +165,34 @@ services:
       retries: 5
 
   icecast:
-    image: infiniteproject/icecast:latest
+    image: moul/icecast:latest
     container_name: eas-icecast
     restart: unless-stopped
     ports:
       - "${ICECAST_PORT:-8001}:8000"  # Icecast web interface and streams (port 8001 to avoid Portainer conflict)
     environment:
       # Admin credentials (CHANGE THESE IN PRODUCTION!)
-      - ICECAST_ADMIN_USER=${ICECAST_ADMIN_USER:-admin}
-      - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-changeme_admin}
+      ICECAST_ADMIN_USERNAME: ${ICECAST_ADMIN_USER:-admin}
+      ICECAST_ADMIN_PASSWORD: ${ICECAST_ADMIN_PASSWORD:-changeme_admin}
 
       # Source credentials for EAS Station to publish streams
-      - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
+      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
 
       # Relay password
-      - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-changeme_relay}
+      ICECAST_RELAY_PASSWORD: ${ICECAST_RELAY_PASSWORD:-changeme_relay}
 
       # Server settings
-      - ICECAST_HOSTNAME=${ICECAST_HOSTNAME:-localhost}
-      - ICECAST_LOCATION=EAS Monitoring Station
-      - ICECAST_CONTACT=${ICECAST_CONTACT:-admin@example.com}
+      ICECAST_HOSTNAME: ${ICECAST_HOSTNAME:-localhost}
+      ICECAST_LOCATION: EAS Monitoring Station
+      ICECAST_ADMIN: ${ICECAST_CONTACT:-admin@example.com}
 
       # Performance limits
-      - ICECAST_MAX_CLIENTS=100
-      - ICECAST_MAX_SOURCES=50
+      ICECAST_MAX_CLIENTS: ${ICECAST_MAX_CLIENTS:-100}
+      ICECAST_MAX_SOURCES: ${ICECAST_MAX_SOURCES:-50}
     volumes:
       - icecast-logs:/var/log/icecast
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8000"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8000 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,34 +147,34 @@ services:
       retries: 5
 
   icecast:
-    image: infiniteproject/icecast:latest
+    image: moul/icecast:latest
     container_name: eas-icecast
     restart: unless-stopped
     ports:
       - "${ICECAST_PORT:-8001}:8000"  # Icecast web interface and streams (port 8001 to avoid Portainer conflict)
     environment:
       # Admin credentials (CHANGE THESE IN PRODUCTION!)
-      - ICECAST_ADMIN_USER=${ICECAST_ADMIN_USER:-admin}
-      - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-changeme_admin}
+      ICECAST_ADMIN_USERNAME: ${ICECAST_ADMIN_USER:-admin}
+      ICECAST_ADMIN_PASSWORD: ${ICECAST_ADMIN_PASSWORD:-changeme_admin}
 
       # Source credentials for EAS Station to publish streams
-      - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
+      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
 
       # Relay password
-      - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-changeme_relay}
+      ICECAST_RELAY_PASSWORD: ${ICECAST_RELAY_PASSWORD:-changeme_relay}
 
       # Server settings
-      - ICECAST_HOSTNAME=${ICECAST_HOSTNAME:-localhost}
-      - ICECAST_LOCATION=EAS Monitoring Station
-      - ICECAST_CONTACT=${ICECAST_CONTACT:-admin@example.com}
+      ICECAST_HOSTNAME: ${ICECAST_HOSTNAME:-localhost}
+      ICECAST_LOCATION: EAS Monitoring Station
+      ICECAST_ADMIN: ${ICECAST_CONTACT:-admin@example.com}
 
       # Performance limits
-      - ICECAST_MAX_CLIENTS=100
-      - ICECAST_MAX_SOURCES=50
+      ICECAST_MAX_CLIENTS: ${ICECAST_MAX_CLIENTS:-100}
+      ICECAST_MAX_SOURCES: ${ICECAST_MAX_SOURCES:-50}
     volumes:
       - icecast-logs:/var/log/icecast
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8000"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8000 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
The infiniteproject/icecast image was causing issues:
- "bash: executable file not found" errors
- Container failing to start properly
- Healthcheck failures

Changes:
1. Switched to moul/icecast:latest - more maintained and reliable
2. Updated environment variable names to match moul/icecast format:
   - ICECAST_ADMIN_USER → ICECAST_ADMIN_USERNAME
   - ICECAST_CONTACT → ICECAST_ADMIN
3. Changed healthcheck format from ["CMD", ...] to ["CMD-SHELL", ...] for better reliability
4. Applied to both docker-compose.yml and docker-compose.embedded-db.yml

The moul/icecast image is well-maintained, Alpine-based, and properly supports environment variable configuration. This should resolve the startup issues and make Icecast run reliably out of the box.