### PR TITLE
Make NVMe device mounts optional in docker-compose files

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -65,10 +65,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
 
@@ -102,10 +103,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
 
@@ -150,10 +152,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,10 +49,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
     depends_on:
@@ -86,10 +87,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
 
@@ -131,10 +133,11 @@ services:
       - "host.docker.internal:host-gateway"
     devices:
       - /dev/bus/usb:/dev/bus/usb
-      - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
-      - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (Samsung 990 PRO)
+      # Uncomment the following lines if you have NVMe drives and want SMART monitoring:
+      # - /dev/nvme0:/dev/nvme0      # NVMe controller for SMART monitoring
+      # - /dev/nvme0n1:/dev/nvme0n1  # NVMe namespace (adjust nvme0n1 to your device)
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO  # Required for SMART monitoring
     security_opt:
       - no-new-privileges:true
 


### PR DESCRIPTION
Comment out NVMe device mounts (/dev/nvme0, /dev/nvme0n1) by default to prevent deployment failures on systems without NVMe drives.

Users with NVMe drives can uncomment these lines to enable SMART monitoring. The application code already handles missing SMART data gracefully.

Fixes deployment error: "error gathering device information while
adding custom device '/dev/nvme0': no such file or directory"