### PR TITLE
Fix GPIO pin visibility when hardware is unavailable

### DIFF
--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -162,12 +162,18 @@ class GPIOController:
             if config.pin in self._pins:
                 raise ValueError(f"Pin {config.pin} is already configured")
 
-            if not self._initialized:
+            self._pins[config.pin] = config
+
+            if not self._initialized or RPiGPIO is None:
+                # Record the configuration even when GPIO hardware isn't available so the
+                # application can still display configured pins in the UI.
+                self._states[config.pin] = GPIOState.ERROR
                 if self.logger:
-                    self.logger.warning(f"Cannot configure pin {config.pin}: GPIO not available")
+                    self.logger.warning(
+                        f"Configured pin {config.pin} but GPIO hardware is not available"
+                    )
                 return
 
-            self._pins[config.pin] = config
             self._states[config.pin] = GPIOState.INACTIVE
 
             # Setup the pin

--- a/tests/test_gpio_controller.py
+++ b/tests/test_gpio_controller.py
@@ -1,0 +1,23 @@
+"""Tests for GPIO controller configuration behavior."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_utils.gpio import GPIOController, GPIOPinConfig, GPIOState
+
+
+def test_add_pin_records_configuration_when_gpio_unavailable():
+    """Configured pins should be visible even without GPIO hardware."""
+
+    controller = GPIOController()
+    controller.add_pin(GPIOPinConfig(pin=17, name="Test Pin"))
+
+    states = controller.get_all_states()
+
+    assert 17 in states
+    assert states[17]["name"] == "Test Pin"
+    assert states[17]["state"] == GPIOState.ERROR.value


### PR DESCRIPTION
## Summary
- retain GPIO pin configurations even when GPIO hardware is missing so they remain visible in the UI
- log a warning and mark the pin state as error when hardware is unavailable instead of discarding the configuration
- add a regression test ensuring the controller reports configured pins without GPIO access

## Testing
- pytest *(fails: missing samples/malformed.wav and ffmpeg dependency)*
- pytest tests/test_gpio_controller.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fecf81c408320a191d7c4a3c4f671)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPIO pins can now be properly configured and tracked in the user interface even when hardware is unavailable or not initialized, with error states displayed for better visibility and user feedback.
  * Improved error messaging to provide clearer information when GPIO hardware is unavailable.

* **Tests**
  * Added test coverage to verify GPIO controller behavior when hardware is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->