### PR TITLE
Fix legacy diagnostics handler syntax on radio settings page

### DIFF
--- a/templates/settings/radio.html
+++ b/templates/settings/radio.html
@@ -1260,7 +1260,7 @@
                 </div>
             `;
         }
-    });
+    };
 
     // Show Presets
     showPresetsBtn?.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- fix the legacy diagnostics helper closure so the radio settings script parses correctly

## Testing
- node --check /tmp/radio_script.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a35426648320b95ca2b06462a121)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minor syntax correction with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->