### PR TITLE
Align navbar with RBAC permissions and document auth tree

### DIFF
--- a/docs/development/AUTH_PERMISSION_TREE.md
+++ b/docs/development/AUTH_PERMISSION_TREE.md
@@ -1,0 +1,107 @@
+# Authentication & RBAC Function Tree
+
+This reference lists every Flask route that enforces authentication or role-based permissions. It is organised by module so developers can quickly identify where RBAC rules apply and which default roles (Admin / Operator / Viewer) satisfy each requirement.
+
+## Legend
+- **Login required** – endpoint checks for an authenticated `g.current_user`. All standard roles qualify once signed in.
+- **Permission required** – endpoint uses `@require_permission(...)`. Default role coverage is derived from `DEFAULT_ROLE_PERMISSIONS`.
+- **First-user bypass** – endpoint allows unauthenticated access only while creating the very first admin account.
+
+---
+
+## 1. Login-gated Routes (any authenticated role)
+
+### `webapp/eas/workflow.py`
+- `/eas/` → `workflow_home` — Login required via `_auth_redirect()`.【F:webapp/eas/workflow.py†L47-L77】
+- `/eas/manual/generate` (POST) → `manual_eas_generate` — Login required (JSON 401 if unauthenticated).【F:webapp/eas/workflow.py†L102-L135】
+- `/eas/manual/events` (GET) → `manual_eas_events` — Login required for listing manual activations.【F:webapp/eas/workflow.py†L520-L567】
+- `/eas/manual/events/<id>/print` → `manual_eas_print` — Login required before rendering print view.【F:webapp/eas/workflow.py†L594-L640】
+- `/eas/manual/events/<id>/export` → `manual_eas_export` — Login required; unauthenticated requests receive 401.【F:webapp/eas/workflow.py†L649-L692】
+- `/eas/manual/events/<id>` (DELETE) → `manual_eas_delete` — Login required before deleting records.【F:webapp/eas/workflow.py†L674-L707】
+- `/eas/manual/events/purge` (POST) → `manual_eas_purge` — Login required for bulk purge actions.【F:webapp/eas/workflow.py†L708-L756】
+
+### `webapp/eas/messages.py`
+- `/eas/messages/purge` (POST) → `purge_eas_messages` — Login required for message purges.【F:webapp/eas/messages.py†L50-L110】
+
+### `webapp/admin/audio.py`
+- `/admin/eas_messages/purge` (POST) → `admin_purge_eas_messages` — Login required to bulk-delete generated audio.【F:webapp/admin/audio.py†L538-L618】
+- `/admin/eas/manual_generate` (POST) → `admin_manual_eas_generate` — Login required (first-user bypass allowed).【F:webapp/admin/audio.py†L621-L706】
+- `/admin/eas/manual_events` (GET) → `admin_manual_eas_events` — Login required to list manual events (first-user bypass).【F:webapp/admin/audio.py†L992-L1038】
+- `/admin/eas/manual_events/<id>/print` → `manual_eas_print` — Redirects unauthenticated users to login.【F:webapp/admin/audio.py†L1105-L1150】
+- `/admin/eas/manual_events/<id>/export` → `manual_eas_export` — Returns HTTP 401 when unauthenticated.【F:webapp/admin/audio.py†L1154-L1189】
+
+### `webapp/admin/dashboard.py`
+- `/admin/users` (POST) → `admin_users` — Login required to create users (first-user bypass).【F:webapp/admin/dashboard.py†L164-L218】
+
+### `webapp/routes_setup.py`
+- `/setup` (GET/POST) → `setup_wizard` — Redirects unauthenticated users to login once setup mode is disabled.【F:webapp/routes_setup.py†L45-L96】
+- `/setup/generate-secret` (POST) → `setup_generate_secret` — Returns 401 when setup mode is off and user is not logged in.【F:webapp/routes_setup.py†L213-L233】
+- `/setup/view-env` (GET) → `setup_view_env` — Requires login outside setup mode.【F:webapp/routes_setup.py†L261-L309】
+- `/setup/download-env` (GET) → `setup_download_env` — Requires login outside setup mode.【F:webapp/routes_setup.py†L312-L338】
+- `/setup/upload-env` (POST) → `setup_upload_env` — Requires login outside setup mode.【F:webapp/routes_setup.py†L339-L386】
+- `/setup/lookup-county-fips` (POST) → `setup_lookup_county_fips` — Requires login outside setup mode.【F:webapp/routes_setup.py†L387-L446】
+- `/setup/derive-zone-codes` (POST) → `setup_derive_zone_codes` — Requires login outside setup mode.【F:webapp/routes_setup.py†L447-L502】
+
+### `webapp/routes_security.py`
+- `/security/settings` (GET) → `security_settings` — Redirects to `/login` when unauthenticated.【F:webapp/routes_security.py†L505-L520】
+
+---
+
+## 2. Permission-gated Routes
+
+Default role coverage per permission (from `DEFAULT_ROLE_PERMISSIONS`):
+
+| Permission | Roles with access |
+|------------|------------------|
+| `system.view_config` | Admin, Operator, Viewer |
+| `system.configure` | Admin |
+| `system.manage_users` | Admin |
+| `system.view_users` | Admin, Operator, Viewer |
+| `logs.view` | Admin, Operator, Viewer |
+| `logs.export` | Admin, Operator, Viewer |
+| `alerts.export` | Admin, Operator, Viewer |
+| `analytics_manage` | _None by default (must be assigned manually)_ |
+
+### `webapp/admin/environment.py`
+- `/api/environment/categories` (GET) → `get_environment_categories` — `system.view_config`.
+- `/api/environment/variables` (GET) → `get_environment_variables` — `system.view_config`.
+- `/api/environment/variables` (PUT) → `update_environment_variables` — `system.configure` (Admin only).
+- `/api/environment/validate` (GET) → `validate_environment` — `system.view_config`.
+- `/settings/environment` (GET) → `environment_settings` — `system.view_config` (reveals whether the current user also has `system.configure`).
+- `/admin/environment/download-env` (GET) → `admin_download_env` — `system.view_config`.
+- `/api/environment/generate-secret` (POST) → `generate_secret_key_api` — `system.configure`.
+【F:webapp/admin/environment.py†L780-L1059】
+
+### `webapp/routes_security.py`
+- `/security/roles` (GET) → `list_roles` — `system.view_users`.
+- `/security/roles/<id>` (GET) → `get_role` — `system.view_users`.
+- `/security/roles` (POST) → `create_role` — `system.manage_users`.
+- `/security/roles/<id>` (PUT) → `update_role` — `system.manage_users`.
+- `/security/permissions` (GET) → `list_permissions` — `system.view_users`.
+- `/security/users/<user_id>/role` (PUT) → `assign_user_role` — `system.manage_users`.
+- `/security/audit-logs` (GET) → `list_audit_logs` — `logs.view`.
+- `/security/audit-logs/export` (GET) → `export_audit_logs` — `logs.export`.
+- `/security/init-roles` (POST) → `init_default_roles` — `system.manage_users`.
+【F:webapp/routes_security.py†L208-L474】
+
+### `webapp/routes_analytics.py`
+- `/api/analytics/metrics/aggregate` (POST) → `aggregate_metrics` — `analytics_manage` (assign to roles as needed).
+- `/api/analytics/trends/analyze` (POST) → `analyze_trends` — `analytics_manage`.
+- `/api/analytics/anomalies/detect` (POST) → `anomaly_detector` (logged under `anomalies` endpoint) — `analytics_manage`.
+- `/api/analytics/anomalies/<id>/acknowledge` (POST) → `acknowledge_anomaly` — `analytics_manage`.
+- `/api/analytics/anomalies/<id>/resolve` (POST) → `resolve_anomaly` — `analytics_manage`.
+- `/api/analytics/anomalies/<id>/false-positive` (POST) → `mark_anomaly_false_positive` — `analytics_manage`.
+【F:webapp/routes_analytics.py†L118-L424】
+
+### `webapp/routes_security.py` (Exports & Tools)
+- `/security/permissions/check` (POST) → `check_permission` — used by UI to probe permission state; no decorator so it mirrors current session privileges.【F:webapp/routes_security.py†L484-L504】
+
+---
+
+## 3. Navigation Visibility Alignment
+
+The main navigation template now mirrors these RBAC rules by hiding dropdowns or menu items unless the current session holds the required permission. For example, the “System” menu only appears when `system.view_config`, `gpio.view`, `logs.view`, or `alerts.export` is granted, and the “Admin” menu becomes visible only when at least one admin/security permission is available.【F:templates/components/navbar.html†L1-L344】
+
+---
+
+Keep this document current whenever authentication rules change so UI, backend, and documentation remain in sync.

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -1,4 +1,46 @@
 <!-- Navigation Component -->
