### PR TITLE
Add error handling for system health backend failures

### DIFF
--- a/webapp/routes_public.py
+++ b/webapp/routes_public.py
@@ -341,6 +341,16 @@ def register(app: Flask, logger) -> None:
     def system_health_page():
         try:
             health_data = get_system_health(logger=route_logger)
+
+            # Check if the backend returned an error instead of health data
+            if "error" in health_data and "system" not in health_data:
+                error_msg = health_data.get("error", "Unknown error")
+                route_logger.error("System health backend error: %s", error_msg)
+                return (
+                    "<h1>Error loading system health</h1>"
+                    f"<p>{error_msg}</p><p><a href='/'>← Back to Main</a></p>"
+                )
+
             template_context = dict(health_data)
             template_context["format_bytes"] = format_bytes
             template_context["format_uptime"] = format_uptime


### PR DESCRIPTION
When build_system_health_snapshot() encounters an error, it returns: {
    "error": str(exc),
    "timestamp": ...,
    "local_timestamp": ...,
}

This dict is missing the "system", "cpu", "hardware" keys that the template expects, causing Jinja2 UndefinedError: "'system' is undefined".

This commit adds a check in the route handler to detect when the backend returns an error dict and display it properly instead of passing it to the template.

Now the page will show:
  "Error loading system health"
  <actual error message from backend>

Instead of the unhelpful "'system' is undefined" template error.

This will reveal what the actual backend error is so we can fix it.