### PR TITLE
Improve hardware reporting on ARM hosts

### DIFF
--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -677,6 +677,21 @@
                                             {% if device.media_errors is not none %} • Media Errors: {{ device.media_errors }}{% endif %}
                                             {% if device.critical_warnings is not none %} • Warnings: {{ device.critical_warnings }}{% endif %}
                                         </div>
+                                        {% set host_writes = device.host_writes_bytes or device.data_units_written_bytes %}
+                                        {% set host_reads = device.host_reads_bytes or device.data_units_read_bytes %}
+                                        {% if host_writes is not none or host_reads is not none or device.percentage_used is not none %}
+                                        <div class="hardware-meta">
+                                            {% if host_writes is not none %}Host Writes: {{ format_bytes(host_writes) }}{% endif %}
+                                            {% if host_reads is not none %}{% if host_writes is not none %} • {% endif %}Host Reads: {{ format_bytes(host_reads) }}{% endif %}
+                                            {% if device.percentage_used is not none %}{% if host_writes is not none or host_reads is not none %} • {% endif %}Wear: {{ device.percentage_used }}%{% endif %}
+                                        </div>
+                                        {% endif %}
+                                        {% if device.power_cycle_count is not none or device.unsafe_shutdowns is not none %}
+                                        <div class="hardware-meta">
+                                            {% if device.power_cycle_count is not none %}Power Cycles: {{ device.power_cycle_count }}{% endif %}
+                                            {% if device.unsafe_shutdowns is not none %}{% if device.power_cycle_count is not none %} • {% endif %}Unsafe Shutdowns: {{ device.unsafe_shutdowns }}{% endif %}
+                                        </div>
+                                        {% endif %}
                                         {% if device.error %}<div class="hardware-meta text-muted">Note: {{ device.error }}</div>{% endif %}
                                     </div>
                                 {% endfor %}


### PR DESCRIPTION
## Summary
- extend CPU and platform collectors to understand ARM-specific metadata (e.g., Raspberry Pi device-tree fields)
- expand SMART parsing so NVMe drives expose power-on hours, host IO counters, and related health metrics
- surface the additional SMART metrics in the system health UI, including host writes/reads and wear/cycle counters

## Testing
- pytest *(fails: missing samples/malformed.wav when collecting legacy decoder tests)*
- pytest tests *(fails: existing audio pipeline expectations and ffmpeg dependency issues)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fae7f880c8320b53d66f23de7647b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced CPU metadata display including hardware details, revision, and serial information
  * Improved device identification through device-tree data collection for better hardware recognition
  * Extended storage health metrics now include host writes/reads (in bytes), wear percentage, power cycles, and unsafe shutdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->