### PR TITLE
fix: prevent unnecessary certificate renewals hitting Let's Encrypt r…

### DIFF
--- a/nginx-init.sh
+++ b/nginx-init.sh
@@ -63,15 +63,19 @@ certificate_is_trusted_and_valid() {
         return 1
     fi
 
+    # Check if certificate is expired or not yet valid
     if ! openssl x509 -in "$CERT_PATH" -checkend 0 -noout >/dev/null 2>&1; then
         return 1
     fi
 
-    if openssl verify -CAfile /etc/ssl/certs/ca-certificates.crt "$CERT_PATH" >/dev/null 2>&1; then
-        return 0
+    # Check if certificate is self-signed (self-signed certs should be replaced)
+    if is_self_signed_certificate "$CERT_PATH"; then
+        return 1
     fi
 
-    return 1
+    # If certificate exists, is not expired, and is not self-signed, consider it valid
+    # Don't fail on openssl verify issues as they may be false positives
+    return 0
 }
 
 describe_certificate_issue() {
@@ -120,7 +124,12 @@ purge_stale_self_signed_material() {
                 ;;
         esac
 
-        if [ -f "$MARKER_FILE" ] || { [ "$DOMAIN_MATCH" -eq 1 ] && ! certificate_is_trusted_and_valid "$CERT_PATH"; } || { [ "$DOMAIN_MATCH" -eq 1 ] && is_self_signed_certificate "$CERT_PATH"; }; then
+        # Only purge certificates that are:
+        # 1. Marked as self-signed (via marker file)
+        # 2. Actually self-signed (detected by certificate check)
+        # 3. Expired or not yet valid
+        # Don't purge certificates just because they fail trust verification
+        if [ -f "$MARKER_FILE" ] || { [ "$DOMAIN_MATCH" -eq 1 ] && is_self_signed_certificate "$CERT_PATH"; } || { [ "$DOMAIN_MATCH" -eq 1 ] && [ -s "$CERT_PATH" ] && ! openssl x509 -in "$CERT_PATH" -checkend 0 -noout >/dev/null 2>&1; }; then
             describe_certificate_issue "$CERT_PATH" "$CERT_DOMAIN"
             echo "Removing stale certificate artifacts for $CERT_DOMAIN"
             purge_certificate_material "$CERT_DOMAIN"
@@ -188,9 +197,8 @@ if [ -f "/etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem" ]; then
         CURRENT_CERT_SELF_SIGNED=0
     else
         describe_certificate_issue "/etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem" "$DOMAIN_NAME"
-        echo "Existing certificate for $DOMAIN_NAME failed validation"
+        echo "Existing certificate for $DOMAIN_NAME is expired or invalid"
         echo "Will request a new trusted certificate"
-        touch "$SELF_SIGNED_MARKER"
         CURRENT_CERT_SELF_SIGNED=1
     fi
 else
@@ -245,7 +253,6 @@ if [ "$CURRENT_CERT_SELF_SIGNED" -ne 0 ]; then
             CERTBOT_CMD="$CERTBOT_CMD -d $DOMAIN_NAME"
             CERTBOT_CMD="$CERTBOT_CMD --cert-name $DOMAIN_NAME"
             CERTBOT_CMD="$CERTBOT_CMD --non-interactive"
-            CERTBOT_CMD="$CERTBOT_CMD --force-renewal"
 
             # Add staging flag if requested
             if [ "$STAGING" = "1" ]; then


### PR DESCRIPTION
…ate limits

The certificate renewal logic was requesting new certificates on every stack deployment, hitting Let's Encrypt's rate limit (5 certs per 168h).

Changes:
- Removed --force-renewal flag from certbot command
- Improved certificate_is_trusted_and_valid() to only reject expired or self-signed certs
- Updated purge logic to preserve valid certificates
- Certificates in persistent volume are now properly reused across deployments

This fixes the "too many certificates already issued" error by only requesting new certificates when actually needed (expired or self-signed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate validation logic to more accurately detect expired and invalid certificates.
  * Enhanced self-signed certificate detection and cleanup to ensure stale certificates are properly removed.
  * Refined certificate status checks for more reliable identification of certificate validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->