### PR TITLE
Normalize now playing metadata rendering

### DIFF
--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -306,41 +306,21 @@ function renderAudioSources() {
                         </div>
 
                         <!-- Now Playing (if available) -->
-                        ${source.metrics.metadata && (source.metrics.metadata.now_playing || source.metrics.metadata.song_title || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.text)) ? `
-                            <div class="mt-3">
-                                <h6 class="text-muted mb-2"><i class="fas fa-music"></i> Now Playing</h6>
-                                <div class="card bg-light border-0">
-                                    <div class="card-body p-3">
-                                        <div class="row align-items-center">
-                                            ${(() => {
-                                                // Get album art URL from various possible sources
-                                                const artworkUrl = source.metrics.metadata.artwork_url
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.amgArtworkURL)
-                                                    || (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.artwork_url)
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.artworkURL);
+                        ${(() => {
+                            const nowPlaying = normalizeNowPlayingMetadata(source.metrics.metadata);
+                            if (!nowPlaying) {
+                                return '';
+                            }
 
-                                                // Get song title from various sources
-                                                const songTitle = (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.text)
-                                                    || (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.title)
-                                                    || source.metrics.metadata.song_title
-                                                    || source.metrics.metadata.title
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.song);
+                            const { artworkUrl, title, artist, album, length } = nowPlaying;
 
-                                                // Get artist from various sources
-                                                const artist = (source.metrics.metadata.now_playing && source.metrics.metadata.now_playing.artist)
-                                                    || source.metrics.metadata.artist
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.artist);
-
-                                                // Get album
-                                                const album = source.metrics.metadata.album
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.album);
-
-                                                // Get length/duration
-                                                const length = source.metrics.metadata.length
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.length)
-                                                    || (source.metrics.metadata.icy && source.metrics.metadata.icy.fields && source.metrics.metadata.icy.fields.duration);
-
-                                                return artworkUrl ? `
+                            return `
+                                <div class="mt-3">
+                                    <h6 class="text-muted mb-2"><i class="fas fa-music"></i> Now Playing</h6>
+                                    <div class="card bg-light border-0">
+                                        <div class="card-body p-3">
+                                            <div class="row align-items-center">
+                                                ${artworkUrl ? `
                                                     <div class="col-auto">
                                                         <img src="${escapeHtml(artworkUrl)}"
                                                              alt="Album Art"
@@ -348,26 +328,19 @@ function renderAudioSources() {
                                                              style="width: 100px; height: 100px; object-fit: cover;"
                                                              onerror="this.style.display='none'">
                                                     </div>
-                                                    <div class="col">
-                                                        ${songTitle ? `<div class="fw-bold fs-5">${escapeHtml(songTitle)}</div>` : ''}
-                                                        ${artist ? `<div class="text-muted">${escapeHtml(artist)}</div>` : ''}
-                                                        ${album ? `<div class="small text-muted"><i class="fas fa-compact-disc"></i> ${escapeHtml(album)}</div>` : ''}
-                                                        ${length ? `<div class="small text-muted"><i class="fas fa-clock"></i> ${escapeHtml(length)}</div>` : ''}
-                                                    </div>
-                                                ` : `
-                                                    <div class="col">
-                                                        ${songTitle ? `<div class="fw-bold fs-5">${escapeHtml(songTitle)}</div>` : ''}
-                                                        ${artist ? `<div class="text-muted">${escapeHtml(artist)}</div>` : ''}
-                                                        ${album ? `<div class="small text-muted"><i class="fas fa-compact-disc"></i> ${escapeHtml(album)}</div>` : ''}
-                                                        ${length ? `<div class="small text-muted"><i class="fas fa-clock"></i> ${escapeHtml(length)}</div>` : ''}
-                                                    </div>
-                                                `;
-                                            })()}
+                                                ` : ''}
+                                                <div class="col">
+                                                    ${title ? `<div class="fw-semibold text-break">${escapeHtml(title)}</div>` : ''}
+                                                    ${artist ? `<div class="text-muted text-break">${escapeHtml(artist)}</div>` : ''}
+                                                    ${album ? `<div class="small text-muted text-break"><i class="fas fa-compact-disc"></i> ${escapeHtml(album)}</div>` : ''}
+                                                    ${length ? `<div class="small text-muted text-break"><i class="fas fa-clock"></i> ${escapeHtml(length)}</div>` : ''}
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                        ` : ''}
+                            `;
+                        })()}
 
                         <!-- Stream Metadata (if available) -->
                         ${source.metrics.metadata ? `
@@ -491,6 +464,114 @@ function getStatusColor(status) {
         'disconnected': 'warning'
     };
     return colors[status] || 'secondary';
+}
+
+function normalizeNowPlayingMetadata(metadata) {
+    if (!metadata) {
+        return null;
+    }
+
+    const icyFields = metadata.icy && metadata.icy.fields ? metadata.icy.fields : {};
+    const streamTitleInfo = parseStreamTitle(icyFields.text);
+
+    const artworkUrl = metadata.artwork_url
+        || (metadata.now_playing && metadata.now_playing.artwork_url)
+        || (icyFields && icyFields.amgArtworkURL)
+        || (icyFields && icyFields.artworkURL);
+
+    const title = cleanMetadataValue(
+        (metadata.now_playing && metadata.now_playing.title)
+        || metadata.song_title
+        || metadata.title
+        || streamTitleInfo.title
+        || streamTitleInfo.text
+    );
+
+    const artist = cleanMetadataValue(
+        (metadata.now_playing && metadata.now_playing.artist)
+        || metadata.artist
+        || icyFields.artist
+        || streamTitleInfo.artist
+    );
+
+    const album = cleanMetadataValue(metadata.album || icyFields.album);
+    const length = cleanMetadataValue(metadata.length || icyFields.length || icyFields.duration);
+
+    if (!artworkUrl && !title && !artist && !album && !length) {
+        return null;
+    }
+
+    return { artworkUrl, title, artist, album, length };
+}
+
+function parseStreamTitle(rawText) {
+    if (!rawText) {
+        return {};
+    }
+
+    let text = String(rawText).trim();
+
+    const streamTitleMatch = text.match(/StreamTitle='([^']*)'/i);
+    if (streamTitleMatch) {
+        text = streamTitleMatch[1];
+    } else if (text.toLowerCase().startsWith('streamtitle=')) {
+        text = text.slice('StreamTitle='.length);
+        text = text.replace(/^['"]?/, '').replace(/['"]?$/, '');
+    }
+
+    const streamUrlIndex = text.indexOf(';StreamUrl');
+    if (streamUrlIndex !== -1) {
+        text = text.substring(0, streamUrlIndex);
+    }
+
+    text = cleanMetadataValue(text);
+
+    if (!text) {
+        return {};
+    }
+
+    const parts = text.split(/\s+-\s+/);
+    if (parts.length >= 2) {
+        return {
+            text,
+            artist: parts[0].trim(),
+            title: parts.slice(1).join(' - ').trim()
+        };
+    }
+
+    return { text, title: text };
+}
+
+function cleanMetadataValue(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    let text = String(value).trim();
+
+    if (!text) {
+        return '';
+    }
+
+    const streamTitleMatch = text.match(/StreamTitle='([^']*)'/i);
+    if (streamTitleMatch) {
+        text = streamTitleMatch[1];
+    }
+
+    text = text.replace(/^StreamTitle=/i, '');
+    text = text.replace(/;StreamUrl='[^']*';?/i, '');
+    text = text.replace(/^['"]/, '').replace(/['"]$/, '');
+    text = text.replace(/\+/g, ' ');
+
+    if (/%[0-9A-Fa-f]{2}/.test(text)) {
+        try {
+            text = decodeURIComponent(text);
+        } catch (err) {
+            // Ignore decoding errors and use the original value
+        }
+    }
+
+    return text.trim();
 }
 
 function escapeHtml(text) {


### PR DESCRIPTION
## Summary
- normalize streaming metadata so the Now Playing card decodes ICY values and omits StreamTitle/StreamUrl noise
- update the Now Playing display styling to keep long titles readable without oversized text

## Testing
- pytest *(fails: FileNotFoundError: samples/malformed.wav; ffmpeg missing for audio decoding)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a62b215c8320af600d3c11956fb9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Now Playing display with enhanced metadata extraction from multiple sources
  * Better parsing and decoding of song information for more reliable display and readability
  * Standardized formatting of track metadata including artwork, title, artist, album, and duration
  * More robust handling of various stream metadata formats and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->