### PR TITLE
Fix nginx crash loop: remove chmod from read-only mount

### DIFF
--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -27,7 +27,7 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME:-localhost}
       - SSL_EMAIL=${SSL_EMAIL:-admin@example.com}
       - CERTBOT_STAGING=${CERTBOT_STAGING:-0}
-    command: /bin/sh -c "chmod +x /docker-entrypoint.d/00-init.sh && /docker-entrypoint.d/00-init.sh"
+    entrypoint: ["/bin/sh", "/docker-entrypoint.d/00-init.sh"]
     depends_on:
       - app
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME:-localhost}
       - SSL_EMAIL=${SSL_EMAIL:-admin@example.com}
       - CERTBOT_STAGING=${CERTBOT_STAGING:-0}
-    command: /bin/sh -c "chmod +x /docker-entrypoint.d/00-init.sh && /docker-entrypoint.d/00-init.sh"
+    entrypoint: ["/bin/sh", "/docker-entrypoint.d/00-init.sh"]
     depends_on:
       - app
     security_opt:


### PR DESCRIPTION
CRITICAL FIX: nginx container was in infinite restart loop

Problem:
- nginx-init.sh mounted as read-only (:ro)
- command tried to chmod the read-only file
- chmod failed with 'Read-only file system'
- nginx crashed and restarted continuously
- Users unable to access application

Solution:
- Changed from 'command' to 'entrypoint' (cleaner approach)
- Removed chmod command entirely
- File is already executable on host (755 permissions)
- nginx now starts successfully

Changes:
- docker-compose.yml: Use entrypoint instead of command with chmod
- docker-compose.embedded-db.yml: Use entrypoint instead of command with chmod

Result:
✅ nginx starts without errors
✅ HTTPS works
✅ Front-end accessible again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container initialization configuration for improved startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->