+{% set is_authenticated = current_user is defined and current_user and current_user.is_authenticated %}
+{% set can_view_eas = has_permission('eas.view') %}
+{% set can_manage_receivers = has_permission('receivers.view') %}
+{% set can_view_gpio = has_permission('gpio.view') %}
+{% set can_view_system_config = has_permission('system.view_config') %}
+{% set can_manage_config = has_permission('system.configure') %}
+{% set can_view_logs = has_permission('logs.view') %}
+{% set can_export_alerts = has_permission('alerts.export') %}
+{% set can_manage_users = has_permission('system.manage_users') %}
+{% set can_view_users = has_permission('system.view_users') or can_manage_users %}
+{% set can_view_alerts = has_permission('alerts.view') %}
+{% set can_manage_analytics = has_permission('analytics_manage') %}
+
+{% set show_broadcast_workflow = can_view_eas %}
+{% set show_led = can_view_eas %}
+{% set show_vfd = can_view_eas %}
+{% set show_screens = can_view_eas %}
+{% set show_radio = can_manage_receivers %}
+{% set show_audio_settings = can_manage_receivers %}
+{% set show_broadcast_dropdown = show_broadcast_workflow or show_led or show_vfd or show_screens or show_radio or show_audio_settings %}
+
+{% set show_gpio_control = can_view_gpio %}
+{% set show_gpio_stats = can_view_gpio %}
+{% set show_system_settings = can_view_system_config %}
+{% set show_environment = can_view_system_config %}
+{% set show_ipaws = can_view_alerts %}
+{% set show_logs = can_view_logs %}
+{% set show_export_alerts = can_export_alerts %}
+{% set show_export_boundaries = can_export_alerts %}
+{% set show_export_statistics = can_export_alerts %}
+{% set show_system_dropdown = show_gpio_control or show_gpio_stats or show_system_settings or show_environment or show_ipaws or show_logs or show_export_alerts or show_export_boundaries or show_export_statistics %}
+
+{% set show_admin_rbac = can_manage_users %}
+{% set show_admin_audit = can_view_logs %}
+{% set show_admin_security = is_authenticated %}
+{% set show_admin_operations = can_manage_config %}
+{% set show_admin_intersections = can_view_alerts %}
+{% set show_admin_alert_validation = can_view_alerts %}
+{% set show_admin_compliance = can_view_alerts %}
+{% set show_admin_analytics = can_manage_analytics or can_view_alerts %}
+{% set show_admin_dropdown = is_authenticated and (show_admin_rbac or show_admin_audit or show_admin_security or show_admin_operations or show_admin_intersections or show_admin_alert_validation or show_admin_compliance or show_admin_analytics) %}
+
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top shadow-sm">
     <div class="container-fluid">
         <div class="navbar-brand-group">
