### PR TITLE
Add migration for LED sign serial mode column

### DIFF
--- a/app_core/migrations/versions/20251113_add_serial_mode_to_led_sign_status.py
+++ b/app_core/migrations/versions/20251113_add_serial_mode_to_led_sign_status.py
@@ -1,0 +1,77 @@
+"""Add serial communication mode tracking to LED sign status.
+
+Revision ID: 20251113_add_serial_mode_to_led_sign_status
+Revises: 20251111_add_received_eas_alerts
+Create Date: 2025-11-13
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20251113_add_serial_mode_to_led_sign_status"
+down_revision = "20251111_add_received_eas_alerts"
+branch_labels = None
+depends_on = None
+
+
+LED_STATUS_TABLE = "led_sign_status"
+SERIAL_MODE_COLUMN = "serial_mode"
+DEFAULT_SERIAL_MODE = "RS232"
+
+
+def upgrade() -> None:
+    """Add the serial_mode column to LED sign status if it is missing."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if LED_STATUS_TABLE not in inspector.get_table_names():
+        # Table has not been created yet; nothing to do.
+        return
+
+    columns = {column["name"] for column in inspector.get_columns(LED_STATUS_TABLE)}
+
+    if SERIAL_MODE_COLUMN not in columns:
+        op.add_column(
+            LED_STATUS_TABLE,
+            sa.Column(
+                SERIAL_MODE_COLUMN,
+                sa.String(length=10),
+                nullable=True,
+                server_default=DEFAULT_SERIAL_MODE,
+            ),
+        )
+
+        # Populate any existing rows with the default value and then enforce non-null.
+        op.execute(
+            sa.text(
+                f"UPDATE {LED_STATUS_TABLE} SET {SERIAL_MODE_COLUMN} = :default"
+                f" WHERE {SERIAL_MODE_COLUMN} IS NULL"
+            ),
+            {"default": DEFAULT_SERIAL_MODE},
+        )
+
+        op.alter_column(
+            LED_STATUS_TABLE,
+            SERIAL_MODE_COLUMN,
+            existing_type=sa.String(length=10),
+            nullable=False,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    """Drop the serial_mode column from LED sign status if it exists."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if LED_STATUS_TABLE not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns(LED_STATUS_TABLE)}
+
+    if SERIAL_MODE_COLUMN in columns:
+        op.drop_column(LED_STATUS_TABLE, SERIAL_MODE_COLUMN)

--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Set
 
 try:  # pragma: no cover - GPIO hardware is optional and platform specific
     from gpiozero import OutputDevice

--- a/templates/components/navbar_new.html
+++ b/templates/components/navbar_new.html
@@ -190,6 +190,11 @@
                                 </a>
                             </li>
                             <li>
+                                <a class="dropdown-item" href="{{ url_for('gpio_pin_map') }}">
+                                    <i class="fas fa-map"></i> GPIO Pin Map
+                                </a>
+                            </li>
+                            <li>
                                 <a class="dropdown-item" href="/admin/gpio">
                                     <i class="fas fa-microchip"></i> GPIO Control
                                 </a>

--- a/templates/gpio_control.html
+++ b/templates/gpio_control.html
@@ -19,10 +19,15 @@
 
 {% block content %}
 <div class="container-fluid mt-4">
-    <div class="row mb-4">
-        <div class="col-12">
+    <div class="row mb-4 align-items-center">
+        <div class="col-12 col-lg-8">
             <h2><i class="fas fa-microchip"></i> GPIO Control Panel</h2>
-            <p class="text-muted">Manage GPIO relays and peripherals with audit logging</p>
+            <p class="text-muted mb-0">Manage GPIO relays and peripherals with audit logging</p>
+        </div>
+        <div class="col-12 col-lg-4 text-lg-end mt-3 mt-lg-0">
+            <a class="btn btn-outline-primary" href="{{ url_for('gpio_pin_map') }}">
+                <i class="fas fa-map"></i> Open GPIO Pin Map
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add an Alembic migration that backfills and enforces the led_sign_status.serial_mode column
- make the downgrade path resilient by checking for the table and column before dropping

## Testing
- pytest tests/test_gpio_controller.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153822a92c8320948c3e124ced2457)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPIO Pin Map navigation link in the System dropdown menu.
  * Added Open GPIO Pin Map button to the GPIO Control Panel.
  * Added serial mode support for LED sign status tracking.

* **Refactor**
  * Enhanced type system for GPIO backend implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->