### PR TITLE
Fix zero-config: App wasn't getting Icecast password, auto-config dis…

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -53,7 +53,7 @@ services:
       ICECAST_SERVER: ${ICECAST_SERVER:-icecast}
       ICECAST_PORT: ${ICECAST_INTERNAL_PORT:-8000}
       ICECAST_EXTERNAL_PORT: ${ICECAST_PORT:-8001}
-      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-}
+      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
       ICECAST_ENABLED: ${ICECAST_ENABLED:-true}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       ICECAST_SERVER: ${ICECAST_SERVER:-icecast}
       ICECAST_PORT: ${ICECAST_INTERNAL_PORT:-8000}
       ICECAST_EXTERNAL_PORT: ${ICECAST_PORT:-8001}
-      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-}
+      ICECAST_SOURCE_PASSWORD: ${ICECAST_SOURCE_PASSWORD:-eas_station_source_password}
       ICECAST_ENABLED: ${ICECAST_ENABLED:-true}
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
…abled

Critical bug: The app container's ICECAST_SOURCE_PASSWORD was defaulting to empty string instead of the working password, causing auto-config to be disabled. This resulted in "Basic Streaming Mode" instead of Icecast.

The bug:
- docker-compose.yml line 42: ICECAST_SOURCE_PASSWORD: ${...:-}  ❌ empty
- docker-compose.embedded-db.yml line 56: Same issue

The fix:
- Changed to: ICECAST_SOURCE_PASSWORD: ${...:-eas_station_source_password} ✅
- Now matches the Icecast container's default
- Auto-config will detect and enable Icecast

What was happening:
1. Icecast container started with password 'eas_station_source_password'
2. App container got empty password ''
3. Auto-config saw empty password, disabled itself
4. UI showed "Basic Streaming Mode" and Flask streaming
5. Flask stream returned 400 if source wasn't running

After this fix:
1. Both containers use same default password
2. Auto-config detects Icecast immediately
3. UI shows "Professional Streaming (Icecast)"
4. Zero-config works out of the box

Note: Users still need to START the audio source before playing it. The 400 error was because WNCI source wasn't started yet.