### PR TITLE
Fix IcecastStreamer: Use correct method name get_audio_chunk()

### DIFF
--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -222,7 +222,7 @@ class IcecastStreamer:
 
             try:
                 # Read audio from source
-                samples = self.audio_source.read_audio(chunk_samples)
+                samples = self.audio_source.get_audio_chunk(timeout=0.1)
 
                 if samples is not None:
                     # Convert float32 [-1, 1] to int16 PCM


### PR DESCRIPTION
BUG: IcecastStreamer was calling audio_source.read_audio() which doesn't exist. The correct method name is get_audio_chunk(timeout).

This was causing 'StreamSourceAdapter' object has no attribute 'read_audio' errors and preventing mount points from appearing.