### PR TITLE
Add Mermaid.js support to documentation viewer

### DIFF
--- a/templates/doc_viewer.html
+++ b/templates/doc_viewer.html
@@ -3,6 +3,29 @@
 {% block title %}{{ title }} - Documentation - EAS Station{% endblock %}
 
 {% block extra_css %}
+<!-- Mermaid.js for diagram rendering -->
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Convert code.language-mermaid blocks to divs for Mermaid rendering
+        document.querySelectorAll('code.language-mermaid').forEach(function(codeBlock) {
+            const pre = codeBlock.parentElement;
+            const mermaidDiv = document.createElement('div');
+            mermaidDiv.className = 'mermaid';
+            mermaidDiv.textContent = codeBlock.textContent;
+            pre.replaceWith(mermaidDiv);
+        });
+
+        // Initialize Mermaid
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            securityLevel: 'loose',
+        });
+        mermaid.contentLoaded();
+    });
+</script>
+
 <style>
 .doc-content {
     font-size: 1.05rem;
@@ -133,6 +156,17 @@
     border-left-color: #0d6efd;
     color: #0d6efd;
     font-weight: 600;
+}
+
+/* Mermaid diagram styling */
+.doc-content .mermaid {
+    display: block;
+    text-align: center;
+    background-color: #fff;
+    padding: 1.5rem;
+    border-radius: 0.375rem;
+    border: 1px solid #dee2e6;
+    margin: 1.5rem 0;
 }
 
 @media print {


### PR DESCRIPTION
The documentation viewer was displaying Mermaid diagrams as plain text code blocks instead of rendering them as visual diagrams. This fixes the issue by:

- Adding Mermaid.js library (v10) from CDN
- Converting code.language-mermaid blocks to div.mermaid elements on page load
- Initializing Mermaid to render diagrams after DOM is ready
- Adding CSS styling for proper diagram presentation

This enables all architecture documents with diagrams (like SYSTEM_ARCHITECTURE.md) to display their Mermaid flowcharts, sequence diagrams, and other visualizations properly in the web UI.

Fixes: Mermaid diagrams appearing as plain text in docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The documentation viewer now supports Mermaid diagrams, allowing documentation authors to create and embed visual diagrams directly within documentation files. Diagrams render automatically upon page load, enabling better visualization and communication of workflows, architectures, and complex processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->