### PR TITLE
Remove ineffective client-side timeout parameter

### DIFF
--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -229,11 +229,11 @@ class IcecastStreamer:
             from urllib.parse import quote
             encoded_password = quote(self.config.password, safe='')
 
-            # Add timeout as a protocol option to prevent 10-minute disconnections
-            # Set to -1 (infinite) to keep connection alive indefinitely
+            # Note: The 10-minute timeout fix is SERVER-SIDE in Icecast config (source-timeout=0)
+            # The icecast:// protocol (libshout) doesn't support HTTP timeout options
             icecast_url = (
                 f"icecast://source:{encoded_password}@"
-                f"{self.config.server}:{self.config.port}/{self.config.mount}?timeout=-1"
+                f"{self.config.server}:{self.config.port}/{self.config.mount}"
             )
 
             # FFmpeg command to encode and stream


### PR DESCRIPTION
The icecast:// protocol (libshout) doesn't support HTTP timeout options, so the ?timeout=-1 parameter is ignored by FFmpeg.

The 10-minute timeout fix must be applied SERVER-SIDE in the Icecast configuration by setting source-timeout=0, which is already configured in docker-entrypoint-icecast.sh (requires container rebuild).

This commit keeps the essential fixes:
- URL-encoded password for special characters
- Stderr reader thread to prevent buffer blocking
- No invalid FFmpeg options

If mountpoints still disappear after 10 minutes, it indicates the Icecast container needs to be rebuilt to apply the source-timeout=0 configuration.