### PR TITLE
Revamp system health containers view

### DIFF
--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -17,6 +17,14 @@
         .status-badge { font-size: 0.8em; }
         .system-overview { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; }
         .system-overview .card-body { background: rgba(255,255,255,0.1); backdrop-filter: blur(10px); }
+        .stack-summary { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.5rem 1rem; }
+        .stack-summary .metric-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; color: #6c757d; }
+        .stack-summary .metric-value { display: block; font-size: 1.1rem; font-weight: 600; }
+        .container-table { font-size: 0.85rem; }
+        .container-table th { text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; color: #6c757d; }
+        .container-table td, .container-table th { vertical-align: middle; }
+        .container-image { font-family: 'Courier New', monospace; font-size: 0.75rem; }
+        .container-meta { font-size: 0.75rem; color: #6c757d; }
     </style>
 {% endblock %}
 
@@ -201,13 +209,19 @@
                 </div>
             </div>
 
-            <!-- Services & Database -->
-            <div class="col-lg-4 mb-3" id="services-card">
+            <!-- Stack Overview -->
+            <div class="col-lg-4 mb-3" id="containers-card">
+                {% set containers_data = containers or {} %}
+                {% set summary = containers_data.summary or {} %}
+                {% set total_containers = summary.get('total', 0) %}
+                {% set running_containers = summary.get('running', 0) %}
+                {% set unhealthy_containers = summary.get('unhealthy', 0) %}
+                {% set stopped_containers = summary.get('stopped', total_containers - running_containers) %}
                 <div class="card health-card h-100">
                     <div class="card-body">
-                        <h5><i class="fas fa-cogs section-icon"></i> Services & Database</h5>
+                        <h5><i class="fas fa-layer-group section-icon"></i> Stack Services</h5>
 
-                        <!-- Database Status -->
+
                         <div class="d-flex justify-content-between align-items-center mb-2">
                             <span class="metric-label">Database</span>
                             {% set db_status = database.status or 'Unknown' %}
@@ -224,40 +238,90 @@
                         </div>
                         {% if database.info %}
                             {% if database.info.version %}
-                            <small class="text-muted d-block">Version: {{ database.info.version[:50] }}{% if database.info.version|length > 50 %}...{% endif %}</small>
+                            <small class="text-muted d-block">Version: {{ database.info.version[:60] }}{% if database.info.version|length > 60 %}…{% endif %}</small>
                             {% endif %}
                             {% if database.info.size %}
                             <small class="text-muted d-block">Size: {{ database.info.size }}</small>
                             {% endif %}
-                            {% if database.info.active_connections %}
+                            {% if database.info.active_connections is not none %}
                             <small class="text-muted d-block">Active Connections: {{ database.info.active_connections }}</small>
                             {% endif %}
                         {% endif %}
 
-                        <!-- System Services -->
-                        {% if services %}
+
                         <hr>
-                        <h6 class="text-muted">System Services</h6>
-                        {% for service_name, status in services.items() %}
-                        <div class="d-flex justify-content-between align-items-center mb-1">
-                            <span class="metric-label">{{ service_name.title() }}</span>
-                            {% set normalized_status = (status or '')|lower %}
-                            {% if normalized_status == 'active' %}
-                                {% set service_class = 'success' %}
-                            {% elif normalized_status in ['inactive', 'unknown', 'unavailable'] %}
-                                {% set service_class = 'secondary' %}
-                            {% else %}
-                                {% set service_class = 'danger' %}
-                            {% endif %}
-                            <span class="badge bg-{{ service_class }} status-badge">{{ status or 'unknown' }}</span>
+
+                        <div class="stack-summary mb-3">
+                            <div>
+                                <span class="metric-label">Containers</span>
+                                <span class="metric-value">{{ total_containers }}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-success">Running</span>
+                                <span class="metric-value text-success">{{ running_containers }}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-warning">Stopped</span>
+                                <span class="metric-value text-warning">{{ stopped_containers if stopped_containers >= 0 else 0 }}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-danger">Unhealthy</span>
+                                <span class="metric-value text-danger">{{ unhealthy_containers }}</span>
+                            </div>
                         </div>
-                        {% endfor %}
+
+                        {% if containers_data.available %}
+                            {% set preview = containers_data.containers[:4] if containers_data.containers else [] %}
+                            {% for container in preview %}
+                                {% set health = (container.health or '')|lower %}
+                                {% set state = (container.state or '')|lower %}
+                                {% if health == 'healthy' %}
+                                    {% set badge_class = 'success' %}
+                                    {% set status_label = 'Healthy' %}
+                                {% elif health == 'unhealthy' %}
+                                    {% set badge_class = 'danger' %}
+                                    {% set status_label = 'Unhealthy' %}
+                                {% elif health == 'starting' %}
+                                    {% set badge_class = 'warning' %}
+                                    {% set status_label = 'Starting' %}
+                                {% else %}
+                                    {% if state == 'running' %}
+                                        {% set badge_class = 'success' %}
+                                    {% elif state in ['restarting', 'created', 'paused'] %}
+                                        {% set badge_class = 'warning' %}
+                                    {% elif state in ['exited', 'dead'] %}
+                                        {% set badge_class = 'secondary' %}
+                                    {% else %}
+                                        {% set badge_class = 'secondary' %}
+                                    {% endif %}
+                                    {% set status_label = container.status or (state|upper if state else 'Unknown') %}
+                                {% endif %}
+                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                    <div>
+                                        <span class="metric-label">{{ container.display_name or container.name }}</span>
+                                        {% if container.service %}
+                                        <small class="text-muted d-block">{{ container.service }}</small>
+                                        {% endif %}
+                                    </div>
+                                    <span class="badge bg-{{ badge_class }} status-badge">{{ status_label }}</span>
+                                </div>
+                            {% endfor %}
+                            {% if containers_data.containers and containers_data.containers|length > 4 %}
+                                <small class="text-muted">… and {{ containers_data.containers|length - 4 }} more containers</small>
+                            {% elif not containers_data.containers %}
+                                <p class="text-muted mb-0">No containers detected for the current engine.</p>
+                            {% endif %}
+                            {% if containers_data.engine %}
+                                <small class="text-muted d-block mt-2">Engine: {{ containers_data.engine|upper }}{% if containers_data.compose_project %} • Project: {{ containers_data.compose_project }}{% endif %}</small>
+                            {% endif %}
+                        {% else %}
+                            <div class="alert alert-warning mb-0 py-2">
+                                Container information unavailable{% if containers_data.error %}: {{ containers_data.error }}{% endif %}
+                            </div>
                         {% endif %}
                     </div>
                 </div>
             </div>
-        </div>
-
         <!-- Storage & Network Row -->
         <div class="row mb-4">
             <!-- Disk Storage -->
@@ -319,6 +383,106 @@
 
                         {% if network.interfaces|length > 3 %}
                         <small class="text-muted">... and {{ network.interfaces|length - 3 }} more interfaces</small>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Container Details -->
+        <div class="row mb-4">
+            <div class="col-12" id="containers-details">
+                <div class="card health-card">
+                    <div class="card-body">
+                        <h5><i class="fas fa-boxes section-icon"></i> Container Details</h5>
+
+                        {% set containers_data = containers or {} %}
+                        {% set container_items = containers_data.containers or [] %}
+
+                        {% if containers_data.available and container_items %}
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover container-table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">Container</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Health</th>
+                                        <th scope="col">Uptime</th>
+                                        <th scope="col">Image</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for container in container_items %}
+                                    {% set status_label = container.status or (container.state|upper if container.state else 'Unknown') %}
+                                    {% set state = (container.state or '')|lower %}
+                                    {% set health = (container.health or '')|lower %}
+                                    {% if health == 'healthy' %}
+                                        {% set status_class = 'success' %}
+                                    {% elif health == 'unhealthy' %}
+                                        {% set status_class = 'danger' %}
+                                    {% elif state == 'running' %}
+                                        {% set status_class = 'success' %}
+                                    {% elif state in ['restarting', 'created', 'paused'] %}
+                                        {% set status_class = 'warning' %}
+                                    {% elif state in ['exited', 'dead'] %}
+                                        {% set status_class = 'secondary' %}
+                                    {% else %}
+                                        {% set status_class = 'secondary' %}
+                                    {% endif %}
+                                    <tr>
+                                        <td>
+                                            <strong>{{ container.display_name or container.name }}</strong>
+                                            {% if container.service %}
+                                            <div class="container-meta">Service: {{ container.service }}</div>
+                                            {% endif %}
+                                            {% if container.project %}
+                                            <div class="container-meta">Project: {{ container.project }}</div>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <span class="badge bg-{{ status_class }} status-badge">{{ status_label }}</span>
+                                        </td>
+                                        <td>
+                                            {% if container.health %}
+                                                {% if container.health == 'healthy' %}
+                                                <span class="badge bg-success status-badge">Healthy</span>
+                                                {% elif container.health == 'unhealthy' %}
+                                                <span class="badge bg-danger status-badge">Unhealthy</span>
+                                                {% elif container.health == 'starting' %}
+                                                <span class="badge bg-warning status-badge">Starting</span>
+                                                {% else %}
+                                                <span class="badge bg-secondary status-badge">{{ container.health }}</span>
+                                                {% endif %}
+                                            {% else %}
+                                                <span class="text-muted">—</span>
+                                            {% endif %}
+                                        </td>
+                                        <td><span class="metric-value">{{ container.running_for or '—' }}</span></td>
+                                        <td>
+                                            {% if container.image %}
+                                            <div class="container-image">{{ container.image }}</div>
+                                            {% else %}
+                                            <span class="text-muted">—</span>
+                                            {% endif %}
+                                            {% if container.ports %}
+                                            <div class="container-meta">Ports: {{ container.ports }}</div>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        {% else %}
+                        <p class="text-muted mb-0">
+                            {% if containers_data.available %}
+                                No container information detected for the current engine.
+                            {% elif containers_data.error %}
+                                Container details unavailable: {{ containers_data.error }}
+                            {% else %}
+                                Container details unavailable.
+                            {% endif %}
+                        </p>
                         {% endif %}
                     </div>
                 </div>
@@ -701,8 +865,45 @@
             `;
         }
 
-        function renderServicesCard(database, services) {
-            const dbStatusRaw = (database && database.status) ? String(database.status) : 'Unknown';
+        function determineContainerBadge(container) {
+            if (!container || typeof container !== 'object') {
+                return { badge: 'secondary', label: 'Unknown' };
+            }
+
+            const state = String(container.state || '').toLowerCase();
+            const rawStatus = container.status || (state ? state.toUpperCase() : 'Unknown');
+            const health = String(container.health || '').toLowerCase();
+
+            if (health === 'healthy') {
+                return { badge: 'success', label: 'Healthy' };
+            }
+            if (health === 'unhealthy') {
+                return { badge: 'danger', label: 'Unhealthy' };
+            }
+            if (health === 'starting') {
+                return { badge: 'warning', label: 'Starting' };
+            }
+            if (state === 'running') {
+                return { badge: 'success', label: rawStatus };
+            }
+            if (['restarting', 'created', 'paused'].includes(state)) {
+                return { badge: 'warning', label: rawStatus };
+            }
+            if (['exited', 'dead'].includes(state)) {
+                return { badge: 'secondary', label: rawStatus };
+            }
+            return { badge: 'secondary', label: rawStatus };
+        }
+
+        function renderStackCard(database, containers) {
+            const containerData = containers && typeof containers === 'object' ? containers : {};
+            const summary = containerData.summary || {};
+            const total = toNumber(summary.total, 0);
+            const running = toNumber(summary.running, 0);
+            const stopped = Math.max(toNumber(summary.stopped, total - running), 0);
+            const unhealthy = toNumber(summary.unhealthy, 0);
+
+            const dbStatusRaw = database && database.status ? String(database.status) : 'Unknown';
             const statusLower = dbStatusRaw.toLowerCase();
             let dbClass = 'warning';
             if (statusLower === 'connected') {
@@ -725,47 +926,174 @@
                 databaseDetails.push(`<small class="text-muted d-block">Active Connections: ${escapeHtml(dbInfo.active_connections)}</small>`);
             }
 
-            const serviceEntries = services && typeof services === 'object' ? Object.entries(services) : [];
-            const servicesHtml = serviceEntries.length
-                ? `
-                        <hr>
-                        <h6 class="text-muted">System Services</h6>
-                        ${serviceEntries
-                            .map(([name, status]) => {
-                                const normalized = String(status || '').toLowerCase();
-                                let badgeClass = 'danger';
-                                if (normalized === 'active') {
-                                    badgeClass = 'success';
-                                } else if (['inactive', 'unknown', 'unavailable'].includes(normalized)) {
-                                    badgeClass = 'secondary';
-                                }
-                                const rawName = String(name || '');
-                                const displayName = rawName
-                                    ? rawName.replace(/\b\w/g, (char) => char.toUpperCase())
-                                    : 'Unknown';
-                                const safeName = escapeHtml(displayName);
-                                const safeStatus = escapeHtml(status || 'unknown');
-                                return `
-                                    <div class="d-flex justify-content-between align-items-center mb-1">
-                                        <span class="metric-label">${safeName}</span>
-                                        <span class="badge bg-${badgeClass} status-badge">${safeStatus}</span>
+            const isAvailable = Boolean(containerData.available);
+            const containersList = Array.isArray(containerData.containers) ? containerData.containers : [];
+            const previewItems = isAvailable ? containersList.slice(0, 4) : [];
+
+            const previewHtml = previewItems
+                .map((container) => {
+                    const { badge, label } = determineContainerBadge(container);
+                    const displayName = container.display_name || container.name || 'Unknown';
+                    const service = container.service ? `<small class="text-muted d-block">${escapeHtml(container.service)}</small>` : '';
+                    return `
+                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                    <div>
+                                        <span class="metric-label">${escapeHtml(displayName)}</span>
+                                        ${service}
                                     </div>
-                                `;
-                            })
-                            .join('')}
-                    `
+                                    <span class="badge bg-${badge} status-badge">${escapeHtml(label)}</span>
+                                </div>
+                            `;
+                })
+                .join('');
+
+            let previewFooter = '';
+            if (isAvailable) {
+                if (containersList.length > previewItems.length) {
+                    previewFooter = `<small class="text-muted">… and ${containersList.length - previewItems.length} more containers</small>`;
+                } else if (!containersList.length) {
+                    previewFooter = '<p class="text-muted mb-0">No containers detected for the current engine.</p>';
+                }
+            }
+
+            const engineLabel = containerData.engine ? String(containerData.engine).toUpperCase() : '';
+            const projectLabel = containerData.compose_project ? escapeHtml(containerData.compose_project) : '';
+            const engineInfo = engineLabel
+                ? `<small class="text-muted d-block mt-2">Engine: ${escapeHtml(engineLabel)}${projectLabel ? ` • Project: ${projectLabel}` : ''}</small>`
+                : '';
+
+            const availabilityAlert = !isAvailable
+                ? `<div class="alert alert-warning mb-0 py-2">Container information unavailable${containerData.error ? `: ${escapeHtml(containerData.error)}` : ''}</div>`
                 : '';
 
             return `
                 <div class="card health-card h-100">
                     <div class="card-body">
-                        <h5><i class="fas fa-cogs section-icon"></i> Services &amp; Database</h5>
+                        <h5><i class="fas fa-layer-group section-icon"></i> Stack Services</h5>
                         <div class="d-flex justify-content-between align-items-center mb-2">
                             <span class="metric-label">Database</span>
                             <span class="badge bg-${dbClass}">${escapeHtml(dbStatusRaw)}</span>
                         </div>
                         ${databaseDetails.join('')}
-                        ${servicesHtml}
+
+                        <hr>
+
+                        <div class="stack-summary mb-3">
+                            <div>
+                                <span class="metric-label">Containers</span>
+                                <span class="metric-value">${total}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-success">Running</span>
+                                <span class="metric-value text-success">${running}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-warning">Stopped</span>
+                                <span class="metric-value text-warning">${stopped}</span>
+                            </div>
+                            <div>
+                                <span class="metric-label text-danger">Unhealthy</span>
+                                <span class="metric-value text-danger">${unhealthy}</span>
+                            </div>
+                        </div>
+
+                        ${isAvailable ? previewHtml : ''}
+                        ${isAvailable ? previewFooter : availabilityAlert}
+                        ${isAvailable ? engineInfo : ''}
+                    </div>
+                </div>
+            `;
+        }
+
+        function renderContainerDetails(containers) {
+            const containerData = containers && typeof containers === 'object' ? containers : {};
+            const available = Boolean(containerData.available);
+            const items = Array.isArray(containerData.containers) ? containerData.containers : [];
+
+            if (!available || !items.length) {
+                const message = available
+                    ? 'No container information detected for the current engine.'
+                    : containerData.error
+                        ? `Container details unavailable: ${escapeHtml(containerData.error)}`
+                        : 'Container details unavailable.';
+                return `
+                <div class="card health-card">
+                    <div class="card-body">
+                        <h5><i class="fas fa-boxes section-icon"></i> Container Details</h5>
+                        <p class="text-muted mb-0">${message}</p>
+                    </div>
+                </div>`;
+            }
+
+            const rows = items
+                .map((container) => {
+                    const { badge, label } = determineContainerBadge(container);
+                    const displayName = container.display_name || container.name || 'Unknown';
+                    const service = container.service ? `<div class="container-meta">Service: ${escapeHtml(container.service)}</div>` : '';
+                    const project = container.project ? `<div class="container-meta">Project: ${escapeHtml(container.project)}</div>` : '';
+
+                    const healthValue = container.health
+                        ? String(container.health).toLowerCase()
+                        : '';
+                    let healthBadge = '<span class="text-muted">—</span>';
+                    if (healthValue) {
+                        if (healthValue === 'healthy') {
+                            healthBadge = '<span class="badge bg-success status-badge">Healthy</span>';
+                        } else if (healthValue === 'unhealthy') {
+                            healthBadge = '<span class="badge bg-danger status-badge">Unhealthy</span>';
+                        } else if (healthValue === 'starting') {
+                            healthBadge = '<span class="badge bg-warning status-badge">Starting</span>';
+                        } else {
+                            healthBadge = `<span class="badge bg-secondary status-badge">${escapeHtml(container.health)}</span>`;
+                        }
+                    }
+
+                    const image = container.image
+                        ? `<div class="container-image">${escapeHtml(container.image)}</div>`
+                        : '<span class="text-muted">—</span>';
+                    const ports = container.ports
+                        ? `<div class="container-meta">Ports: ${escapeHtml(container.ports)}</div>`
+                        : '';
+
+                    return `
+                        <tr>
+                            <td>
+                                <strong>${escapeHtml(displayName)}</strong>
+                                ${service}
+                                ${project}
+                            </td>
+                            <td><span class="badge bg-${badge} status-badge">${escapeHtml(label)}</span></td>
+                            <td>${healthBadge}</td>
+                            <td><span class="metric-value">${escapeHtml(container.running_for || '—')}</span></td>
+                            <td>
+                                ${image}
+                                ${ports}
+                            </td>
+                        </tr>
+                    `;
+                })
+                .join('');
+
+            return `
+                <div class="card health-card">
+                    <div class="card-body">
+                        <h5><i class="fas fa-boxes section-icon"></i> Container Details</h5>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover container-table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">Container</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Health</th>
+                                        <th scope="col">Uptime</th>
+                                        <th scope="col">Image</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    ${rows}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             `;
@@ -984,9 +1312,14 @@
                 memoryContainer.innerHTML = renderMemoryCard(data.memory || {});
             }
 
-            const servicesContainer = document.getElementById('services-card');
-            if (servicesContainer) {
-                servicesContainer.innerHTML = renderServicesCard(data.database || {}, data.services || {});
+            const stackContainer = document.getElementById('containers-card');
+            if (stackContainer) {
+                stackContainer.innerHTML = renderStackCard(data.database || {}, data.containers || {});
+            }
+
+            const containersDetailContainer = document.getElementById('containers-details');
+            if (containersDetailContainer) {
+                containersDetailContainer.innerHTML = renderContainerDetails(data.containers || {});
             }
 
             const storageContainer = document.getElementById('storage-card');


### PR DESCRIPTION
## Summary
- collect Docker or Podman container status in the system health snapshot and expose the aggregated data to the UI
- redesign the /system_health page to show container summaries and detailed container tables instead of static service checks
- update the front-end refresh logic to render the new stack information alongside existing resource metrics

## Testing
- pytest *(fails: requires samples/malformed.wav and ffmpeg in the test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9350755c8320bb363d8885feb11f)