### PR TITLE
Add NVMe device mounts for SMART monitoring

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -65,6 +65,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:
@@ -100,6 +102,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:
@@ -146,6 +150,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:
@@ -84,6 +86,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:
@@ -127,6 +131,8 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
+      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
     cap_add:
       - SYS_RAWIO
     security_opt:


### PR DESCRIPTION
SMART data collection requires direct access to block devices. Following Scrutiny's working configuration, add NVMe device mounts:

- /dev/nvme0:/dev/nvme0       (NVMe controller)
- /dev/nvme0n1:/dev/nvme0n1   (Samsung 990 PRO namespace)

Changes:
- Updated all services (app, poller, ipaws-poller) in both compose files
- Maintains existing SYS_RAWIO capability
- Matches Scrutiny's proven configuration

This enables smartctl to query SMART attributes from the Samsung 990 PRO for the system health monitoring page.

Ref: Scrutiny container config showing working device mounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled SMART monitoring for NVMe drives by adding device mappings across services in the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->