@@ -81,165 +123,242 @@
                     </li>
 
                     <!-- Broadcast Operations -->
+                    {% if show_broadcast_dropdown %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="broadcastDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="fas fa-tower-broadcast"></i>
                             <span class="d-none d-md-inline">Broadcast</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="broadcastDropdown">
+                            {% if show_broadcast_workflow %}
                             <li>
-                                <a class="dropdown-item" href="{{ url_for('eas.workflow_home') }}" {% if current_user is not defined or not current_user.is_authenticated %}title="Sign in required to create manual broadcasts."{% endif %}>
+                                <a class="dropdown-item" href="{{ url_for('eas.workflow_home') }}">
                                     <i class="fas fa-broadcast-tower"></i> Broadcast Workflow
-                                    {% if current_user is not defined or not current_user.is_authenticated %}
-                                    <i class="fas fa-lock small ms-1 text-warning"></i>
-                                    {% endif %}
                                 </a>
                             </li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">Display Outputs</h6></li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('led_control') }}">
-                                    <i class="fas fa-tv"></i> LED Sign
-                                </a>
-                            </li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('vfd_control') }}">
-                                    <i class="fas fa-desktop"></i> VFD Display
-                                </a>
-                            </li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('screens_page') }}">
-                                    <i class="fas fa-display"></i> Custom Screens
-                                </a>
-                            </li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">Input Sources</h6></li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('radio_settings') }}">
-                                    <i class="fas fa-signal"></i> Radio/SDR
-                                </a>
-                            </li>
-                            <li>
-                                <a class="dropdown-item" href="{{ url_for('audio_settings') }}">
-                                    <i class="fas fa-microphone"></i> Audio Streams
-                                </a>
-                            </li>
+                            {% endif %}
+                            {% set has_display_section = show_led or show_vfd or show_screens %}
+                            {% if has_display_section %}
+                                {% if show_broadcast_workflow %}
+                                <li><hr class="dropdown-divider"></li>
+                                {% endif %}
+                                <li><h6 class="dropdown-header">Display Outputs</h6></li>
+                                {% if show_led %}
+                                <li>
+                                    <a class="dropdown-item" href="{{ url_for('led_control') }}">
+                                        <i class="fas fa-tv"></i> LED Sign
+                                    </a>
+                                </li>
+                                {% endif %}
+                                {% if show_vfd %}
+                                <li>
+                                    <a class="dropdown-item" href="{{ url_for('vfd_control') }}">
+                                        <i class="fas fa-desktop"></i> VFD Display
+                                    </a>
+                                </li>
+                                {% endif %}
+                                {% if show_screens %}
+                                <li>
+                                    <a class="dropdown-item" href="{{ url_for('screens_page') }}">
+                                        <i class="fas fa-display"></i> Custom Screens
+                                    </a>
+                                </li>
+                                {% endif %}
+                            {% endif %}
+                            {% set has_input_section = show_radio or show_audio_settings %}
+                            {% if has_input_section %}
+                                {% if show_broadcast_workflow or has_display_section %}
+                                <li><hr class="dropdown-divider"></li>
+                                {% endif %}
+                                <li><h6 class="dropdown-header">Input Sources</h6></li>
+                                {% if show_radio %}
+                                <li>
+                                    <a class="dropdown-item" href="{{ url_for('radio_settings') }}">
+                                        <i class="fas fa-signal"></i> Radio/SDR
+                                    </a>
+                                </li>
+                                {% endif %}
+                                {% if show_audio_settings %}
+                                <li>
+                                    <a class="dropdown-item" href="{{ url_for('audio_settings') }}">
+                                        <i class="fas fa-microphone"></i> Audio Streams
+                                    </a>
+                                </li>
+                                {% endif %}
+                            {% endif %}
                         </ul>
                     </li>
