### PR TITLE
Improve SDR recovery handling and radio manager syncing

### DIFF
--- a/app_core/models.py
+++ b/app_core/models.py
@@ -601,12 +601,13 @@ class RadioReceiver(db.Model):
             gain=self.gain,
             channel=self.channel,
             serial=self.serial,
-            enabled=bool(self.enabled and self.auto_start),
+            enabled=bool(self.enabled),
             modulation_type=self.modulation_type or 'IQ',
             audio_output=bool(self.audio_output),
             stereo_enabled=bool(self.stereo_enabled),
             deemphasis_us=float(self.deemphasis_us) if self.deemphasis_us else 75.0,
             enable_rbds=bool(self.enable_rbds),
+            auto_start=bool(self.auto_start),
         )
 
     def latest_status(self) -> Optional["RadioReceiverStatus"]:

--- a/app_core/radio/manager.py
+++ b/app_core/radio/manager.py
@@ -31,6 +31,7 @@ class ReceiverConfig:
     stereo_enabled: bool = True  # FM stereo decoding
     deemphasis_us: float = 75.0  # De-emphasis time constant
     enable_rbds: bool = False  # Extract RBDS data
+    auto_start: bool = True  # Start automatically when manager boots
 
 
 @dataclass
@@ -150,6 +151,9 @@ class RadioManager:
 
         with self._lock:
             for receiver in self._receivers.values():
+                config = getattr(receiver, 'config', None)
+                if config is not None and not getattr(config, 'auto_start', True):
+                    continue
                 receiver.start()
 
     def stop_all(self) -> None:

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -331,7 +331,8 @@ except Exception as e:
                 gain=self.gain,
                 channel=self.channel,
                 serial=self.serial,
-                enabled=bool(self.enabled and self.auto_start),
+                enabled=bool(self.enabled),
+                auto_start=bool(self.auto_start),
             )
 
     class RadioReceiverStatus(Base):

