### PR TITLE
Debug SDR device connection and audio issues

### DIFF
--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -73,7 +73,9 @@ class SDRSourceAdapter(AudioSourceAdapter):
         if not receiver_id:
             raise ValueError("receiver_id required in device_params")
 
-        self._radio_manager = RadioManager()
+        # Get the global radio manager instance
+        from app_core.extensions import get_radio_manager
+        self._radio_manager = get_radio_manager()
         self._receiver_id = receiver_id
 
         # Get receiver configuration to check demodulation settings
@@ -98,8 +100,6 @@ class SDRSourceAdapter(AudioSourceAdapter):
                 logger.info(f"Created {self._receiver_config.modulation_type} demodulator for receiver: {receiver_id}")
 
         # Start IQ capture from the specified receiver
-        # Note: This requires the radio manager to support IQ streaming,
-        # which would need to be implemented in the receiver drivers
         self._capture_handle = self._radio_manager.start_audio_capture(
             receiver_id=self._receiver_id,
             sample_rate=self.config.sample_rate,

--- a/app_core/extensions.py
+++ b/app_core/extensions.py
@@ -5,4 +5,17 @@ from flask_sqlalchemy import SQLAlchemy
 # SQLAlchemy is initialised via the application factory in ``app.py``.
 db = SQLAlchemy()
 
-__all__ = ["db"]
+# Global RadioManager instance for SDR receivers
+# This is initialized in the application factory
+radio_manager = None
+
+def get_radio_manager():
+    """Get the global RadioManager instance."""
+    global radio_manager
+    if radio_manager is None:
+        from app_core.radio import RadioManager
+        radio_manager = RadioManager()
+        radio_manager.register_builtin_drivers()
+    return radio_manager
+
+__all__ = ["db", "get_radio_manager"]

--- a/templates/audio_sources.html
+++ b/templates/audio_sources.html
@@ -237,7 +237,7 @@
                         <label for="sourceType" class="form-label">Source Type</label>
                         <select class="form-select" id="sourceType" required>
                             <option value="">Select type...</option>
-                            <option value="sdr">SDR Receiver</option>
+                            <!-- SDR sources should be added via Settings > Radio page -->
                             <option value="alsa">ALSA Device</option>
                             <option value="pulse">PulseAudio</option>
                             <option value="file">Audio File</option>

--- a/templates/settings/audio.html
+++ b/templates/settings/audio.html
@@ -272,7 +272,7 @@
                             <label for="sourceType" class="form-label">Source Type <span class="text-danger">*</span></label>
                             <select class="form-select" id="sourceType" name="type" required>
                                 <option value="">Select type...</option>
-                                <option value="sdr">SDR (Software-Defined Radio)</option>
+                                <!-- SDR sources should be added via Settings > Radio page -->
                                 <option value="stream">Stream (HTTP/M3U)</option>
                                 <option value="alsa">ALSA (Advanced Linux Sound Architecture)</option>
                                 <option value="pulse">PulseAudio</option>

--- a/templates/settings/radio.html
+++ b/templates/settings/radio.html
@@ -1487,14 +1487,16 @@
     };
 
     // ========================================================================
-    // Waveform Monitor
+    // Waterfall Monitor (Spectrum Display)
     // ========================================================================
 
     const waveformContainer = document.getElementById('waveformContainer');
     const waveformAutoRefresh = document.getElementById('waveformAutoRefresh');
     let waveformRefreshHandle = null;
     const waveformCanvases = new Map();
