### PR TITLE
Fix missing Protocol import in GPIO module

### DIFF
--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Set
 
 try:  # pragma: no cover - GPIO hardware is optional and platform specific
     from gpiozero import OutputDevice


### PR DESCRIPTION
## Summary
- import `Protocol` in the GPIO utility module so the backend protocol class can be defined at runtime

## Testing
- pytest tests/test_gpio_controller.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153822a92c8320948c3e124ced2457)