### PR TITLE
Add required nationwide FIPS code (000000) to location settings

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -883,7 +883,7 @@
                                     <p class="text-muted small mb-0">No SAME / FIPS counties selected yet.</p>
                                 </div>
                                 <input type="hidden" id="locationFipsCodes" name="fips_codes">
-                                <small class="text-muted d-block mt-2">Select up to 31 SAME location codes to monitor.</small>
+                                <small class="text-muted d-block mt-2">Select up to 31 SAME location codes to monitor. The nationwide code (000000) is automatically included and required for nationwide alerts.</small>
                             </div>
                             <div class="col-md-6">
                                 <label for="locationZoneCodes" class="form-label fw-bold">NOAA Zone / UGC Codes</label>
@@ -3435,6 +3435,7 @@
                 const detail = getFipsCodeDetails(code);
                 const normalized = detail ? detail.code : normalizeFipsCode(code);
                 const label = detail ? detail.description : normalized;
+                const isNationwide = normalized === '000000';
                 const subtitle = (() => {
                     if (!detail) {
                         return normalized;
@@ -3451,15 +3452,18 @@
                     }
                     return parts.join(' • ') || normalized;
                 })();
+                const removeButton = isNationwide
+                    ? `<span class="badge bg-primary text-white">Required</span>`
+                    : `<button type="button" class="btn btn-sm btn-outline-danger" data-remove-fips="${escapeHtml(normalized)}">
+                            <i class="fas fa-times"></i>
+                       </button>`;
                 return `
                     <div class="border rounded-3 p-2 bg-body-secondary bg-opacity-25 d-flex align-items-center justify-content-between mb-2 gap-3">
                         <div class="flex-grow-1">
                             <div class="fw-semibold">${escapeHtml(label)}</div>
                             <div class="small text-muted mb-0">${escapeHtml(subtitle)}</div>
                         </div>
-                        <button type="button" class="btn btn-sm btn-outline-danger" data-remove-fips="${escapeHtml(normalized)}">
-                            <i class="fas fa-times"></i>
-                        </button>
+                        ${removeButton}
                     </div>
                 `;
             }).join('');
@@ -3468,6 +3472,8 @@
         function setLocationFipsSelection(codes) {
             const normalized = Array.isArray(codes) ? codes.map(normalizeFipsCode).filter(Boolean) : [];
             const unique = [];
+            // Ensure 000000 (nationwide) is always first in the list
+            unique.push('000000');
             normalized.forEach((code) => {
                 if (!unique.includes(code)) {
                     unique.push(code);
@@ -3512,6 +3518,11 @@
         function removeLocationFipsCode(code) {
             const normalized = normalizeFipsCode(code);
             if (!normalized) {
+                return;
+            }
+            // Prevent removal of 000000 (nationwide) - it's required
+            if (normalized === '000000') {
+                updateLocationSettingsStatus('The nationwide code (000000) cannot be removed as it is required for nationwide alerts.', 'warning');
                 return;
             }
             locationFipsSelection = locationFipsSelection.filter((entry) => entry !== normalized);


### PR DESCRIPTION
This commit ensures that the nationwide FIPS code (000000) is always
included in the location settings and cannot be removed by users. This
is necessary to ensure that nationwide emergency alerts are always
received by the audio ingest system.

Changes:
- Auto-include 000000 in FIPS codes list on page load
- Make 000000 non-removable with visual "Required" badge
- Add protection in removeLocationFipsCode() function
- Update help text to explain 000000 is automatically included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nationwide location code automatically positions first in selections.
  * Help text updated to clarify nationwide inclusion among location codes.

* **Improvements**
  * Nationwide location code marked as "Required" and cannot be removed.
  * Warning message displays when attempting to remove nationwide code.
  * UI updated to show "Required" badge instead of removal button for nationwide code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->