### PR TITLE
Fix nginx config structure - add http and events blocks

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,18 +1,32 @@
 # nginx configuration for EAS Station with HTTPS support
 # This configuration handles both HTTP and HTTPS traffic
 
-# Rate limiting zone to prevent abuse
-limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
-limit_req_zone $binary_remote_addr zone=general_limit:10m rate=30r/s;
-
-# Upstream backend (Flask/Gunicorn)
-upstream eas_backend {
-    server app:5000;
-    keepalive 32;
+events {
+    worker_connections 1024;
 }
 
-# HTTP server - redirect to HTTPS (will be enabled after SSL certificates are obtained)
-server {
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    # Rate limiting zone to prevent abuse
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=general_limit:10m rate=30r/s;
+
+    # Upstream backend (Flask/Gunicorn)
+    upstream eas_backend {
+        server app:5000;
+        keepalive 32;
+    }
+
+    # HTTP server - redirect to HTTPS (will be enabled after SSL certificates are obtained)
+    server {
     listen 80;
     listen [::]:80;
     server_name ${DOMAIN_NAME};
@@ -119,4 +133,5 @@ server {
         expires 1d;
         add_header Cache-Control "public, immutable";
     }
+}
 }


### PR DESCRIPTION
CRITICAL: nginx config syntax error preventing startup

Error: limit_req_zone not allowed at top level
Solution: Add proper http and events blocks

nginx.conf now has correct structure for successful startup