-    const WAVEFORM_REFRESH_INTERVAL_MS = 1000; // 1 Hz refresh rate (reduced from 100ms to prevent backend flooding)
+    const waterfallHistory = new Map(); // Store spectrum history for waterfall
+    const WAVEFORM_REFRESH_INTERVAL_MS = 200; // 5 Hz refresh rate for waterfall
+    const WATERFALL_HISTORY_SIZE = 100; // Number of spectrum lines to keep
 
     function createWaveformCanvas(receiver) {
         const canvasId = `waveform-${receiver.id}`;
@@ -1510,7 +1512,7 @@
                     <span class="badge bg-secondary">${escapeHtml(receiver.identifier)}</span>
                 </div>
                 <div class="card-body p-2">
-                    <canvas id="${canvasId}" width="600" height="200" style="width: 100%; height: auto;"></canvas>
+                    <canvas id="${canvasId}" width="800" height="300" style="width: 100%; height: auto;"></canvas>
                     <div class="small text-muted text-center mt-2">
                         <span id="waveform-info-${receiver.id}">Initializing...</span>
                     </div>
@@ -1518,69 +1520,84 @@
             </div>
         `;
 
+        // Initialize waterfall history
+        waterfallHistory.set(receiver.id, []);
+
         return col;
     }
 
-    function drawWaveform(canvas, waveformData) {
+    function drawWaterfall(canvas, history, spectrumData) {
         const ctx = canvas.getContext('2d');
         const width = canvas.width;
         const height = canvas.height;
 
-        // Clear canvas
-        ctx.fillStyle = '#1a1a1a';
-        ctx.fillRect(0, 0, width, height);
-
-        // Draw grid
-        ctx.strokeStyle = '#333';
-        ctx.lineWidth = 1;
-
-        // Horizontal grid lines
-        for (let i = 0; i <= 4; i++) {
-            const y = (height / 4) * i;
-            ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.lineTo(width, y);
-            ctx.stroke();
-        }
-
-        // Center line
-        ctx.strokeStyle = '#555';
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-        ctx.moveTo(0, height / 2);
-        ctx.lineTo(width, height / 2);
-        ctx.stroke();
-
-        if (!waveformData || waveformData.length === 0) {
+        if (!spectrumData || spectrumData.length === 0) {
+            // Clear canvas if no data
+            ctx.fillStyle = '#1a1a1a';
+            ctx.fillRect(0, 0, width, height);
             return;
         }
 
-        // Draw waveform
-        const step = width / waveformData.length;
-        const middle = height / 2;
-        const scale = height / 2;
-
-        ctx.strokeStyle = '#00ff00';
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-
-        for (let i = 0; i < waveformData.length; i++) {
-            const x = i * step;
-            const y = middle - (waveformData[i] * scale);
-
-            if (i === 0) {
-                ctx.moveTo(x, y);
-            } else {
-                ctx.lineTo(x, y);
-            }
+        // Add new spectrum to history
+        history.push(spectrumData);
+        if (history.length > WATERFALL_HISTORY_SIZE) {
+            history.shift(); // Remove oldest
         }
 
-        ctx.stroke();
+        // Clear canvas
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, width, height);
+
+        // Draw waterfall (newest at bottom)
+        const lineHeight = height / WATERFALL_HISTORY_SIZE;
+        const binWidth = width / spectrumData.length;
+
+        for (let row = 0; row < history.length; row++) {
+            const spectrum = history[row];
+            const y = height - (history.length - row) * lineHeight;
+
+            for (let bin = 0; bin < spectrum.length; bin++) {
+                const intensity = spectrum[bin]; // 0 to 1
+                const x = bin * binWidth;
+
+                // Color mapping: blue (weak) -> cyan -> green -> yellow -> red (strong)
+                let r, g, b;
+                if (intensity < 0.2) {
+                    // Dark blue to blue
+                    r = 0;
+                    g = 0;
+                    b = Math.floor(intensity * 5 * 255);
+                } else if (intensity < 0.4) {
+                    // Blue to cyan
+                    r = 0;
+                    g = Math.floor((intensity - 0.2) * 5 * 255);
+                    b = 255;
+                } else if (intensity < 0.6) {
+                    // Cyan to green
+                    r = 0;
+                    g = 255;
+                    b = 255 - Math.floor((intensity - 0.4) * 5 * 255);
+                } else if (intensity < 0.8) {
+                    // Green to yellow
+                    r = Math.floor((intensity - 0.6) * 5 * 255);
+                    g = 255;
+                    b = 0;
+                } else {
+                    // Yellow to red
+                    r = 255;
+                    g = 255 - Math.floor((intensity - 0.8) * 5 * 255);
+                    b = 0;
+                }
+
+                ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+                ctx.fillRect(x, y, Math.ceil(binWidth), Math.ceil(lineHeight) + 1);
+            }
+        }
     }
 
     async function updateWaveform(receiver) {
         try {
-            const response = await fetch(`/api/radio/waveform/${receiver.id}?samples=512`);
+            const response = await fetch(`/api/radio/spectrum/${receiver.id}`);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
             }
@@ -1589,6 +1606,7 @@
 
             // Get or create canvas
             let canvas = waveformCanvases.get(receiver.id);
+            let history = waterfallHistory.get(receiver.id);
             if (!canvas) {
                 const col = createWaveformCanvas(receiver);
 
@@ -1600,20 +1618,23 @@
                 waveformContainer.appendChild(col);
                 canvas = document.getElementById(`waveform-${receiver.id}`);
                 waveformCanvases.set(receiver.id, canvas);
+                history = waterfallHistory.get(receiver.id);
             }
 
-            // Draw waveform
-            drawWaveform(canvas, data.waveform);
+            // Draw waterfall
+            drawWaterfall(canvas, history, data.spectrum);
 
             // Update info
             const infoElement = document.getElementById(`waveform-info-${receiver.id}`);
             if (infoElement) {
-                const sampleRate = data.sample_rate ? (data.sample_rate / 1000000).toFixed(2) : '?';
-                infoElement.textContent = `Sample rate: ${sampleRate} MHz | Samples: ${data.num_samples}`;
+                const centerFreq = data.center_frequency ? (data.center_frequency / 1000000).toFixed(3) : '?';
+                const freqMin = data.freq_min ? (data.freq_min / 1000000).toFixed(3) : '?';
+                const freqMax = data.freq_max ? (data.freq_max / 1000000).toFixed(3) : '?';
+                infoElement.textContent = `Center: ${centerFreq} MHz | Range: ${freqMin} - ${freqMax} MHz`;
             }
 
         } catch (error) {
-            console.error(`Failed to update waveform for receiver ${receiver.id}:`, error);
+            console.error(`Failed to update waterfall for receiver ${receiver.id}:`, error);
         }
     }
 


### PR DESCRIPTION
…ll display

This commit addresses multiple SDR-related bugs and missing features:

## 1. Fixed Device Opening Bug (drivers.py)
- CRITICAL: Resolved conflict when both serial and channel are provided
- Changed logic to use ONLY serial when available (don't mix with device_id)
- This fixes the "Unable to open AirSpy device" error
- Location: app_core/radio/drivers.py:200-214

## 2. Implemented Real-Time IQ Sample Streaming
- Added ring buffer to SoapySDR receivers for real-time sample access
- Implemented get_samples() method to retrieve recent IQ data
- Buffer stores ~0.67 seconds of samples (32768 samples at 48kHz)
- Enables audio demodulation and spectrum visualization
- Location: app_core/radio/drivers.py:109-465

## 3. Added RadioManager Audio Capture Methods
- Implemented start_audio_capture() for streaming from receivers
- Implemented stop_audio_capture() for cleanup
- Implemented get_audio_data() to retrieve samples via handle
- Implemented get_receiver() to access receiver instances
- Location: app_core/radio/manager.py:244-316

## 4. Created Global RadioManager Instance
- Added get_radio_manager() function for singleton access
- Prevents multiple RadioManager instances causing conflicts
- Ensures consistent receiver state across application
- Location: app_core/extensions.py:10-19

## 5. Fixed SDRSourceAdapter Integration
- Updated to use global RadioManager via get_radio_manager()
- Properly connects SDR receivers to audio ingestion pipeline
- Supports FM/AM demodulation when configured
- Location: app_core/audio/sources.py:76-78

## 6. Added Spectrum/Waterfall Display
- Created new /api/radio/spectrum endpoint for FFT data
- Computes real-time spectrum from IQ samples
- Returns normalized magnitude data for visualization
- Location: webapp/routes_settings_radio.py:457-526

## 7. Updated Settings/Radio Page to Show Waterfall
- Replaced waveform display with proper waterfall spectrogram
- Added color-coded intensity mapping (blue->cyan->green->yellow->red)
- Shows frequency range and center frequency
- Stores 100 spectrum lines for scrolling waterfall effect
- Increased refresh rate to 5 Hz (200ms) for smooth updates
- Location: templates/settings/radio.html:1489-1639

## 8. Removed SDR from Audio Source Options
- SDR receivers should only be added via Settings > Radio
- Removed confusing SDR option from audio source creation forms
- Added comments explaining the correct workflow
- Locations: templates/audio_sources.html:240, templates/settings/audio.html:275

## Testing Notes
These changes require SoapySDR to be installed and an SDR device connected. The waterfall display will show "Receiver not running" until a receiver is started via the Settings > Radio page.

Fixes: #563 (SDR device opening errors)
Fixes: #564 (Missing audio integration)
Fixes: #565 (Waterfall display)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time spectrum waterfall display in Radio settings, replacing the previous waveform monitor with color-mapped frequency history visualization.

* **UI Changes**
  * Enlarged radio monitor canvas (800×300) for improved visibility.
  * SDR receiver configuration moved to Settings > Radio; SDR option removed from Audio Sources dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->