### PR TITLE
Fix XML parsing errors in SVG diagrams by encoding ampersands

### DIFF
--- a/docs/assets/diagrams/alert-processing-pipeline.svg
+++ b/docs/assets/diagrams/alert-processing-pipeline.svg
@@ -73,7 +73,7 @@
   <!-- Parse Error -->
   <rect x="320" y="320" width="120" height="50" rx="6" fill="url(#grad-error)" filter="url(#shadow)"/>
   <text x="380" y="340" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Parse Error</text>
-  <text x="380" y="358" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#fee2e2">Log & Skip</text>
+  <text x="380" y="358" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#fee2e2">Log &amp; Skip</text>
 
   <path d="M 270,345 L 320,345" stroke="#334155" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
   <text x="285" y="335" font-family="Arial, sans-serif" font-size="11" fill="#64748b">NO</text>
@@ -137,7 +137,7 @@
   <!-- Duplicate Log -->
   <rect x="810" y="365" width="120" height="50" rx="6" fill="#fef3c7" stroke="#f59e0b" stroke-width="2" filter="url(#shadow)"/>
   <text x="870" y="385" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#92400e">Duplicate</text>
-  <text x="870" y="403" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#92400e">Log & Skip</text>
+  <text x="870" y="403" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#92400e">Log &amp; Skip</text>
 
   <path d="M 765,390 L 810,390" stroke="#334155" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
   <text x="778" y="380" font-family="Arial, sans-serif" font-size="11" fill="#64748b">YES</text>

--- a/docs/assets/diagrams/audio-source-routing.svg
+++ b/docs/assets/diagrams/audio-source-routing.svg
@@ -223,7 +223,7 @@
   <!-- Web UI Output -->
   <rect x="470" y="450" width="420" height="210" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
   <text x="680" y="475" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#1e40af">
-    Web UI & API
+    Web UI &amp; API
   </text>
 
   <!-- UI Box -->

--- a/docs/assets/diagrams/broadcast-workflow.svg
+++ b/docs/assets/diagrams/broadcast-workflow.svg
@@ -149,7 +149,7 @@
   <g id="transmit-group">
     <!-- Store & Transmit -->
     <rect x="650" y="1000" width="140" height="65" rx="6" fill="url(#bw-grad-complete)" filter="url(#bw-shadow)"/>
-    <text x="720" y="1022" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Store & Transmit</text>
+    <text x="720" y="1022" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Store &amp; Transmit</text>
     <text x="720" y="1040" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#ede9fe">• Save WAV file</text>
     <text x="720" y="1054" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#ede9fe">• Key transmitter (GPIO)</text>
 

--- a/docs/assets/diagrams/sdr-setup-flow.svg
+++ b/docs/assets/diagrams/sdr-setup-flow.svg
@@ -33,7 +33,7 @@
 
   <!-- Title Section -->
   <text x="450" y="35" font-family="Arial, sans-serif" font-size="26" font-weight="bold" text-anchor="middle" fill="#1e293b">
-    SDR Setup & Configuration
+    SDR Setup &amp; Configuration
   </text>
   <text x="450" y="58" font-family="Arial, sans-serif" font-size="13" text-anchor="middle" fill="#64748b">
     Complete workflow for Software-Defined Radio receiver setup
@@ -134,7 +134,7 @@
 
   <!-- Step 6: Enable -->
   <rect x="640" y="510" width="180" height="50" rx="6" fill="url(#sdr-grad-config)" filter="url(#sdr-shadow)"/>
-  <text x="730" y="532" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="white">6. Enable & Save</text>
+  <text x="730" y="532" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="white">6. Enable &amp; Save</text>
   <text x="730" y="550" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#d1fae5">✓ Enabled  ✓ Auto-start</text>
 
   <path d="M 610,535 L 640,535" stroke="#334155" stroke-width="2" fill="none" marker-end="url(#sdr-arrow)"/>
@@ -142,7 +142,7 @@
   <!-- Phase 3: Testing & Verification -->
   <rect x="50" y="640" width="800" height="200" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="2"/>
   <text x="60" y="665" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#92400e">
-    Phase 3: Testing & Verification
+    Phase 3: Testing &amp; Verification
   </text>
 
   <!-- Monitor Status -->

--- a/static/img/raspberry-pi-hero.svg
+++ b/static/img/raspberry-pi-hero.svg
@@ -92,7 +92,7 @@
     
     <g transform="translate(80, 460)">
       <circle cx="6" cy="6" r="6" fill="#8b5cf6"/>
-      <text x="24" y="12" class="feature-text">Open Source & Community Driven</text>
+      <text x="24" y="12" class="feature-text">Open Source &amp; Community Driven</text>
     </g>
   </g>
   


### PR DESCRIPTION
Fixed unencoded ampersands in SVG text elements that were causing XML parsing errors (xmlParseEntityRef: no name). All ampersands in text content are now properly encoded as &amp; entities.

Files fixed:
- docs/assets/diagrams/audio-source-routing.svg: "Web UI & API"
- docs/assets/diagrams/broadcast-workflow.svg: "Store & Transmit"
- docs/assets/diagrams/alert-processing-pipeline.svg: "Log & Skip" (2 occurrences)
- docs/assets/diagrams/sdr-setup-flow.svg: Multiple instances in titles
- static/img/raspberry-pi-hero.svg: "Open Source & Community Driven"

These SVG files are now valid XML and will render correctly in browsers and documentation viewers.