### PR TITLE
Add rich metadata display (album art, song info) to audio monitoring …

### DIFF
--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -305,6 +305,70 @@ function renderAudioSources() {
                             </small>
                         </div>
 
+                        <!-- Now Playing (if available) -->
+                        ${source.metrics.metadata && (source.metrics.metadata.now_playing || source.metrics.metadata.song_title || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.text)) ? `
+                            <div class="mt-3">
+                                <h6 class="text-muted mb-2"><i class="fas fa-music"></i> Now Playing</h6>
+                                <div class="card bg-light border-0">
+                                    <div class="card-body p-3">
+                                        <div class="row align-items-center">
+                                            ${(() => {
+                                                // Get album art URL from various possible sources
+                                                const artworkUrl = source.metrics.metadata.artwork_url
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.amgArtworkURL)
+                                                    || (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.artwork_url)
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.artworkURL);
+
+                                                // Get song title from various sources
+                                                const songTitle = (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.text)
+                                                    || (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.title)
+                                                    || source.metrics.metadata.song_title
+                                                    || source.metrics.metadata.title
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.song);
+
+                                                // Get artist from various sources
+                                                const artist = (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.artist)
+                                                    || source.metrics.metadata.artist
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.artist);
+
+                                                // Get album
+                                                const album = source.metrics.metadata.album
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.album);
+
+                                                // Get length/duration
+                                                const length = source.metrics.metadata.length
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.length)
+                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.duration);
+
+                                                return artworkUrl ? `
+                                                    <div class="col-auto">
+                                                        <img src="${escapeHtml(artworkUrl)}"
+                                                             alt="Album Art"
+                                                             class="img-thumbnail"
+                                                             style="width: 100px; height: 100px; object-fit: cover;"
+                                                             onerror="this.style.display='none'">
+                                                    </div>
+                                                    <div class="col">
+                                                        ${songTitle ? `<div class="fw-bold fs-5">${escapeHtml(songTitle)}</div>` : ''}
+                                                        ${artist ? `<div class="text-muted">${escapeHtml(artist)}</div>` : ''}
+                                                        ${album ? `<div class="small text-muted"><i class="fas fa-compact-disc"></i> ${escapeHtml(album)}</div>` : ''}
+                                                        ${length ? `<div class="small text-muted"><i class="fas fa-clock"></i> ${escapeHtml(length)}</div>` : ''}
+                                                    </div>
+                                                ` : `
+                                                    <div class="col">
+                                                        ${songTitle ? `<div class="fw-bold fs-5">${escapeHtml(songTitle)}</div>` : ''}
+                                                        ${artist ? `<div class="text-muted">${escapeHtml(artist)}</div>` : ''}
+                                                        ${album ? `<div class="small text-muted"><i class="fas fa-compact-disc"></i> ${escapeHtml(album)}</div>` : ''}
+                                                        ${length ? `<div class="small text-muted"><i class="fas fa-clock"></i> ${escapeHtml(length)}</div>` : ''}
+                                                    </div>
+                                                `;
+                                            })()}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        ` : ''}
+
                         <!-- Stream Metadata (if available) -->
                         ${source.metrics.metadata ? `
                             <div class="mt-3">


### PR DESCRIPTION
…page

Enhanced the audio monitoring page to display comprehensive stream metadata including:
- Album artwork (from amgArtworkURL and other sources)
- Song title (from text="" attribute or traditional format)
- Artist name
- Album name
- Song duration/length

Backend improvements:
- Enhanced ICY metadata parsing in StreamSourceAdapter to extract rich metadata fields from iHeartRadio and similar streams (text="", artist="", amgArtworkURL="", length="", album="")
- Falls back to traditional "Artist - Title" parsing for standard streams
- Extracts metadata from XML-like attributes in StreamTitle field

Frontend improvements:
- Added "Now Playing" card with album art thumbnail and song information
- Supports multiple metadata field name variations for compatibility
- Graceful fallback when artwork fails to load
- Clean, card-based UI that displays above technical stream information

This addresses the request to utilize the rich metadata sent by streaming services that was previously only sent to Icecast but not displayed to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Now Playing" section to the audio monitoring interface displaying current track information including title, artist, album, and length with appropriate formatting
  * Track artwork thumbnail displayed alongside track information when available
  * Enhanced metadata parsing to support extraction of track details from richer metadata formats for improved compatibility with various audio sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->