### PR TITLE
Fix PDF export buttons: relabel and fix broken references

### DIFF
--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -999,7 +999,7 @@
                                     <i class="fas fa-code"></i> <span id="raw-data-btn-text">View Raw CAP Data</span>
                                 </button>
                                 <a href="{{ url_for('alert_detail_pdf', alert_id=alert.id) }}" target="_blank" class="btn btn-outline-secondary">
-                                    <i class="fas fa-print"></i> Print This Page
+                                    <i class="fas fa-file-pdf"></i> Export PDF
                                 </a>
                                 <button type="button" class="btn btn-outline-success" onclick="findSimilarAlerts()">
                                     <i class="fas fa-search"></i> Find Similar Alerts

--- a/templates/audio_detail.html
+++ b/templates/audio_detail.html
@@ -11,7 +11,7 @@
             </h1>
             <div class="d-flex gap-2 flex-wrap">
                 <a href="{{ url_for('audio_detail_pdf', message_id=message.id) }}" target="_blank" class="btn btn-info">
-                    <i class="fas fa-print"></i> Print
+                    <i class="fas fa-file-pdf"></i> Export PDF
                 </a>
                 {% if audio_url %}
                 <a class="btn btn-primary" href="{{ audio_url }}" target="_blank" rel="noopener">

--- a/templates/audio_history.html
+++ b/templates/audio_history.html
@@ -14,7 +14,7 @@
                     <button type="button" class="btn btn-success" onclick="exportAudioArchive()" title="Export visible audio records">
                         <i class="fas fa-file-export"></i> Export
                     </button>
-                    <button type="button" class="btn btn-info" onclick="printPageAsPDF('audio_history')" title="Print this page">
+                    <button type="button" class="btn btn-info" onclick="window.print()" title="Print this page">
                         <i class="fas fa-print"></i> Print
                     </button>
                     {% if current_user %}

--- a/templates/doc_viewer.html
+++ b/templates/doc_viewer.html
@@ -197,7 +197,7 @@
                         <a href="/docs" class="btn btn-outline-secondary">
                             <i class="fas fa-arrow-left"></i> Back to Documentation Index
                         </a>
-                        <button onclick="printPageAsPDF('documentation')" class="btn btn-outline-primary">
+                        <button onclick="window.print()" class="btn btn-outline-primary">
                             <i class="fas fa-print"></i> Print
                         </button>
                     </div>

--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -17,7 +17,7 @@
             </a>
             {% endif %}
             <a href="{{ url_for('eas.manual_eas_print_pdf', event_id=event.id) }}" target="_blank" class="btn btn-primary btn-sm ms-2">
-                <i class="fas fa-print"></i> Print
+                <i class="fas fa-file-pdf"></i> Export PDF
             </a>
             {% if current_user %}
             <button type="button" class="btn btn-danger btn-sm ms-2" onclick="deleteManualActivation()" title="Delete this activation">


### PR DESCRIPTION
ISSUES FIXED:
1. PDF export buttons were mislabeled as "Print" instead of "Export PDF"
2. doc_viewer.html and audio_history.html had broken references to printPageAsPDF() which was removed in the server-side PDF implementation

CHANGES:
- Relabeled all PDF export buttons to "Export PDF" for clarity
- Changed icons from fa-print to fa-file-pdf for PDF exports
- Fixed doc_viewer.html and audio_history.html to use window.print() instead of the removed printPageAsPDF() function

Updated templates:
- alert_detail.html:1002 - "Export PDF" with fa-file-pdf icon
- audio_detail.html:14 - "Export PDF" with fa-file-pdf icon
- manual_eas_print.html:20 - "Export PDF" with fa-file-pdf icon
- doc_viewer.html:200 - Fixed to use window.print()
- audio_history.html:17 - Fixed to use window.print()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized export and print button labels across the application for improved clarity.
  * Updated icons to better reflect export versus print functionality.
  * Refined print and export workflows for a more consistent user experience across alert details, audio details, and document views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->