### PR TITLE
Fix diagram file path references in SYSTEM_ARCHITECTURE.md

### DIFF
--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -1090,7 +1090,7 @@ Detailed flowchart showing the complete CAP alert ingestion workflow from extern
 
 ![Alert Processing Pipeline](../assets/diagrams/alert-processing-pipeline.svg)
 
-**File:** [assets/diagrams/alert-processing-pipeline.svg](../assets/diagrams/alert-processing-pipeline.svg)
+**File:** [../assets/diagrams/alert-processing-pipeline.svg](../assets/diagrams/alert-processing-pipeline.svg)
 
 ---
 
@@ -1100,7 +1100,7 @@ Step-by-step workflow diagram illustrating the complete EAS message generation a
 
 ![EAS Broadcast Workflow](../assets/diagrams/broadcast-workflow.svg)
 
-**File:** [assets/diagrams/broadcast-workflow.svg](../assets/diagrams/broadcast-workflow.svg)
+**File:** [../assets/diagrams/broadcast-workflow.svg](../assets/diagrams/broadcast-workflow.svg)
 
 ---
 
@@ -1110,7 +1110,7 @@ Block diagram showing multi-source audio ingestion architecture with adapters, p
 
 ![Audio Source Routing](../assets/diagrams/audio-source-routing.svg)
 
-**File:** [assets/diagrams/audio-source-routing.svg](../assets/diagrams/audio-source-routing.svg)
+**File:** [../assets/diagrams/audio-source-routing.svg](../assets/diagrams/audio-source-routing.svg)
 
 ---
 
@@ -1120,7 +1120,7 @@ Physical deployment diagram showing Raspberry Pi 5 hardware configuration with a
 
 ![Hardware Deployment](../assets/diagrams/system-deployment-hardware.svg)
 
-**File:** [assets/diagrams/system-deployment-hardware.svg](../assets/diagrams/system-deployment-hardware.svg)
+**File:** [../assets/diagrams/system-deployment-hardware.svg](../assets/diagrams/system-deployment-hardware.svg)
 
 ---
 


### PR DESCRIPTION
Update the display text of diagram file path links to accurately reflect the relative paths (../assets/diagrams/) instead of showing incorrect paths (assets/diagrams/). This ensures consistency between the link display text and the actual relative path being referenced.

Fixed 4 diagram references:
- alert-processing-pipeline.svg
- broadcast-workflow.svg
- audio-source-routing.svg
- system-deployment-hardware.svg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagram file path references in system architecture documentation for proper relative path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->