### PR TITLE
Fix slow audio stream caused by sample rate mismatch

### DIFF
--- a/app_core/audio/auto_streaming.py
+++ b/app_core/audio/auto_streaming.py
@@ -146,6 +146,13 @@ class AutoStreamingService:
                 return False
 
             try:
+                # Detect sample rate from audio source
+                sample_rate = 44100  # Default
+                if hasattr(audio_source, 'config') and hasattr(audio_source.config, 'sample_rate'):
+                    sample_rate = audio_source.config.sample_rate
+                elif hasattr(audio_source, 'sample_rate'):
+                    sample_rate = audio_source.sample_rate
+
                 # Create Icecast configuration
                 config = IcecastConfig(
                     server=self.icecast_server,
@@ -157,7 +164,8 @@ class AutoStreamingService:
                     genre="Emergency Alert System",
                     bitrate=bitrate or self.default_bitrate,
                     format=self.default_format,
-                    public=False
+                    public=False,
+                    sample_rate=sample_rate
                 )
 
                 # Create and start streamer

--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -46,6 +46,7 @@ class IcecastConfig:
     bitrate: int = 128
     format: StreamFormat = StreamFormat.MP3
     public: bool = False
+    sample_rate: int = 44100  # Audio sample rate in Hz
 
 
 class IcecastStreamer:
@@ -148,7 +149,7 @@ class IcecastStreamer:
             cmd = [
                 'ffmpeg',
                 '-f', 's16le',  # Input: 16-bit PCM
-                '-ar', '22050',  # Sample rate
+                '-ar', str(self.config.sample_rate),  # Sample rate
                 '-ac', '1',      # Mono
                 '-i', 'pipe:0',  # Read from stdin
             ]
@@ -205,7 +206,7 @@ class IcecastStreamer:
         """Feed audio to FFmpeg for encoding and streaming."""
         logger.debug("Icecast feed loop started")
 
-        chunk_samples = int(22050 * 0.1)  # 100ms chunks at 22050 Hz
+        chunk_samples = int(self.config.sample_rate * 0.1)  # 100ms chunks
 
         while not self._stop_event.is_set():
             if not self._ffmpeg_process or self._ffmpeg_process.poll() is not None:


### PR DESCRIPTION
The audio was playing at half speed because the Icecast streamer had a hardcoded sample rate of 22050 Hz while audio sources default to 44100 Hz.

Changes:
- Add sample_rate parameter to IcecastConfig (defaults to 44100 Hz)
- Update FFmpeg command to use configurable sample rate
- Update chunk calculation to use configurable sample rate
- Auto-detect sample rate from audio source in AutoStreamingService

This ensures audio plays at the correct speed by matching the source's actual sample rate instead of assuming 22050 Hz.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio streaming with automatic sample rate detection from audio sources, defaulting to 44100 Hz.
  * Added configurable sample rate settings for audio stream output to optimize compatibility with different audio sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->