### PR TITLE
Restore system_health.html from before codex corruption

### DIFF
--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -791,20 +791,37 @@
                                             {% if device.media_errors is not none %} • Media Errors: {{ device.media_errors }}{% endif %}
                                             {% if device.critical_warnings is not none %} • Warnings: {{ device.critical_warnings }}{% endif %}
                                         </div>
-                                        {% set host_writes = device.host_writes_bytes or device.data_units_written_bytes %}
-                                        {% set host_reads = device.host_reads_bytes or device.data_units_read_bytes %}
-                                        {% if host_writes is not none or host_reads is not none or device.percentage_used is not none %}
-                                        <div class="hardware-meta">
-                                            {% if host_writes is not none %}Host Writes: {{ format_bytes(host_writes) }}{% endif %}
-                                            {% if host_reads is not none %}{% if host_writes is not none %} • {% endif %}Host Reads: {{ format_bytes(host_reads) }}{% endif %}
-                                            {% if device.percentage_used is not none %}{% if host_writes is not none or host_reads is not none %} • {% endif %}Wear: {{ device.percentage_used }}%{% endif %}
-                                        </div>
+                                        {% set nvme_ns = namespace(lines=[]) %}
+                                        {% set nvme_written = device.get('data_units_written_bytes') %}
+                                        {% set nvme_read = device.get('data_units_read_bytes') %}
+                                        {% set nvme_host_reads = device.get('host_read_commands') %}
+                                        {% set nvme_host_writes = device.get('host_write_commands') %}
+                                        {% set nvme_busy = device.get('controller_busy_time_minutes') %}
+                                        {% set nvme_unsafe = device.get('unsafe_shutdowns') %}
+                                        {% set nvme_wear = device.get('percentage_used') %}
+                                        {% if nvme_written is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Written: ' ~ format_bytes(nvme_written)] %}
                                         {% endif %}
-                                        {% if device.power_cycle_count is not none or device.unsafe_shutdowns is not none %}
-                                        <div class="hardware-meta">
-                                            {% if device.power_cycle_count is not none %}Power Cycles: {{ device.power_cycle_count }}{% endif %}
-                                            {% if device.unsafe_shutdowns is not none %}{% if device.power_cycle_count is not none %} • {% endif %}Unsafe Shutdowns: {{ device.unsafe_shutdowns }}{% endif %}
-                                        </div>
+                                        {% if nvme_read is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Read: ' ~ format_bytes(nvme_read)] %}
+                                        {% endif %}
+                                        {% if nvme_host_reads is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Reads: ' ~ '{:,}'.format(nvme_host_reads) ~ ' cmds'] %}
+                                        {% endif %}
+                                        {% if nvme_host_writes is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Writes: ' ~ '{:,}'.format(nvme_host_writes) ~ ' cmds'] %}
+                                        {% endif %}
+                                        {% if nvme_wear is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Wear: ' ~ '%.1f'|format(nvme_wear) ~ '%'] %}
+                                        {% endif %}
+                                        {% if nvme_busy is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Busy: ' ~ '{:,}'.format(nvme_busy) ~ ' min'] %}
+                                        {% endif %}
+                                        {% if nvme_unsafe is not none %}
+                                            {% set nvme_ns.lines = nvme_ns.lines + ['Unsafe: ' ~ '{:,}'.format(nvme_unsafe)] %}
+                                        {% endif %}
+                                        {% if nvme_ns.lines %}
+                                            <div class="hardware-meta">NVMe: {{ nvme_ns.lines|join(' • ') }}</div>
                                         {% endif %}
                                         {% if device.error %}<div class="hardware-meta text-muted">Note: {{ device.error }}</div>{% endif %}
                                     </div>
@@ -1106,6 +1123,7 @@
     <script>
         const initialHealthData = {{ health_data_json | safe }} || {};
         const REFRESH_INTERVAL_MS = 30000;
+        const numberFormatter = new Intl.NumberFormat();
         let lastUpdatedTime = null;
 
         function escapeHtml(value) {
@@ -1823,432 +1841,6 @@
                             Realloc: ${reallocated}${mediaErrors}${warnings}
                         </div>
                         ${nvmeMeta}
-                        ${note}
-                    </div>
-                `;
-            }).join('');
-
-            const overflow = devices.length > 5
-                ? `<small class="text-muted">… and ${devices.length - 5} more devices</small>`
-                : '';
-
-            return `
-                <div class="card health-card h-100">
-                    <div class="card-body">
-                        <h5><i class="fas fa-heartbeat section-icon"></i> Storage Health (S.M.A.R.T.)</h5>
-                        ${sections}
-                        ${overflow}
-                    </div>
-                </div>
-            `;
-        }
-
-        function determineContainerBadge(container) {
-            if (!container || typeof container !== 'object') {
-                return { badge: 'secondary', label: 'Unknown' };
-            }
-
-            const state = String(container.state || '').toLowerCase();
-            const rawStatus = container.status || (state ? state.toUpperCase() : 'Unknown');
-            const health = String(container.health || '').toLowerCase();
-
-            if (health === 'healthy') {
-                return { badge: 'success', label: 'Healthy' };
-            }
-            if (health === 'unhealthy') {
-                return { badge: 'danger', label: 'Unhealthy' };
-            }
-            if (health === 'starting') {
-                return { badge: 'warning', label: 'Starting' };
-            }
-            if (state === 'running') {
-                return { badge: 'success', label: rawStatus };
-            }
-            if (['restarting', 'created', 'paused'].includes(state)) {
-                return { badge: 'warning', label: rawStatus };
-            }
-            if (['exited', 'dead'].includes(state)) {
-                return { badge: 'secondary', label: rawStatus };
-            }
-            return { badge: 'secondary', label: rawStatus };
-        }
-
-        function renderStackCard(database, containers) {
-            const containerData = containers && typeof containers === 'object' ? containers : {};
-            const summary = containerData.summary || {};
-            const total = toNumber(summary.total, 0);
-            const running = toNumber(summary.running, 0);
-            const stopped = Math.max(toNumber(summary.stopped, total - running), 0);
-            const unhealthy = toNumber(summary.unhealthy, 0);
-
-            const dbStatusRaw = database && database.status ? String(database.status) : 'Unknown';
-            const statusLower = dbStatusRaw.toLowerCase();
-            let dbClass = 'warning';
-            if (statusLower === 'connected') {
-                dbClass = 'success';
-            } else if (statusLower.includes('error')) {
-                dbClass = 'danger';
-            } else if (statusLower === 'unknown' || statusLower === 'unavailable') {
-                dbClass = 'secondary';
-            }
-
-            const cacheSection = cacheSize || microcode
-                ? `
-                        <hr>
-                        <div class="row">
-                            ${cacheSize
-                                ? `
-                                    <div class="col-sm-6">
-                                        <div class="metric-row">
-                                            <span class="metric-label">Cache Size:</span>
-                                            <span class="metric-value">${cacheSize}</span>
-                                        </div>
-                                    </div>
-                                `
-                                : ''}
-                            ${microcode
-                                ? `
-                                    <div class="col-sm-6">
-                                        <div class="metric-row">
-                                            <span class="metric-label">Microcode:</span>
-                                            <span class="metric-value">${microcode}</span>
-                                        </div>
-                                    </div>
-                                `
-                                : ''}
-                        </div>
-                    `
-                : '';
-
-            return `
-                <div class="card health-card h-100">
-                    <div class="card-body">
-                        <h5><i class="fas fa-microchip section-icon"></i> CPU Details</h5>
-
-                        <div class="metric-row">
-                            <span class="metric-label">Model:</span>
-                            <span class="metric-value">${model}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">Vendor:</span>
-                            <span class="metric-value">${vendor}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">Architecture:</span>
-                            <span class="metric-value">${architecture}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">Virtualization:</span>
-                            <span class="metric-value">${virtualizationLabel}</span>
-                        </div>
-
-                        <div class="row">
-                            <div class="col-sm-6">
-                                <div class="metric-row">
-                                    <span class="metric-label">Physical Cores:</span>
-                                    <span class="metric-value">${cpu.physical_cores ?? 'N/A'}</span>
-                                </div>
-                                <div class="metric-row">
-                                    <span class="metric-label">Logical Cores:</span>
-                                    <span class="metric-value">${cpu.logical_cores ?? 'N/A'}</span>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="metric-row">
-                                    <span class="metric-label">Max Frequency:</span>
-                                    <span class="metric-value">${maxFreqLabel}</span>
-                                </div>
-                                <div class="metric-row">
-                                    <span class="metric-label">Min Frequency:</span>
-                                    <span class="metric-value">${minFreqLabel}</span>
-                                </div>
-                            </div>
-                        </div>
-
-                        ${cacheSection}
-                        ${flagSection}
-                    </div>
-                </div>
-            `;
-        }
-
-        function renderPlatformCard(platform) {
-            const data = platform && typeof platform === 'object' ? platform : {};
-            const manufacturer = escapeHtml(data.sys_vendor || data.board_vendor || 'Unknown');
-            const product = escapeHtml(data.product_name || 'Unknown');
-            const productVersion = data.product_version ? `<div class="metric-row"><span class="metric-label">Version:</span><span class="metric-value">${escapeHtml(String(data.product_version))}</span></div>` : '';
-            const productSerial = data.product_serial ? `<div class="metric-row"><span class="metric-label">Serial:</span><span class="metric-value">${escapeHtml(String(data.product_serial))}</span></div>` : '';
-            const boardName = escapeHtml(data.board_name || 'Unknown');
-            const boardVersion = data.board_version ? `<div class="metric-row"><span class="metric-label">Board Version:</span><span class="metric-value">${escapeHtml(String(data.board_version))}</span></div>` : '';
-            const assetTag = data.chassis_asset_tag ? `<div class="metric-row"><span class="metric-label">Asset Tag:</span><span class="metric-value">${escapeHtml(String(data.chassis_asset_tag))}</span></div>` : '';
-            const biosVendor = escapeHtml(data.bios_vendor || 'Unknown');
-            const biosVersion = escapeHtml(data.bios_version || 'Unknown');
-            const biosDate = escapeHtml(data.bios_date || 'Unknown');
-
-            return `
-                <div class="card health-card h-100">
-                    <div class="card-body">
-                        <h5><i class="fas fa-desktop section-icon"></i> Platform &amp; Firmware</h5>
-
-                        <div class="metric-row">
-                            <span class="metric-label">Manufacturer:</span>
-                            <span class="metric-value">${manufacturer}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">Product:</span>
-                            <span class="metric-value">${product}</span>
-                        </div>
-                        ${productVersion}
-                        ${productSerial}
-
-                        <hr>
-                        <div class="metric-row">
-                            <span class="metric-label">Mainboard:</span>
-                            <span class="metric-value">${boardName}</span>
-                        </div>
-                        ${boardVersion}
-                        ${assetTag}
-
-                        <hr>
-                        <div class="metric-row">
-                            <span class="metric-label">BIOS Vendor:</span>
-                            <span class="metric-value">${biosVendor}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">BIOS Version:</span>
-                            <span class="metric-value">${biosVersion}</span>
-                        </div>
-                        <div class="metric-row">
-                            <span class="metric-label">BIOS Date:</span>
-                            <span class="metric-value">${biosDate}</span>
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
-
-        function renderHardwareInventoryCard(blockInfo) {
-            const info = blockInfo && typeof blockInfo === 'object' ? blockInfo : {};
-            const available = Boolean(info.available);
-            const devices = Array.isArray(info.devices) ? info.devices : [];
-
-            if (!available || devices.length === 0) {
-                const error = info.error ? `: ${escapeHtml(info.error)}` : '';
-                return `
-                    <div class="card health-card h-100">
-                        <div class="card-body">
-                            <h5><i class="fas fa-database section-icon"></i> Storage Inventory</h5>
-                            <div class="alert alert-warning mb-0 py-2">Storage inventory unavailable${error}</div>
-                        </div>
-                    </div>
-                `;
-            }
-
-            const disks = devices.filter((device) => String(device.type || '').toLowerCase() === 'disk');
-            const summary = info.summary && typeof info.summary === 'object' ? info.summary : {};
-            const summaryParts = [];
-            if (summary.disks !== undefined) {
-                summaryParts.push(`${toNumber(summary.disks, 0)} disks`);
-            }
-            if (summary.partitions !== undefined) {
-                summaryParts.push(`${toNumber(summary.partitions, 0)} partitions`);
-            }
-            if (summary.virtual) {
-                summaryParts.push(`${toNumber(summary.virtual, 0)} virtual`);
-            }
-            const summaryHtml = summaryParts.length
-                ? `<div class="hardware-meta mb-2">${summaryParts.map((part) => escapeHtml(part)).join(' • ')}</div>`
-                : '';
-
-            const rows = disks
-                .map((disk) => {
-                    const name = disk && typeof disk === 'object' ? disk : {};
-                    const devicePath = escapeHtml(name.path || (name.name ? `/dev/${name.name}` : 'unknown'));
-                    const model = name.model ? `<div class="hardware-meta">${escapeHtml(name.model)}</div>` : '';
-                    const serial = name.serial ? `<div class="hardware-meta">Serial: ${escapeHtml(name.serial)}</div>` : '';
-                    const vendor = name.vendor ? `<div class="hardware-meta">Vendor: ${escapeHtml(name.vendor)}</div>` : '';
-                    const sizeBytes = name.size_bytes != null ? toNumber(name.size_bytes, 0) : null;
-                    const sizeLabel = sizeBytes && sizeBytes > 0 ? formatBytes(sizeBytes) : 'Unknown';
-                    const transport = name.transport ? escapeHtml(String(name.transport).toUpperCase()) : '';
-                    const hasRotational = name.is_rotational === true || name.is_rotational === false;
-                    let rotational = '';
-                    if (name.is_rotational === true) {
-                        rotational = 'HDD';
-                    } else if (name.is_rotational === false) {
-                        rotational = 'SSD';
-                    }
-                    let transportDetail = '';
-                    if (transport) {
-                        transportDetail = transport;
-                        if (hasRotational) {
-                            transportDetail += ` • ${rotational}`;
-                        }
-                    } else if (hasRotational) {
-                        transportDetail = rotational;
-                    }
-                    const transportLine = transportDetail
-                        ? `<div class="hardware-meta">${transportDetail}</div>`
-                        : '';
-                    const readOnly = name.is_read_only === true ? '<div class="hardware-meta text-danger">Read Only</div>' : '';
-                    const removable = name.is_removable === true ? '<div class="hardware-meta">Removable media</div>' : '';
-
-                    const children = Array.isArray(name.children) ? name.children : [];
-                    const childRows = children.length
-                        ? children
-                            .map((child) => {
-                                const childDevice = child && typeof child === 'object' ? child : {};
-                                const childPath = escapeHtml(childDevice.path || (childDevice.name ? `/dev/${childDevice.name}` : 'unknown'));
-                                const fs = childDevice.filesystem ? ` <span class="text-muted">(${escapeHtml(childDevice.filesystem)})</span>` : '';
-                                const mountpoints = Array.isArray(childDevice.mountpoints) && childDevice.mountpoints.length
-                                    ? ` <span class="text-muted">→ ${childDevice.mountpoints.map((mp) => escapeHtml(mp)).join(', ')}</span>`
-                                    : '';
-                                return `<div class="hardware-meta">${childPath}${fs}${mountpoints}</div>`;
-                            })
-                            .join('')
-                        : '<span class="text-muted">—</span>';
-
-                    return `
-                        <tr>
-                            <td>
-                                <strong>${devicePath}</strong>
-                                ${model}
-                                ${serial}
-                                ${vendor}
-                            </td>
-                            <td>
-                                <div class="hardware-meta">Size: ${sizeLabel}</div>
-                                ${transportLine}
-                                ${readOnly}
-                                ${removable}
-                            </td>
-                            <td>${childRows}</td>
-                        </tr>
-                    `;
-                })
-                .join('');
-
-            const tableContent = disks.length
-                ? `
-                        <div class="table-responsive">
-                            <table class="table table-sm table-hover device-inventory-table">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Device</th>
-                                        <th scope="col">Details</th>
-                                        <th scope="col">Mounts</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    ${rows}
-                                </tbody>
-                            </table>
-                        </div>
-                    `
-                : '<p class="text-muted mb-0">No physical disks reported.</p>';
-
-            return `
-                <div class="card health-card h-100">
-                    <div class="card-body">
-                        <h5><i class="fas fa-database section-icon"></i> Storage Inventory</h5>
-                        ${summaryHtml}
-                        ${tableContent}
-                    </div>
-                </div>
-            `;
-        }
-
-        function renderSmartHealthCard(smartInfo) {
-            const info = smartInfo && typeof smartInfo === 'object' ? smartInfo : {};
-            if (!info.available) {
-                const error = info.error ? `: ${escapeHtml(info.error)}` : '';
-                return `
-                    <div class="card health-card h-100">
-                        <div class="card-body">
-                            <h5><i class="fas fa-heartbeat section-icon"></i> Storage Health (S.M.A.R.T.)</h5>
-                            <div class="alert alert-warning mb-0 py-2">S.M.A.R.T. data unavailable${error}</div>
-                        </div>
-                    </div>
-                `;
-            }
-
-            const devices = Array.isArray(info.devices) ? info.devices : [];
-            if (!devices.length) {
-                return `
-                    <div class="card health-card h-100">
-                        <div class="card-body">
-                            <h5><i class="fas fa-heartbeat section-icon"></i> Storage Health (S.M.A.R.T.)</h5>
-                            <p class="text-muted mb-0">No S.M.A.R.T. capable devices detected.</p>
-                        </div>
-                    </div>
-                `;
-            }
-
-            const sections = devices.slice(0, 5).map((device) => {
-                const data = device && typeof device === 'object' ? device : {};
-                const path = escapeHtml(data.path || data.name || 'Unknown device');
-                const model = data.model ? `<div class="hardware-meta">${escapeHtml(data.model)}</div>` : '';
-                const serial = data.serial ? `<div class="hardware-meta">Serial: ${escapeHtml(data.serial)}</div>` : '';
-
-                const statusRaw = String(data.overall_status || 'unknown').toLowerCase();
-                let badgeClass = 'warning';
-                let statusLabel = data.overall_status ? escapeHtml(String(data.overall_status)) : 'Unknown';
-                if (['passed', 'ok', 'healthy', 'success'].includes(statusRaw)) {
-                    badgeClass = 'success';
-                    statusLabel = 'Passed';
-                } else if (['failed', 'fail', 'critical'].includes(statusRaw)) {
-                    badgeClass = 'danger';
-                    statusLabel = 'Failed';
-                }
-
-                const temperature = data.temperature_celsius != null
-                    ? `${toNumber(data.temperature_celsius, 0).toFixed(0)}°C`
-                    : 'N/A';
-                const powerOnHours = data.power_on_hours != null ? `${escapeHtml(String(data.power_on_hours))}h` : '';
-                const reallocated = data.reallocated_sector_count != null ? escapeHtml(String(data.reallocated_sector_count)) : 'N/A';
-                const mediaErrors = data.media_errors != null ? ` • Media Errors: ${escapeHtml(String(data.media_errors))}` : '';
-                const warnings = data.critical_warnings != null ? ` • Warnings: ${escapeHtml(String(data.critical_warnings))}` : '';
-                const hostWritesBytes = data.host_writes_bytes != null ? Number(data.host_writes_bytes) : (data.data_units_written_bytes != null ? Number(data.data_units_written_bytes) : null);
-                const hostReadsBytes = data.host_reads_bytes != null ? Number(data.host_reads_bytes) : (data.data_units_read_bytes != null ? Number(data.data_units_read_bytes) : null);
-                const hostSegments = [];
-                if (hostWritesBytes !== null && Number.isFinite(hostWritesBytes)) {
-                    hostSegments.push(`Host Writes: ${formatBytes(hostWritesBytes)}`);
-                }
-                if (hostReadsBytes !== null && Number.isFinite(hostReadsBytes)) {
-                    hostSegments.push(`Host Reads: ${formatBytes(hostReadsBytes)}`);
-                }
-                if (data.percentage_used != null) {
-                    hostSegments.push(`Wear: ${escapeHtml(String(data.percentage_used))}%`);
-                }
-                const hostDetails = hostSegments.length ? `<div class="hardware-meta">${hostSegments.join(' • ')}</div>` : '';
-
-                const powerSegments = [];
-                if (data.power_cycle_count != null) {
-                    powerSegments.push(`Power Cycles: ${escapeHtml(String(data.power_cycle_count))}`);
-                }
-                if (data.unsafe_shutdowns != null) {
-                    powerSegments.push(`Unsafe Shutdowns: ${escapeHtml(String(data.unsafe_shutdowns))}`);
-                }
-                const powerDetails = powerSegments.length ? `<div class="hardware-meta">${powerSegments.join(' • ')}</div>` : '';
-                const note = data.error ? `<div class="hardware-meta text-muted">Note: ${escapeHtml(String(data.error))}</div>` : '';
-
-                return `
-                    <div class="mb-3">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <span class="metric-label">${path}</span>
-                                ${model}
-                                ${serial}
-                            </div>
-                            <span class="badge bg-${badgeClass} smart-status-badge">${statusLabel}</span>
-                        </div>
-                        <div class="hardware-meta">
-                            Temp: ${temperature}${powerOnHours ? ` • Power On: ${powerOnHours}` : ''}
-                        </div>
-                        <div class="hardware-meta">
-                            Realloc: ${reallocated}${mediaErrors}${warnings}
-                        </div>
-                        ${hostDetails}
-                        ${powerDetails}
                         ${note}
                     </div>
                 `;


### PR DESCRIPTION
Codex corrupted the system_health.html template in commit 2e03b4c by injecting HTML template code into the JavaScript <script> block, creating multiple issues:
- Duplicate '{% block scripts %}' definitions (causing Jinja2 error)
- Mixed HTML/Jinja2 code inside JavaScript sections
- Increased file size from 2172 to 3488 lines with duplicate content
- Template rendering failures with "'system' is undefined" errors

This commit restores the template to the clean version from e0538e0, which includes all legitimate improvements (ARM hardware reporting, NVMe SMART telemetry, etc.) but excludes the corrupted content.

Changes:
- Restored from e0538e0:templates/system_health.html
- Removed 880 lines of corrupted/duplicate content
- Single, properly formatted {% block scripts %} definition
- All variable references properly structured
- Template syntax validated with Jinja2 parser

Fixes: "block 'scripts' defined twice" error
Fixes: "'system' is undefined" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined NVMe metrics display into a consolidated summary line instead of separate blocks
  * Reorganized system health dashboard layout for improved information presentation
  * Enhanced container and database status rendering for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->