+                    {% endif %}
 
                     <!-- System Management -->
+                    {% if show_system_dropdown %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="systemDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="fas fa-server"></i>
                             <span class="d-none d-md-inline">System</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="systemDropdown">
+                            {% if show_gpio_control or show_gpio_stats %}
                             <li><h6 class="dropdown-header">Hardware</h6></li>
+                            {% if show_gpio_control %}
                             <li>
                                 <a class="dropdown-item" href="/admin/gpio">
                                     <i class="fas fa-microchip"></i> GPIO Control
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_gpio_stats %}
                             <li>
                                 <a class="dropdown-item" href="/admin/gpio/statistics">
                                     <i class="fas fa-chart-pie"></i> GPIO Statistics
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_system_settings or show_environment or show_ipaws or show_logs or show_export_alerts %}
                             <li><hr class="dropdown-divider"></li>
+                            {% endif %}
+                            {% endif %}
+                            {% if show_system_settings or show_environment or show_ipaws %}
                             <li><h6 class="dropdown-header">Configuration</h6></li>
+                            {% if show_system_settings %}
                             <li>
                                 <a class="dropdown-item" href="/admin">
                                     <i class="fas fa-sliders"></i> System Settings
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_environment %}
                             <li>
                                 <a class="dropdown-item" href="/settings/environment">
                                     <i class="fas fa-cog"></i> Environment
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_ipaws %}
                             <li>
                                 <a class="dropdown-item" href="/debug/ipaws">
                                     <i class="fas fa-satellite"></i> IPAWS Debug
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_logs or show_export_alerts %}
                             <li><hr class="dropdown-divider"></li>
