### PR TITLE
Fix MkDocs mermaid integration

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,77 @@
+(function () {
+  function getDocumentBody() {
+    return document.body || document.querySelector("body");
+  }
+
+  function getMermaidTheme() {
+    const body = getDocumentBody();
+    if (!body) {
+      return "default";
+    }
+
+    const scheme = body.getAttribute("data-md-color-scheme");
+    if (scheme) {
+      return scheme === "slate" ? "dark" : "default";
+    }
+    const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    return prefersDark ? "dark" : "default";
+  }
+
+  function renderMermaidDiagrams() {
+    if (typeof mermaid === "undefined") {
+      return;
+    }
+
+    const mermaidElements = document.querySelectorAll(".mermaid");
+    if (!mermaidElements.length) {
+      return;
+    }
+
+    mermaidElements.forEach((element) => {
+      element.removeAttribute("data-processed");
+    });
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: getMermaidTheme(),
+    });
+
+    mermaid.init(undefined, mermaidElements);
+  }
+
+  if (typeof document$ !== "undefined" && document$.subscribe) {
+    document$.subscribe(renderMermaidDiagrams);
+  }
+
+  const schemeMediaQuery = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
+  if (schemeMediaQuery) {
+    if (typeof schemeMediaQuery.addEventListener === "function") {
+      schemeMediaQuery.addEventListener("change", renderMermaidDiagrams);
+    } else if (typeof schemeMediaQuery.addListener === "function") {
+      schemeMediaQuery.addListener(renderMermaidDiagrams);
+    }
+  }
+
+  const bodyElement = getDocumentBody();
+  if (bodyElement) {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "attributes" && mutation.attributeName === "data-md-color-scheme") {
+          renderMermaidDiagrams();
+          break;
+        }
+      }
+    });
+
+    observer.observe(bodyElement, {
+      attributes: true,
+      attributeFilter: ["data-md-color-scheme"],
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderMermaidDiagrams);
+  } else {
+    renderMermaidDiagrams();
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:
@@ -114,6 +114,11 @@ extra:
 # Additional CSS
 # extra_css:
 #   - stylesheets/extra.css  # Not available in current docs structure
+
+# Additional JavaScript
+extra_javascript:
+  - https://unpkg.com/mermaid@10.9.0/dist/mermaid.min.js
+  - javascripts/mermaid-init.js
 
 # Navigation Structure
 # Auto-discover documentation structure


### PR DESCRIPTION
## Summary
- configure the MkDocs Material build to load Mermaid properly
- add a JavaScript initializer so diagrams render on navigation and theme changes

## Testing
- mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691247a3784c8320a4d5960b7b5cc14f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mermaid diagram rendering with dynamic theming support
  * Diagrams automatically adapt to light and dark mode preferences and re-render when theme changes are detected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->