### PR TITLE
Expose Icecast stream metadata to audio monitor

### DIFF
--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -293,16 +293,27 @@ class IcecastStreamer:
         """Get streaming statistics."""
         uptime = time.time() - self._start_time if self._start_time > 0 else 0
 
+        # Guard against division by zero when calculating bitrate
+        if uptime <= 0:
+            bitrate = 0.0
+        else:
+            bitrate = (self._bytes_sent * 8 / 1000) / uptime
+
         return {
             'running': not self._stop_event.is_set(),
             'uptime_seconds': uptime,
             'bytes_sent': self._bytes_sent,
-            'bitrate_kbps': (self._bytes_sent * 8 / 1000 / max(uptime, 1)),
+            'bitrate_kbps': bitrate,
             'reconnect_count': self._reconnect_count,
             'last_error': self._last_error,
             'server': self.config.server,
             'port': self.config.port,
             'mount': self.config.mount,
+            'name': self.config.name,
+            'description': self.config.description,
+            'genre': self.config.genre,
+            'format': self.config.format.value,
+            'public': self.config.public,
         }
 
 

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -222,16 +222,22 @@ function renderAudioSources() {
                     <!-- Audio Player -->
                     <div class="audio-player-container" id="player-container-${source.name}">
                         ${source.status === 'running' ? `
-                            <audio controls id="audio-${source.name}">
-                                ${source.icecast_url ? `
-                                    <source src="${source.icecast_url}" type="audio/mpeg">
-                                ` : ''}
-                                <source src="/api/audio/stream/${encodeURIComponent(source.name)}" type="audio/wav">
+                            <audio controls id="audio-${source.name}" src="${source.icecast_url || `/api/audio/stream/${encodeURIComponent(source.name)}`}" data-stream-type="${source.icecast_url ? 'icecast' : 'flask-proxy'}">
                                 Your browser does not support the audio element.
                             </audio>
                             ${source.icecast_url ? `
                                 <small class="text-success d-block mt-1">
                                     <i class="fas fa-broadcast-tower"></i> Professional Streaming (Icecast) - Better quality, no dropouts
+                                    ${source.streaming && source.streaming.icecast ? `
+                                        <span class="d-block text-muted small mt-1">
+                                            ${typeof source.streaming.icecast.bitrate_kbps === 'number' ? `${Number(source.streaming.icecast.bitrate_kbps).toFixed(1)} kbps` : ''}
+                                            ${typeof source.streaming.icecast.uptime_seconds === 'number' ? `
+                                                <span class="ms-2">
+                                                    <i class="fas fa-clock"></i> Uptime ${Math.floor(source.streaming.icecast.uptime_seconds / 60)}m
+                                                </span>
+                                            ` : ''}
+                                        </span>
+                                    ` : ''}
                                 </small>
                             ` : `
                                 <small class="text-muted d-block mt-1">
@@ -342,6 +348,24 @@ function renderAudioSources() {
                                         <div class="d-flex justify-content-between mb-1">
                                             <span class="text-muted">URL:</span>
                                             <span class="font-monospace small text-break">${escapeHtml(source.metrics.metadata.stream_url)}</span>
+                                        </div>
+                                    ` : ''}
+                                    ${source.metrics.metadata.icecast_stream_url && source.metrics.metadata.icecast_stream_url !== source.metrics.metadata.stream_url ? `
+                                        <div class="d-flex justify-content-between mb-1">
+                                            <span class="text-muted">Icecast URL:</span>
+                                            <span class="font-monospace small text-break">${escapeHtml(source.metrics.metadata.icecast_stream_url)}</span>
+                                        </div>
+                                    ` : ''}
+                                    ${source.metrics.metadata.icecast_server ? `
+                                        <div class="d-flex justify-content-between mb-1">
+                                            <span class="text-muted">Icecast Server:</span>
+                                            <span class="font-monospace small text-break">${escapeHtml(source.metrics.metadata.icecast_server)}${source.metrics.metadata.icecast_port ? `:${source.metrics.metadata.icecast_port}` : ''}</span>
+                                        </div>
+                                    ` : ''}
+                                    ${source.metrics.metadata.icecast_mount ? `
+                                        <div class="d-flex justify-content-between mb-1">
+                                            <span class="text-muted">Mount:</span>
+                                            <span class="font-monospace small text-break">${escapeHtml(source.metrics.metadata.icecast_mount)}</span>
                                         </div>
                                     ` : ''}
                                 </div>


### PR DESCRIPTION
## Summary
- augment the Icecast streamer stats with descriptive fields that can be surfaced in the UI
- enrich the /api/audio/sources payload with sanitized metadata, Icecast status, and database fallbacks so clients regain stream details
- update the audio monitor page to render Icecast-specific metadata and status badges alongside the existing stream info

## Testing
- PYTHONPATH=. pytest tests/test_audio_ingest.py *(fails: known SilenceDetector and AudioHealthMonitor expectations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f79fa105c8320ad0e7708fe7b92f6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved division by zero error in streaming bitrate calculations.

* **New Features**
  * Enhanced Icecast streaming interface with live metadata display (bitrate, uptime).
  * Expanded audio monitoring dashboard with comprehensive stream information including Icecast configuration details.
  * Extended streaming statistics with additional metadata fields (name, description, genre, format, public status).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->