### PR TITLE
Improve stream recovery and SQL warning handling

### DIFF
--- a/webapp/admin/api.py
+++ b/webapp/admin/api.py
@@ -462,6 +462,8 @@ def register_api_routes(app, logger):
                 end_dt = datetime.fromisoformat(end_date).replace(tzinfo=UTC_TZ)
                 query = query.filter(CAPAlert.sent <= end_dt)
 
+            matching_ids = query.with_entities(CAPAlert.id).scalar_subquery()
+
             alerts = db.session.query(
                 CAPAlert.id,
                 CAPAlert.identifier,
@@ -475,7 +477,7 @@ def register_api_routes(app, logger):
                 CAPAlert.area_desc,
                 func.ST_AsGeoJSON(CAPAlert.geom).label('geometry'),
             ).filter(
-                CAPAlert.id.in_(query.with_entities(CAPAlert.id).subquery())
+                CAPAlert.id.in_(matching_ids)
             ).all()
 
             county_boundary = None


### PR DESCRIPTION
## Summary
- clear the stream adapter error state after successful FFmpeg restarts and refresh its metadata
- keep the admin audio stream endpoint alive during transient adapter errors instead of disconnecting immediately
- update the historical alerts query to use scalar_subquery to avoid SQLAlchemy deprecation warnings

## Testing
- pytest tests/test_audio_ingest.py *(fails: ModuleNotFoundError: No module named 'app_core')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8a2a05048320abac5efb0b8aee1e)