### PR TITLE
Fix Icecast root issue: Use gosu to drop privileges

### DIFF
--- a/Dockerfile.icecast
+++ b/Dockerfile.icecast
@@ -1,15 +1,19 @@
 FROM debian:bookworm-slim
 
-# Install Icecast
+# Install Icecast and gosu for privilege dropping
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         icecast2 \
         wget \
         curl \
+        gosu \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure Icecast to run in foreground (keep changeowner enabled for security)
+# Configure Icecast to run in foreground
 RUN sed -i 's/<background>1<\/background>/<background>0<\/background>/' /etc/icecast2/icecast.xml
+
+# Make config writable by icecast2 user
+RUN chown icecast2:icecast /etc/icecast2/icecast.xml
 
 # Expose Icecast port
 EXPOSE 8000

--- a/docker-entrypoint-icecast.sh
+++ b/docker-entrypoint-icecast.sh
@@ -33,5 +33,5 @@ update_config "changeowner" "true"
 
 echo "Icecast configuration complete. Starting server..."
 
-# Execute the command
-exec "$@"
+# Drop privileges and execute icecast as icecast2 user
+exec gosu icecast2 "$@"


### PR DESCRIPTION
The real fix - run entrypoint as root (to modify config), then use gosu to drop privileges to icecast2 user before starting Icecast.

Changes:
- Install gosu in Dockerfile
- Make icecast.xml writable by icecast2 user
- Use 'exec gosu icecast2' in entrypoint to drop privileges
- This avoids the 'should not run as root' error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container security by implementing privilege management to run the application with minimal required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->