### PR TITLE
Fix export errors for manual EAS events

### DIFF
--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -11,11 +11,9 @@
             </p>
         </div>
         <div class="d-print-none">
-            {% if summary_url %}
-            <a class="btn btn-outline-primary btn-sm" href="{{ summary_url }}" target="_blank" rel="noopener">
+            <a class="btn btn-outline-primary btn-sm" href="{{ url_for('eas.manual_eas_export', event_id=event.id) }}" target="_blank" rel="noopener">
                 <i class="fas fa-file-export"></i> Export JSON
             </a>
-            {% endif %}
             <a href="{{ url_for('eas.manual_eas_print_pdf', event_id=event.id) }}" target="_blank" class="btn btn-primary btn-sm ms-2">
                 <i class="fas fa-file-pdf"></i> Export PDF
             </a>

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -742,9 +742,11 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             try:
                 import json
                 metadata_str = json.dumps(event.generation_metadata, indent=2)
+                # Split JSON into lines to preserve formatting in PDF
+                metadata_lines = metadata_str.split('\n')
                 sections.append({
                     'heading': 'Generation Metadata',
-                    'content': metadata_str,
+                    'content': metadata_lines,
                 })
             except (TypeError, ValueError) as exc:
                 logger.warning('Failed to serialize generation metadata: %s', exc)


### PR DESCRIPTION
Fixed two export issues on the manual events print page:

1. Export JSON 404 error: Changed the export button to use the proper export endpoint (/eas/manual/events/<id>/export) instead of directly linking to a static file path that may not exist. The export endpoint has proper error handling for missing files.

2. Export PDF 500 error: Fixed JSON metadata formatting in PDF generation by splitting multi-line JSON strings into individual lines. This prevents the _wrap_text function from destroying JSON formatting and potentially causing errors.

Changes:
- templates/manual_eas_print.html: Updated export JSON button to use url_for('eas.manual_eas_export') instead of static file URL
- webapp/eas/workflow.py: Split JSON metadata string into lines for proper PDF formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export JSON button is now always available on the manual EAS print page
  * PDF export formatting for metadata has been improved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->