### PR TITLE
Fix Icecast changeowner: Explicitly enable in entrypoint script

### DIFF
--- a/docker-entrypoint-icecast.sh
+++ b/docker-entrypoint-icecast.sh
@@ -28,6 +28,9 @@ update_config "admin" "${ICECAST_ADMIN:-icemaster@localhost}"
 update_config "clients" "${ICECAST_MAX_CLIENTS:-100}"
 update_config "sources" "${ICECAST_MAX_SOURCES:-2}"
 
+# Enable changeowner for security (allows Icecast to drop root privileges)
+update_config "changeowner" "true"
+
 echo "Icecast configuration complete. Starting server..."
 
 # Execute the command


### PR DESCRIPTION
The entrypoint script was not setting changeowner=true, causing Icecast to refuse to run as root. This explicitly enables it so Icecast can drop privileges on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Icecast configuration to drop root privileges, enhancing security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->