### PR TITLE
Fix IcecastStreamer initialization: Start in stopped state

### DIFF
--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -71,6 +71,7 @@ class IcecastStreamer:
         self._ffmpeg_process: Optional[subprocess.Popen] = None
         self._feeder_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._stop_event.set()  # Start in stopped state
 
         # Statistics
         self._start_time = 0.0


### PR DESCRIPTION
BUG: IcecastStreamer._stop_event was initialized as NOT SET, which means the first call to start() would fail with 'already running' warning.

FIX: Explicitly set _stop_event on initialization so it starts in the stopped state, allowing start() to work on first call.

This was preventing mount points from appearing in Icecast admin page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio streaming status initialization to correctly reflect stopped state before streaming begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->