### PR TITLE
Add ICY metadata parsing for stream sources

### DIFF
--- a/app_core/audio/auto_streaming.py
+++ b/app_core/audio/auto_streaming.py
@@ -37,6 +37,8 @@ class AutoStreamingService:
         icecast_server: str = "localhost",
         icecast_port: int = 8000,
         icecast_password: str = "",
+        icecast_admin_user: Optional[str] = None,
+        icecast_admin_password: Optional[str] = None,
         default_bitrate: int = 128,
         default_format: StreamFormat = StreamFormat.MP3,
         enabled: bool = False
@@ -55,6 +57,8 @@ class AutoStreamingService:
         self.icecast_server = icecast_server
         self.icecast_port = icecast_port
         self.icecast_password = icecast_password
+        self.icecast_admin_user = icecast_admin_user
+        self.icecast_admin_password = icecast_admin_password
         self.default_bitrate = default_bitrate
         self.default_format = default_format
         self.enabled = enabled
@@ -165,7 +169,9 @@ class AutoStreamingService:
                     bitrate=bitrate or self.default_bitrate,
                     format=self.default_format,
                     public=False,
-                    sample_rate=sample_rate
+                    sample_rate=sample_rate,
+                    admin_user=self.icecast_admin_user,
+                    admin_password=self.icecast_admin_password,
                 )
 
                 # Create and start streamer

--- a/app_core/audio/icecast_auto_config.py
+++ b/app_core/audio/icecast_auto_config.py
@@ -23,6 +23,8 @@ class IcecastAutoConfig:
         self.source_password = ""
         self.external_port = 8001  # For generating URLs accessible from browser
         self.public_hostname = None  # Public hostname/IP for browser access
+        self.admin_user = None
+        self.admin_password = None
 
         self._detect_config()
 
@@ -50,6 +52,16 @@ class IcecastAutoConfig:
             # Get server and port
             self.server = os.environ.get('ICECAST_SERVER', 'icecast')
             self.port = int(os.environ.get('ICECAST_PORT', '8000'))
+
+            # Admin credentials (optional, but required for metadata updates)
+            self.admin_user = os.environ.get('ICECAST_ADMIN_USER')
+            self.admin_password = os.environ.get('ICECAST_ADMIN_PASSWORD')
+            if bool(self.admin_user) ^ bool(self.admin_password):
+                logger.warning(
+                    "Icecast auto-configuration: Admin username/password mismatch. "
+                    "Metadata updates will be disabled until both ICECAST_ADMIN_USER "
+                    "and ICECAST_ADMIN_PASSWORD are provided."
+                )
 
             # For external URLs (browser access), use the external port
             external_port_str = os.environ.get('ICECAST_EXTERNAL_PORT')
@@ -123,6 +135,7 @@ class IcecastAutoConfig:
             'port': self.port,
             'external_port': self.external_port,
             'has_password': bool(self.source_password),
+            'has_admin_credentials': bool(self.admin_user and self.admin_password),
         }
 
 

--- a/app_core/audio/ingest.py
+++ b/app_core/audio/ingest.py
@@ -254,6 +254,9 @@ class AudioSourceAdapter(ABC):
             peak_db = rms_db = -np.inf
             silence_detected = True
 
+        # Preserve existing metadata (e.g., RBDS information) across metric updates
+        current_metadata = self.metrics.metadata if self.metrics else None
+
         # Update metrics
         self.metrics = AudioMetrics(
             timestamp=current_time,
@@ -263,7 +266,8 @@ class AudioSourceAdapter(ABC):
             channels=self.config.channels,
             frames_captured=self.metrics.frames_captured + len(audio_chunk),
             silence_detected=silence_detected,
-            buffer_utilization=self._audio_queue.qsize() / self._audio_queue.maxsize
+            buffer_utilization=self._audio_queue.qsize() / self._audio_queue.maxsize,
+            metadata=current_metadata,
         )
 
         self._last_metrics_update = current_time

--- a/webapp/admin/api.py
+++ b/webapp/admin/api.py
@@ -342,7 +342,7 @@ def register_api_routes(app, logger):
                 alerts_query = get_active_alerts_query()
                 logger.info("Including only active alerts in API response")
 
-            alerts = db.session.query(
+            alerts = alerts_query.with_entities(
                 CAPAlert.id,
                 CAPAlert.identifier,
                 CAPAlert.event,
@@ -353,8 +353,6 @@ def register_api_routes(app, logger):
                 CAPAlert.expires,
                 CAPAlert.area_desc,
                 func.ST_AsGeoJSON(CAPAlert.geom).label('geometry'),
-            ).filter(
-                CAPAlert.id.in_(alerts_query.with_entities(CAPAlert.id).subquery())
             ).all()
 
             county_boundary = None

--- a/webapp/admin/audio_ingest.py
+++ b/webapp/admin/audio_ingest.py
@@ -249,6 +249,8 @@ def _initialize_auto_streaming() -> None:
                 icecast_server=auto_config.server,
                 icecast_port=auto_config.port,
                 icecast_password=auto_config.source_password,
+                icecast_admin_user=auto_config.admin_user,
+                icecast_admin_password=auto_config.admin_password,
                 default_bitrate=128,
                 enabled=True
             )


### PR DESCRIPTION
## Summary
- start a background metadata listener for stream audio sources to harvest ICY updates
- parse StreamTitle/StreamUrl fields and merge them into the source metrics metadata cache
- expose now playing song and artist details so Icecast metadata updates have real payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f86676e7483209c4c6bbfe0d7b31c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic metadata polling and updates for Icecast audio streams when admin credentials are configured.
  * Introduced ICY metadata harvesting from stream sources.
  * Metadata is now preserved across system metric updates.

* **Improvements**
  * Enhanced metadata handling and persistence throughout the audio streaming pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->