### PR TITLE
Add county-based EAS originator code decoder

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -114,6 +114,61 @@ ORIGINATOR_DESCRIPTIONS = {
     'PEP': 'National Public Warning System (PEP)',
 }
 
+# County abbreviations for Lima Ohio EAS Operational Area
+COUNTY_ABBREVIATIONS = {
+    'ALLE': 'Allen',
+    'AUGL': 'Auglaize',
+    'HANC': 'Hancock',
+    'HARD': 'Hardin',
+    'MERC': 'Mercer',
+    'PAUL': 'Paulding',
+    'PUTN': 'Putnam',
+    'VANW': 'Van Wert',
+}
+
+def decode_county_originator(originator_code: str) -> Optional[str]:
+    """
+    Decode county-based originator codes.
+
+    Format: XXXXCOEM or XXXXCOSO
+    Where:
+    - XXXX = 4-letter county abbreviation
+    - CO = County
+    - EM = Emergency Management
+    - SO = Sheriff's Office
+
+    Examples:
+    - PUTNCOSO = Putnam County Sheriff's Office
+    - PUTNCOEM = Putnam County Emergency Management
+    """
+    code = originator_code.upper().strip()
+
+    # Check if it matches the county pattern (8 characters)
+    if len(code) != 8:
+        return None
+
+    # Extract components
+    county_abbr = code[:4]
+    middle = code[4:6]  # Should be 'CO'
+    suffix = code[6:8]  # Either 'EM' or 'SO'
+
+    # Validate the middle part
+    if middle != 'CO':
+        return None
+
+    # Get county name
+    county_name = COUNTY_ABBREVIATIONS.get(county_abbr)
+    if not county_name:
+        return None
+
+    # Decode the suffix
+    if suffix == 'EM':
+        return f"{county_name} County Emergency Management"
+    elif suffix == 'SO':
+        return f"{county_name} County Sheriff's Office"
+
+    return None
+
 PRIMARY_ORIGINATORS: Tuple[str, ...] = ('EAS', 'CIV', 'WXR', 'PEP')
 
 

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-from .eas import ORIGINATOR_DESCRIPTIONS, describe_same_header
+from .eas import ORIGINATOR_DESCRIPTIONS, decode_county_originator, describe_same_header
 from .eas_fsk import SAME_BAUD, SAME_MARK_FREQ, SAME_SPACE_FREQ, encode_same_bits
 from .fips_codes import get_same_lookup
 from app_utils.event_codes import EVENT_CODE_REGISTRY
@@ -135,6 +135,12 @@ def _clean_originator_label(fields: Dict[str, object]) -> str:
 
     code = (fields.get("originator") or "").strip()
     if code:
+        # Try to decode county-based originator first
+        county_desc = decode_county_originator(code)
+        if county_desc:
+            return county_desc
+
+        # Fall back to standard originator descriptions
         mapping = ORIGINATOR_DESCRIPTIONS.get(code)
         if mapping:
             if "/" in mapping:


### PR DESCRIPTION
Implement decoding for Lima Ohio EAS Operational Area county originator codes.
County codes follow the format XXXXCOEM or XXXXCOSO where XXXX is a 4-letter
county abbreviation, CO indicates county, and EM/SO indicate Emergency Management
or Sheriff's Office respectively.

Changes:
- Add COUNTY_ABBREVIATIONS mapping for 8 Lima Ohio area counties
- Create decode_county_originator() function to parse county codes
- Update _clean_originator_label() to try county decoding first
- Supports all 8 counties: Allen, Auglaize, Hancock, Hardin, Mercer,
  Paulding, Putnam, and Van Wert

Examples:
- PUTNCOSO -> "Putnam County Sheriff's Office"
- PUTNCOEM -> "Putnam County Emergency Management"
- ALLECOEM -> "Allen County Emergency Management"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Emergency Alert System originators for the Lima, Ohio area now display as human-readable descriptions (e.g., "Putnam County Sheriff's Office" or "Putnam County Emergency Management") instead of encoded codes. Supports eight Ohio counties: Allen, Auglaize, Hancock, Hardin, Mercer, Paulding, Putnam, and Van Wert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->