### PR TITLE
Fix eager loading error for CAPAlert.eas_messages relationship

### DIFF
--- a/app_core/eas_storage.py
+++ b/app_core/eas_storage.py
@@ -1265,7 +1265,6 @@ def collect_compliance_log_entries(
         alert_query = (
             CAPAlert.query.filter(CAPAlert.sent >= window_start)
             .order_by(CAPAlert.sent.desc())
-            .options(joinedload(CAPAlert.eas_messages))
         )
 
         for alert in alert_query:


### PR DESCRIPTION
Removed invalid joinedload() call for the eas_messages relationship in collect_compliance_log_entries(). The relationship is defined with lazy="dynamic" which returns a query object and doesn't support eager loading via joinedload().

The eager loading was unnecessary since the function doesn't iterate through the eas_messages in the alert loop. This fixes the error: "Capalerts.eas_messages does not support object population. - eager loading cannot be applied."

Fixes compliance log collection and export functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data loading behavior for improved query performance in compliance logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->