### PR TITLE
Increase server timeouts to prevent 504 errors during audio processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ CMD ["gunicorn", \
     "--bind", "0.0.0.0:5000", \
     "--workers", "1", \
     "--threads", "4", \
-    "--timeout", "120", \
+    "--timeout", "300", \
     "--worker-class", "gthread", \
     "--worker-tmp-dir", "/dev/shm", \
     "--log-level", "info", \

--- a/nginx.conf
+++ b/nginx.conf
@@ -83,9 +83,11 @@ server {
     client_max_body_size 100M;
 
     # Proxy timeouts
-    proxy_connect_timeout 120s;
-    proxy_send_timeout 120s;
-    proxy_read_timeout 120s;
+    # Increased to 300s (5 minutes) to accommodate long-running audio decoding operations
+    # Audio processing can take 60-180s for large files with SAME detection, tone analysis, and narration extraction
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
 
     # Proxy to Flask backend
     location / {

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -14,7 +14,7 @@
         </div>
         <p id="progress-message" class="text-center text-muted mb-0">Initializing...</p>
         <p class="text-center text-muted small mt-3 mb-0">
-            <i class="fas fa-info-circle"></i> Large files may take 1-2 minutes to process.<br>
+            <i class="fas fa-info-circle"></i> Large files may take 2-4 minutes to process.<br>
             Please do not close this window.
         </p>
     </div>
@@ -690,14 +690,14 @@
                             });
                     }, 500); // Poll every 500ms
 
-                    // Fallback: Hide overlay after 3 minutes (safety net)
+                    // Fallback: Hide overlay after 5 minutes (safety net matching server timeout)
                     setTimeout(function() {
                         if (progressOverlay.style.display === 'flex') {
                             clearInterval(pollInterval);
                             updateProgress(100, 'Processing... (This may take a while)');
                             // The page will reload when the server responds
                         }
-                    }, 180000);
+                    }, 300000);
                 });
             }
 


### PR DESCRIPTION
The audio decoding process (SAME detection, tone analysis, narration extraction) can take 60-180 seconds for large files, which was exceeding the 120-second timeout and causing 504 Gateway Timeout errors.

Changes:
- nginx.conf: Increase proxy timeouts from 120s to 300s (5 minutes)
  * proxy_connect_timeout: 120s → 300s
  * proxy_send_timeout: 120s → 300s
  * proxy_read_timeout: 120s → 300s

- Dockerfile: Increase gunicorn worker timeout from 120s to 300s
  * --timeout parameter: 120 → 300

- templates/eas/alert_verification.html:
  * Update frontend fallback timeout from 3 minutes to 5 minutes
  * Update user-facing message: "1-2 minutes" → "2-4 minutes"

This gives adequate headroom for:
- Large audio files (10+ minutes of recording)
- Complex SAME detection with multiple headers
- Tone detection (EBS two-tone, NWS 1050 Hz)
- Narration segment extraction with speech detection
- Database queries for large time windows

The 300-second timeout provides 2.5x the typical processing time while remaining reasonable for user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended system timeouts to support longer processing durations for large file operations
  * Updated user messaging to reflect new processing time expectations for large files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->