### PR TITLE
Fix syntax error: replace misplaced 'continue' with 'return None' in …

### DIFF
--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -167,8 +167,8 @@ class SDRSourceAdapter(AudioSourceAdapter):
                                 raw = np.frombuffer(audio_data, dtype=np.int16)
                                 iq_array = raw.astype(np.float32) / 32768.0
                             except (ValueError, TypeError) as fallback_exc:
-                                self._logger.error("Failed to convert audio data: %s (fallback also failed: %s)", exc, fallback_exc)
-                                continue
+                                logger.error("Failed to convert audio data: %s (fallback also failed: %s)", exc, fallback_exc)
+                                return None
 
                         # Convert interleaved I/Q to complex
                         iq_complex = iq_array[0::2] + 1j * iq_array[1::2]


### PR DESCRIPTION
…SDRSourceAdapter

- Changed 'continue' to 'return None' on line 171 in _read_audio_chunk method
- This 'continue' was not inside a loop, causing a SyntaxError
- Also fixed incorrect self._logger reference to use module-level logger
- The error handler now properly returns None when audio data conversion fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio data conversion fallback handling to enhance reliability during format conversion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->