### PR TITLE
Fix duplicate depends_on key in docker-compose.embedded-db.yml

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -20,6 +20,8 @@ services:
     depends_on:
       alerts-db:
         condition: service_healthy
+      icecast:
+        condition: service_healthy
     ports:
       - "80:5000"
     env_file:
@@ -64,11 +66,6 @@ services:
       - SYS_RAWIO
     security_opt:
       - no-new-privileges:true
-    depends_on:
-      alerts-db:
-        condition: service_healthy
-      icecast:
-        condition: service_healthy
 
   poller:
     image: eas-station:latest


### PR DESCRIPTION
- Merged Icecast dependency into existing depends_on section
- Removed duplicate depends_on that caused YAML parse error
- App now waits for both alerts-db and icecast to be healthy