### PR TITLE
Fix WAV decoding to capture complete SAME headers with multiple locat…

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -592,7 +592,8 @@ def _correlate_and_decode_with_dll(samples: List[float], sample_rate: int) -> Tu
                                 # The 8th dash comes after station ID, which is what we want
                                 dash_count = msg_text.count('-')
                                 location_count = 0
-                                if '+' in msg_text:
+                                has_time_section = '+' in msg_text
+                                if has_time_section:
                                     pre_expiration, _ = msg_text.split('+', 1)
                                     location_segments = pre_expiration.split('-')[3:]
                                     for segment in location_segments:
@@ -600,17 +601,18 @@ def _correlate_and_decode_with_dll(samples: List[float], sample_rate: int) -> Tu
                                         if len(cleaned) == 6 and cleaned.isdigit():
                                             location_count += 1
 
-                                if location_count <= 0:
-                                    min_dashes = 6
-                                else:
-                                    min_dashes = 6 + max(location_count - 1, 0)
+                                    if location_count <= 0:
+                                        min_dashes = 6
+                                    else:
+                                        min_dashes = 6 + max(location_count - 1, 0)
 
-                                if dash_count >= min_dashes:
-                                    if 'ZCZC' in msg_text or 'NNNN' in msg_text:
-                                        messages.append(msg_text.strip())
-                                    current_msg = []
-                                    in_message = False
-                                    synced = False
+                                    # Only terminate if we have the time section and enough dashes
+                                    if dash_count >= min_dashes:
+                                        if 'ZCZC' in msg_text or 'NNNN' in msg_text:
+                                            messages.append(msg_text.strip())
+                                        current_msg = []
+                                        in_message = False
+                                        synced = False
                             elif len(current_msg) > MAX_MSG_LEN:
                                 # Safety: prevent runaway messages
                                 if 'ZCZC' in msg_text or 'NNNN' in msg_text:


### PR DESCRIPTION
…ion codes

The decoder was prematurely terminating messages when encountering dashes before the time section ('+' character). This caused incomplete decoding of SAME headers with multiple location codes.

The issue was in the _correlate_and_decode_with_dll function where message termination logic was checking dash counts before verifying the presence of the time section. For messages like:

ZCZC-EAS-RWT-012057-012081-012101-012103-012115+0030-2780415-WTSP/TV-

The decoder would stop after the 4th location code (012103-) because it reached the minimum dash threshold without a '+' character to properly count locations.

Fix: Only apply dash-based termination logic after the '+' character is encountered, ensuring all location codes are captured before checking for message completion.

Resolves issue with Same.wav in samples directory now correctly decoding the full 69-character message instead of stopping at 41 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message decoding logic to enhance accuracy of alert message termination conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->