+                            {% endif %}
+                            {% endif %}
+                            {% if show_logs or show_export_alerts %}
                             <li><h6 class="dropdown-header">Data & Logs</h6></li>
+                            {% if show_logs %}
                             <li>
                                 <a class="dropdown-item" href="/logs">
                                     <i class="fas fa-file-alt"></i> System Logs
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_export_alerts %}
                             <li>
                                 <a class="dropdown-item" href="/export/alerts">
                                     <i class="fas fa-download"></i> Export Alerts
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_export_boundaries %}
                             <li>
                                 <a class="dropdown-item" href="/export/boundaries">
                                     <i class="fas fa-download"></i> Export Boundaries
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_export_statistics %}
                             <li>
                                 <a class="dropdown-item" href="/export/statistics">
                                     <i class="fas fa-download"></i> Export Statistics
                                 </a>
                             </li>
+                            {% endif %}
+                            {% endif %}
                         </ul>
                     </li>
+                    {% endif %}
 
                     <!-- Admin & Security -->
-                    {% if current_user is defined and current_user.is_authenticated %}
+                    {% if show_admin_dropdown %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="adminDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="fas fa-shield-alt"></i>
                             <span class="d-none d-md-inline">Admin</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="adminDropdown">
+                            {% if show_admin_rbac or show_admin_audit or show_admin_security %}
                             <li><h6 class="dropdown-header">Security</h6></li>
+                            {% if show_admin_rbac %}
                             <li>
                                 <a class="dropdown-item" href="/admin/rbac">
                                     <i class="fas fa-user-shield"></i> RBAC Management
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_audit %}
                             <li>
                                 <a class="dropdown-item" href="/admin/audit-logs">
                                     <i class="fas fa-clipboard-list"></i> Audit Logs
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_security %}
                             <li>
                                 <a class="dropdown-item" href="/security/settings">
                                     <i class="fas fa-lock"></i> Security Settings
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_operations or show_admin_intersections or show_admin_alert_validation or show_admin_compliance or show_admin_analytics %}
                             <li><hr class="dropdown-divider"></li>
+                            {% endif %}
+                            {% endif %}
+                            {% if show_admin_operations or show_admin_intersections %}
                             <li><h6 class="dropdown-header">Operations & Maintenance</h6></li>
+                            {% if show_admin_operations %}
                             <li>
                                 <a class="dropdown-item" href="/admin/operations">
                                     <i class="fas fa-cogs"></i> Admin Operations
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_intersections %}
                             <li>
                                 <a class="dropdown-item" href="/admin/intersections">
                                     <i class="fas fa-project-diagram"></i> Intersection Management
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_alert_validation or show_admin_compliance or show_admin_analytics %}
                             <li><hr class="dropdown-divider"></li>
+                            {% endif %}
+                            {% endif %}
+                            {% if show_admin_alert_validation or show_admin_compliance or show_admin_analytics %}
                             <li><h6 class="dropdown-header">Compliance & Analytics</h6></li>
+                            {% if show_admin_alert_validation %}
                             <li>
                                 <a class="dropdown-item" href="{{ url_for('alert_verification') }}">
                                     <i class="fas fa-shield-check"></i> Alert Validation
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_compliance %}
                             <li>
                                 <a class="dropdown-item" href="{{ url_for('compliance_dashboard') }}">
                                     <i class="fas fa-clipboard-check"></i> Compliance Dashboard
                                 </a>
                             </li>
+                            {% endif %}
+                            {% if show_admin_analytics %}
                             <li>
                                 <a class="dropdown-item" href="/analytics">
                                     <i class="fas fa-chart-line"></i> Analytics
                                 </a>
                             </li>
+                            {% endif %}
+                            {% endif %}
                         </ul>
                     </li>
                     {% endif %}


### PR DESCRIPTION
## Summary
- gate broadcast, system, and admin navigation menus behind the appropriate RBAC permission checks
- add an authentication tree reference in `docs/development` covering all login- and permission-protected endpoints

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f86428f248320b2bc4f9fb7d4649a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive reference guide documenting authentication and permission enforcement throughout the application.

* **UI Improvements**
  * Navigation menu now dynamically displays sections—including Broadcast, System, and Admin controls—based on your assigned permissions, ensuring you only see relevant options for your role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->