### PR TITLE
Add custom nginx Dockerfile with required tools

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,21 @@
+FROM nginx:alpine
+
+# Install required tools for certificate handling and envsubst
+RUN apk add --no-cache \
+    openssl \
+    gettext \
+    bash
+
+# Create necessary directories
+RUN mkdir -p /var/www/certbot /etc/nginx/conf.d
+
+# Copy initialization script
+COPY nginx-init.sh /docker-entrypoint.d/00-init.sh
+RUN chmod +x /docker-entrypoint.d/00-init.sh
+
+# Copy nginx configuration template
+COPY nginx.conf /etc/nginx/nginx.conf.template
+
+EXPOSE 80 443
+
+CMD ["/docker-entrypoint.d/00-init.sh"]

--- a/docker-compose.embedded-db.yml
+++ b/docker-compose.embedded-db.yml
@@ -11,15 +11,16 @@
 
 services:
   nginx:
-    image: nginx:alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    image: eas-nginx:latest
     restart: unless-stopped
     ports:
       - "80:80"    # HTTP (redirects to HTTPS)
       - "443:443"  # HTTPS
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf.template:ro
-      - ./nginx-init.sh:/docker-entrypoint.d/00-init.sh:ro
-      - certbot-conf:/etc/letsencrypt:ro
+      - certbot-conf:/etc/letsencrypt
       - certbot-www:/var/www/certbot
       - nginx-logs:/var/log/nginx
       - app-config:/app-config:ro  # Read persistent config from setup wizard
@@ -27,7 +28,6 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME:-localhost}
       - SSL_EMAIL=${SSL_EMAIL:-admin@example.com}
       - CERTBOT_STAGING=${CERTBOT_STAGING:-0}
-    entrypoint: ["/bin/sh", "/docker-entrypoint.d/00-init.sh"]
     depends_on:
       - app
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
 services:
   nginx:
-    image: nginx:alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    image: eas-nginx:latest
     restart: unless-stopped
     ports:
       - "80:80"    # HTTP (redirects to HTTPS)
       - "443:443"  # HTTPS
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf.template:ro
-      - ./nginx-init.sh:/docker-entrypoint.d/00-init.sh:ro
-      - certbot-conf:/etc/letsencrypt:ro
+      - certbot-conf:/etc/letsencrypt
       - certbot-www:/var/www/certbot
       - nginx-logs:/var/log/nginx
       - app-config:/app-config:ro  # Read persistent config from setup wizard
@@ -16,7 +17,6 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME:-localhost}
       - SSL_EMAIL=${SSL_EMAIL:-admin@example.com}
       - CERTBOT_STAGING=${CERTBOT_STAGING:-0}
-    entrypoint: ["/bin/sh", "/docker-entrypoint.d/00-init.sh"]
     depends_on:
       - app
     security_opt:


### PR DESCRIPTION
CRITICAL FIX: nginx container not starting - missing tools

Problem:
- nginx:alpine is too minimal - missing openssl, bash, gettext
- Script tried to use tools that don't exist in base image
- Container crashed immediately with no logs
- Site completely inaccessible

Solution:
- Created Dockerfile.nginx extending nginx:alpine
- Install openssl (for self-signed certs)
- Install bash (for script compatibility)
- Install gettext (for envsubst template processing)
- Build custom eas-nginx image with all required tools

Changes:
- Dockerfile.nginx: New custom nginx image with tools
- docker-compose.yml: Build custom nginx instead of stock image
- docker-compose.embedded-db.yml: Build custom nginx instead of stock image
- Removed read-only mounts (files now in image)

This will allow nginx to actually start and serve traffic.