### PR TITLE
Fix Mermaid placeholder by removing underscores

### DIFF
--- a/webapp/documentation.py
+++ b/webapp/documentation.py
@@ -31,7 +31,7 @@ def _markdown_to_html(content: str) -> str:
     mermaid_pattern = r'```mermaid\r?\n(.*?)```'
 
     def save_mermaid(match):
-        placeholder = f'%%%MERMAID_BLOCK_{len(mermaid_blocks)}%%%'
+        placeholder = f'%%%MERMAIDBLOCK{len(mermaid_blocks)}%%%'
         mermaid_blocks[placeholder] = match.group(1)
         return placeholder
 


### PR DESCRIPTION
The previous fix still had underscores in the placeholder (%%%MERMAID_BLOCK_N%%%) which were being converted to <em> tags by the italic regex, breaking the replacement.

Changed to %%%MERMAIDBLOCKN%%% (no underscores) to completely avoid markdown formatting interference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal placeholder handling for documentation processing. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->