### PR TITLE
Fix Mermaid diagram rendering in documentation viewer

### DIFF
--- a/webapp/documentation.py
+++ b/webapp/documentation.py
@@ -31,7 +31,7 @@ def _markdown_to_html(content: str) -> str:
     mermaid_pattern = r'```mermaid\r?\n(.*?)```'
 
     def save_mermaid(match):
-        placeholder = f'___MERMAID_BLOCK_{len(mermaid_blocks)}___'
+        placeholder = f'%%%MERMAID_BLOCK_{len(mermaid_blocks)}%%%'
         mermaid_blocks[placeholder] = match.group(1)
         return placeholder
 


### PR DESCRIPTION
The markdown parser was breaking Mermaid diagram placeholders because the old placeholder format (___MERMAID_BLOCK_0___) contained underscores, which were being converted to <em> tags by the italic regex.

Changed placeholder format from ___MERMAID_BLOCK_N___ to %%%MERMAID_BLOCK_N%%% to avoid conflicts with markdown formatting rules.

Fixes: Diagrams now render properly at /docs/architecture/SYSTEM_ARCHITECTURE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to documentation processing with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->