### PR TITLE
Fix Mermaid rendering so diagrams render instead of MERMAIDBLOCK

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,4 +1,6 @@
 (function () {
+  let renderIdCounter = 0;
+
   function getDocumentBody() {
     return document.body || document.querySelector("body");
   }
@@ -13,8 +15,75 @@
     if (scheme) {
       return scheme === "slate" ? "dark" : "default";
     }
+
     const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
     return prefersDark ? "dark" : "default";
+  }
+
+  function escapeHtml(value) {
+    return String(value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function extractMermaidCode(element) {
+    if (element.dataset && element.dataset.mermaidCode) {
+      return element.dataset.mermaidCode;
+    }
+
+    const tagName = element.tagName ? element.tagName.toLowerCase() : "";
+    let code = "";
+    if (tagName === "pre") {
+      const codeElement = element.querySelector("code");
+      code = codeElement ? codeElement.textContent || "" : element.textContent || "";
+    } else {
+      code = element.textContent || "";
+    }
+
+    return code.trim();
+  }
+
+  function ensureMermaidContainer(element, code) {
+    if (element.dataset && element.dataset.mermaidCode) {
+      element.dataset.mermaidCode = code;
+      return element;
+    }
+
+    const container = document.createElement("div");
+    container.className = "mermaid";
+    container.dataset.mermaidCode = code;
+    element.replaceWith(container);
+    return container;
+  }
+
+  function renderMermaidBlock(element) {
+    const code = extractMermaidCode(element);
+    if (!code) {
+      return;
+    }
+
+    const container = ensureMermaidContainer(element, code);
+    const renderId = `mermaid-${renderIdCounter++}`;
+
+    try {
+      mermaid.render(
+        renderId,
+        code,
+        (svgCode, bindFunctions) => {
+          container.innerHTML = svgCode;
+          if (typeof bindFunctions === "function") {
+            bindFunctions(container);
+          }
+        },
+        container
+      );
+    } catch (error) {
+      console.error("Mermaid rendering failed", error);
+      container.innerHTML = `<pre class="mermaid-error">${escapeHtml(code)}</pre>`;
+    }
   }
 
   function renderMermaidDiagrams() {
@@ -22,25 +91,41 @@
       return;
     }
 
-    const mermaidElements = document.querySelectorAll(".mermaid");
+    const mermaidElements = document.querySelectorAll("pre.mermaid, div.mermaid");
     if (!mermaidElements.length) {
       return;
     }
 
-    mermaidElements.forEach((element) => {
-      element.removeAttribute("data-processed");
-    });
-
     mermaid.initialize({
       startOnLoad: false,
       theme: getMermaidTheme(),
+      securityLevel: "loose",
     });
 
-    mermaid.init(undefined, mermaidElements);
+    mermaidElements.forEach((element) => {
+      if (element.removeAttribute) {
+        element.removeAttribute("data-processed");
+      }
+      renderMermaidBlock(element);
+    });
   }
 
-  if (typeof document$ !== "undefined" && document$.subscribe) {
+  function subscribeToDocumentReady() {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", renderMermaidDiagrams);
+    } else {
+      renderMermaidDiagrams();
+    }
+  }
+
+  const hasDocumentSubscription =
+    typeof document$ !== "undefined" && document$ && typeof document$.subscribe === "function";
+
+  if (hasDocumentSubscription) {
     document$.subscribe(renderMermaidDiagrams);
+    renderMermaidDiagrams();
+  } else {
+    subscribeToDocumentReady();
   }
 
   const schemeMediaQuery = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
@@ -58,7 +143,7 @@
       for (const mutation of mutations) {
         if (mutation.type === "attributes" && mutation.attributeName === "data-md-color-scheme") {
           renderMermaidDiagrams();
-          break;
+          return;
         }
       }
     });
@@ -69,9 +154,4 @@
     });
   }
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", renderMermaidDiagrams);
-  } else {
-    renderMermaidDiagrams();
-  }
 })();


### PR DESCRIPTION
## Summary
- replace the Mermaid runtime initialiser so each fenced block is re-rendered with mermaid.render
- cache the original diagram text in data attributes so theme changes and instant navigation re-run the renderer correctly
- add defensive error handling to surface Mermaid parsing failures instead of leaving MERMAIDBLOCK placeholders

## Testing
- mkdocs build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124f81c40c83209f890e7400ce6707)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic diagram re-rendering when color scheme changes.

* **Bug Fixes**
  * Improved Mermaid diagram rendering with enhanced error handling that displays code blocks when rendering fails.
  * Fixed element selection for better diagram detection and processing.

* **Chores**
  * Enhanced HTML sanitization and security protocols for diagram rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->