--- a/tests/test_radio_drivers.py
+++ b/tests/test_radio_drivers.py
@@ -1,0 +1,154 @@
+import pathlib
+import sys
+import time
+import types
+
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_core.radio.drivers import RTLSDRReceiver
+from app_core.radio.manager import ReceiverConfig
+
+
+class _Result:
+    def __init__(self, ret: int) -> None:
+        self.ret = ret
+
+
+class _FailingDevice:
+    def __init__(self) -> None:
+        self.stream = object()
+
+    def setSampleRate(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setFrequency(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setGain(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setupStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        return "stream"
+
+    def activateStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def readStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        return _Result(-4)
+
+    def deactivateStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def closeStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def unmake(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def close(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+
+class _WorkingDevice:
+    def __init__(self) -> None:
+        self.stream = object()
+
+    def setSampleRate(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setFrequency(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setGain(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def setupStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        return "stream"
+
+    def activateStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def readStream(self, stream, buffers, length):  # noqa: N802 - mimic Soapy API
+        buffer = buffers[0]
+        buffer[:length] = 0.25 + 0.25j
+        return _Result(length)
+
+    def deactivateStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def closeStream(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def unmake(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+    def close(self, *args, **kwargs):  # noqa: N802 - mimic Soapy API
+        pass
+
+
+class _DeviceFactory:
+    open_count = 0
+
+    def __new__(cls, args):
+        cls.open_count += 1
+        if cls.open_count == 1:
+            return _FailingDevice()
+        return _WorkingDevice()
+
+    @classmethod
+    def enumerate(cls):
+        return []
+
+
+class _SoapyModule(types.SimpleNamespace):
+    pass
+
+
+def _install_soapysdr_stub(monkeypatch):
+    module = _SoapyModule()
+    module.SOAPY_SDR_RX = 1
+    module.SOAPY_SDR_CF32 = 2
+    module.Device = _DeviceFactory
+    monkeypatch.setitem(sys.modules, "SoapySDR", module)
+    return module
+
+
+def test_receiver_recovers_from_stream_error(monkeypatch):
+    _DeviceFactory.open_count = 0
+    _install_soapysdr_stub(monkeypatch)
+
+    config = ReceiverConfig(
+        identifier="test",
+        driver="rtlsdr",
+        frequency_hz=162_550_000,
+        sample_rate=2_400_000,
+        gain=10.0,
+        auto_start=True,
+    )
+
+    receiver = RTLSDRReceiver(config)
+    receiver.start()
+
+    try:
+        deadline = time.time() + 2.0
+        success = False
+        while time.time() < deadline:
+            status = receiver.get_status()
+            samples = receiver.get_samples(512)
+            if status.locked and samples is not None and len(samples) == 512:
+                # Ensure samples look like complex64 numpy array
+                assert isinstance(samples, np.ndarray)
+                assert samples.dtype == np.complex64
+                success = True
+                break
+            time.sleep(0.05)
+
+        assert success, "receiver did not recover from initial stream error"
+    finally:
+        receiver.stop()
+        monkeypatch.delitem(sys.modules, "SoapySDR", raising=False)
+        _DeviceFactory.open_count = 0

--- a/tests/test_radio_manager.py
+++ b/tests/test_radio_manager.py
@@ -1,0 +1,88 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_core.radio.manager import RadioManager, ReceiverConfig, ReceiverInterface, ReceiverStatus
+
+
+class _DummyReceiver(ReceiverInterface):
+    def __init__(self, config: ReceiverConfig) -> None:
+        super().__init__(config)
+        self.started = 0
+        self.stopped = 0
+        self._status = ReceiverStatus(identifier=config.identifier, locked=False)
+
+    def start(self) -> None:
+        self.started += 1
+
+    def stop(self) -> None:
+        self.stopped += 1
+
+    def get_status(self) -> ReceiverStatus:
+        return self._status
+
+    def capture_to_file(self, duration_seconds, output_dir, prefix, *, mode="iq"):
+        raise NotImplementedError
+
+
+def test_start_all_respects_auto_start_flag():
+    manager = RadioManager()
+    manager.register_driver("dummy", _DummyReceiver)
+
+    configs = [
+        ReceiverConfig(
+            identifier="auto",
+            driver="dummy",
+            frequency_hz=162_550_000,
+            sample_rate=2_400_000,
+            enabled=True,
+            auto_start=True,
+        ),
+        ReceiverConfig(
+            identifier="manual",
+            driver="dummy",
+            frequency_hz=162_550_000,
+            sample_rate=2_400_000,
+            enabled=True,
+            auto_start=False,
+        ),
+    ]
+
+    manager.configure_receivers(configs)
+    manager.start_all()
+
+    auto_receiver = manager.get_receiver("auto")
+    manual_receiver = manager.get_receiver("manual")
+
+    assert auto_receiver is not None
+    assert manual_receiver is not None
+    assert auto_receiver.started == 1
+    assert manual_receiver.started == 0
+
+
+def test_receiver_config_preserves_auto_start_flag():
+    from app_core.models import RadioReceiver
+
+    class _Stub:
+        identifier = "wx42"
+        display_name = "Weather"
+        driver = "rtlsdr"
+        frequency_hz = 162_550_000
+        sample_rate = 2_400_000
+        gain = None
+        channel = None
+        serial = None
+        enabled = True
+        auto_start = False
+        modulation_type = 'IQ'
+        audio_output = False
+        stereo_enabled = True
+        deemphasis_us = 75.0
+        enable_rbds = False
+
+    config = RadioReceiver.to_receiver_config(_Stub())
+    assert config.enabled is True
+    assert config.auto_start is False


### PR DESCRIPTION
## Summary
- add exponential backoff recovery to the SoapySDR receiver loop so streams reconnect automatically and preserve sample buffers
- expose the auto_start flag on ReceiverConfig, keep receivers configured even when auto_start is false, and resync the RadioManager after CRUD operations
- cover the new radio manager behaviour and SoapySDR recovery logic with focused regression tests

## Testing
- pytest tests/test_radio_manager.py tests/test_radio_drivers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b6350c7883208261e8631296d49d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-receiver `auto_start` configuration option to control which receivers automatically start on system boot.
  * Enhanced radio driver resilience with automatic device reconnection and recovery from stream errors.

* **Bug Fixes**
  * Improved error handling and resource cleanup for radio device streams and buffer management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->