### PR TITLE
Fix Icecast healthcheck: Use curl instead of wget

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -189,7 +189,7 @@ services:
     volumes:
       - icecast-logs:/var/log/icecast2
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8000 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
     volumes:
       - icecast-logs:/var/log/icecast2
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8000 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
The healthcheck was failing because it used wget but we only installed curl in the Dockerfile. Changed both compose files to use curl.

This fixes the 'unhealthy' status in Portainer/Docker.