### PR TITLE
Fix Icecast metadata artist parsing

### DIFF
--- a/tests/test_stream_metadata_parsing.py
+++ b/tests/test_stream_metadata_parsing.py
@@ -1,0 +1,40 @@
+"""Tests for parsing rich ICY metadata from stream sources."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app_core.audio.ingest import AudioSourceConfig, AudioSourceType
+from app_core.audio.sources import StreamSourceAdapter
+
+
+def test_icy_metadata_extracts_artist_from_text_attribute_prefix():
+    """Ensure artist information is captured when encoded ahead of text=""."""
+
+    config = AudioSourceConfig(
+        source_type=AudioSourceType.STREAM,
+        name="Test Stream",
+        device_params={'stream_url': 'http://example.com/stream'},
+    )
+    adapter = StreamSourceAdapter(config)
+
+    metadata_text = (
+        "StreamTitle='Huntr/X - text=\"Golden\" song_spot=\"M\" "
+        "MediaBaseId=\"3136003\" amgArtworkURL=\"https://example.com/art.jpg\" "
+        "length=\"00:03:11\"';"
+        "StreamUrl='http://example.com/stream'"
+    )
+
+    adapter._handle_icy_metadata(metadata_text)
+
+    metadata = adapter.metrics.metadata
+    assert metadata is not None
+    assert metadata.get('artist') == 'Huntr/X'
+    assert metadata.get('song_artist') == 'Huntr/X'
+    assert metadata.get('song_title') == 'Golden'
+
+    now_playing = metadata.get('now_playing')
+    assert isinstance(now_playing, dict)
+    assert now_playing.get('artist') == 'Huntr/X'
+    assert now_playing.get('title') == 'Golden'


### PR DESCRIPTION
## Summary
- ensure the stream metadata parser extracts artist names from iHeart-style text="" entries
- include the parsed song artist in the metadata forwarded to Icecast
- add a regression test covering ICY metadata with prefixed artist information

## Testing
- `pytest tests/test_stream_metadata_parsing.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fad8b084483209cea3ccf1fb0a7e9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of artist and song information from streaming source metadata.
  * Enhanced metadata synchronization for Icecast streaming with coordinated background processing, ensuring more reliable metadata updates.

* **Tests**
  * Added test coverage for streaming metadata parsing and extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->