### PR TITLE
Fix stack light not responding correctly to alert states

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -70,6 +70,53 @@ def _get_oled_enabled_status():
 
 
 _BROADCAST_STATE_KEY = 'eas:broadcast_active'
+_INCOMING_STATE_KEY = 'eas:incoming_alert'
+
+
+def set_incoming_alert(event_code: str = '') -> None:
+    """Record in Redis that an alert has been received but broadcast has not started.
+
+    Called when an alert is first processed so hardware indicators (tower light)
+    can show a pre-broadcast "incoming" state (e.g. yellow blink) while audio
+    is being generated and the playout decision is being made.  The key carries
+    a short TTL so stale entries self-expire if the broadcast never starts.
+    """
+    try:
+        from app_core.redis_client import get_redis_client
+        client = get_redis_client()
+        if client is None:
+            return
+        payload = json.dumps({'incoming': True, 'event_code': event_code or '', 'ts': time.time()})
+        client.set(_INCOMING_STATE_KEY, payload, ex=300)  # 5-minute safety TTL
+    except Exception:
+        pass
+
+
+def clear_incoming_alert() -> None:
+    """Remove the incoming alert marker from Redis."""
+    try:
+        from app_core.redis_client import get_redis_client
+        client = get_redis_client()
+        if client is None:
+            return
+        client.delete(_INCOMING_STATE_KEY)
+    except Exception:
+        pass
+
+
+def get_incoming_alert_state() -> dict:
+    """Return current incoming-alert state dict, or ``{'incoming': False}`` if none."""
+    try:
+        from app_core.redis_client import get_redis_client
+        client = get_redis_client()
+        if client is None:
+            return {'incoming': False}
+        raw = client.get(_INCOMING_STATE_KEY)
+        if raw is None:
+            return {'incoming': False}
+        return json.loads(raw)
+    except Exception:
+        return {'incoming': False}
 
 
 def set_broadcast_active(
@@ -99,6 +146,8 @@ def set_broadcast_active(
         # TTL = duration + 60 s safety margin so stale entries self-expire
         ttl = max(60, int(duration_seconds) + 60)
         client.set(_BROADCAST_STATE_KEY, payload, ex=ttl)
+        # Broadcast starting supersedes the incoming-alert state
+        client.delete(_INCOMING_STATE_KEY)
     except Exception:
         pass
 
@@ -2537,6 +2586,12 @@ class EASBroadcaster:
         alert_identifier = getattr(alert, 'identifier', None) or payload.get('identifier')
         forwarding_decision = str(payload.get('forwarding_decision', '') or '').lower()
         is_forwarded = forwarding_decision == 'forwarded' or bool(payload.get('forwarded', False))
+
+        # Signal hardware indicators (tower light) that an alert has arrived but
+        # broadcast has not started yet.  The hardware service polls this key and
+        # calls start_incoming_alert() on the tower light controller.
+        set_incoming_alert(event_code=event_code or '')
+
         behavior_manager = self.gpio_behavior_manager
         if behavior_manager:
             behavior_manager.trigger_incoming_alert(

--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -2571,7 +2571,12 @@ class TowerLightController:
         """Signal that an alert has been received but playout has not started.
 
         Shows yellow (blink or solid) to indicate an incoming alert decision.
+        Does nothing when :attr:`TowerLightConfig.incoming_uses_yellow` is
+        ``False``.
         """
+        if not self.config.incoming_uses_yellow:
+            return
+
         with self._lock:
             yellow_state = "blink" if self.config.blink_on_alert else "on"
             for cmd in (_TOWER_CMD_GRN_OFF, _TOWER_CMD_RED_OFF):

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -2494,24 +2494,32 @@ def run_api_server():
         logger.error(f"Error running API server: {e}", exc_info=True)
 
 
-def _update_alert_indicators(broadcast_was_active: bool) -> bool:
+def _update_alert_indicators(
+    broadcast_was_active: bool,
+    incoming_was_active: bool,
+) -> tuple:
     """Drive tower light and NeoPixel controllers based on broadcast state.
 
-    Reads the current ``eas:broadcast_active`` Redis key and calls the
-    appropriate alert-lifecycle methods on any configured hardware indicator
-    controllers whenever the broadcast state changes.
+    Reads the current ``eas:broadcast_active`` and ``eas:incoming_alert`` Redis
+    keys and calls the appropriate alert-lifecycle methods on any configured
+    hardware indicator controllers whenever the state changes.
 
-    Returns the NEW broadcast-active boolean so the caller can track state
-    across loop iterations.
+    The tower light follows a three-state machine:
+      idle → incoming (yellow) → active broadcast (red) → idle (green)
+
+    Returns ``(broadcast_active, incoming_active)`` so the caller can track
+    state across loop iterations.
     """
     try:
-        from app_utils.eas import get_broadcast_state
+        from app_utils.eas import get_broadcast_state, get_incoming_alert_state
         state = get_broadcast_state()
         broadcast_active = bool(state.get('active', False))
+        incoming_state = get_incoming_alert_state()
+        incoming_active = bool(incoming_state.get('incoming', False))
     except Exception:
-        return broadcast_was_active  # Leave light in current state on error
+        return broadcast_was_active, incoming_was_active  # Leave light in current state on error
 
-    # Transition: idle → active
+    # Transition: * → active broadcast (broadcast takes priority over incoming)
     if broadcast_active and not broadcast_was_active:
         if _tower_light_controller and _tower_light_controller.is_available:
             try:
@@ -2524,7 +2532,7 @@ def _update_alert_indicators(broadcast_was_active: bool) -> bool:
             except Exception as exc:
                 logger.warning("NeoPixel start_alert failed: %s", exc)
 
-    # Transition: active → idle
+    # Transition: active → idle (broadcast ended)
     elif not broadcast_active and broadcast_was_active:
         if _tower_light_controller and _tower_light_controller.is_available:
             try:
@@ -2537,7 +2545,23 @@ def _update_alert_indicators(broadcast_was_active: bool) -> bool:
             except Exception as exc:
                 logger.warning("NeoPixel end_alert failed: %s", exc)
 
-    return broadcast_active
+    # Transition: idle → incoming (alert received, broadcast not yet started)
+    elif not broadcast_active and incoming_active and not incoming_was_active:
+        if _tower_light_controller and _tower_light_controller.is_available:
+            try:
+                _tower_light_controller.start_incoming_alert()
+            except Exception as exc:
+                logger.warning("Tower light start_incoming_alert failed: %s", exc)
+
+    # Transition: incoming → idle (alert rejected or expired without broadcast)
+    elif not broadcast_active and not incoming_active and incoming_was_active:
+        if _tower_light_controller and _tower_light_controller.is_available:
+            try:
+                _tower_light_controller.end_alert()
+            except Exception as exc:
+                logger.warning("Tower light end_alert (incoming expired) failed: %s", exc)
+
+    return broadcast_active, incoming_active
 
 
 def health_check_loop():
@@ -2548,6 +2572,7 @@ def health_check_loop():
     last_metrics_publish = 0
     metrics_interval = 5  # Publish metrics every 5 seconds
     broadcast_was_active = False  # Track last-known broadcast state
+    incoming_was_active = False   # Track last-known incoming-alert state
 
     while _running:
         try:
@@ -2556,7 +2581,9 @@ def health_check_loop():
             # Drive alert indicators (tower light, NeoPixel) based on
             # broadcast state; runs every loop iteration (1 s resolution).
             if _redis_client and (_tower_light_controller or _neopixel_controller):
-                broadcast_was_active = _update_alert_indicators(broadcast_was_active)
+                broadcast_was_active, incoming_was_active = _update_alert_indicators(
+                    broadcast_was_active, incoming_was_active
+                )
 
             # Publish metrics periodically
             if current_time - last_metrics_publish >= metrics_interval:

--- a/tests/test_gpio_controller.py
+++ b/tests/test_gpio_controller.py
@@ -625,6 +625,18 @@ def test_tower_light_start_incoming_alert_blink():
     assert _TOWER_CMD_RED_OFF in ser.written
 
 
+def test_tower_light_start_incoming_alert_disabled_sends_nothing():
+    """start_incoming_alert should send no commands when incoming_uses_yellow=False."""
+    ctrl, ser = _make_tower_ctrl(
+        TowerLightConfig(serial_port="/dev/null", blink_on_alert=True, incoming_uses_yellow=False)
+    )
+    ser.written.clear()
+
+    ctrl.start_incoming_alert()
+
+    assert len(ser.written) == 0
+
+
 def test_tower_light_end_alert_returns_to_standby():
     """end_alert should restore the standby (green on) state."""
     ctrl, ser = _make_tower_ctrl()


### PR DESCRIPTION
Three bugs fixed:

1. start_incoming_alert() ignored the incoming_uses_yellow config flag,
   always showing yellow even when the user had disabled it.  Added an
   early return when the flag is False.

2. start_incoming_alert() was never called anywhere — the hardware
   service only polled eas:broadcast_active (a binary active/idle state).
   Added set_incoming_alert() / clear_incoming_alert() / get_incoming_alert_state()
   functions in eas.py using a new eas:incoming_alert Redis key.
   set_incoming_alert() is called when an alert arrives pre-broadcast;
   set_broadcast_active() now also clears the incoming key so the
   transition from yellow → red happens cleanly.

3. _update_alert_indicators() in hardware_service.py was a 2-state
   machine (idle/active).  Expanded it to a proper 3-state machine:
   idle (green) → incoming (yellow) → active broadcast (red) → idle.
   health_check_loop() now tracks both broadcast_was_active and
   incoming_was_active across iterations.

Added test: test_tower_light_start_incoming_alert_disabled_sends_nothing
covers the incoming_uses_yellow=False path.

https://claude.ai/code/session_01XarMRyPrmgtHxv4sLfUPAY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incoming alert state tracking to the system with automatic 5-minute expiration.
  * Tower lights now indicate incoming alert status (yellow indicator when configured).
  * Incoming state automatically clears when a broadcast begins.

* **Tests**
  * Added test coverage for incoming alert tower light behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->