### PR TITLE
Fix Icecast 403 Forbidden error caused by XML config update failure

### DIFF
--- a/Dockerfile.icecast
+++ b/Dockerfile.icecast
@@ -7,6 +7,7 @@ RUN apt-get update && \
         wget \
         curl \
         gosu \
+        perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure Icecast to run in foreground

--- a/docker-entrypoint-icecast.sh
+++ b/docker-entrypoint-icecast.sh
@@ -3,12 +3,14 @@ set -e
 
 CONFIG_FILE="/etc/icecast2/icecast.xml"
 
-# Function to update XML config values
+# Function to update XML config values (handles multiline and whitespace)
 update_config() {
     local tag=$1
     local value=$2
     if [ -n "$value" ]; then
-        sed -i "s|<${tag}>[^<]*</${tag}>|<${tag}>${value}</${tag}>|g" "$CONFIG_FILE"
+        # Use perl for better multiline regex support
+        # This handles: <tag>value</tag>, <tag> value </tag>, and multiline variants
+        perl -i -0777 -pe "s|<${tag}>.*?</${tag}>|<${tag}>${value}</${tag}>|gs" "$CONFIG_FILE"
     fi
 }
 


### PR DESCRIPTION
The sed command in docker-entrypoint-icecast.sh was failing to properly update Icecast XML config when tags had whitespace or newlines. This caused the source-password to not be updated, resulting in 403 Forbidden errors.

Changes:
- Replace sed with perl for robust multiline XML handling
- Add perl to Icecast Docker image
- Use non-greedy regex to handle whitespace and newlines correctly

This ensures the ICECAST_SOURCE_PASSWORD environment variable properly updates the Icecast configuration, fixing authentication failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Icecast Docker container image with additional runtime support.
  * Improved configuration update mechanism for more reliable XML handling during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->