### PR TITLE
Expose min and max built-in functions to Jinja2 templates

### DIFF
--- a/webapp/template_helpers.py
+++ b/webapp/template_helpers.py
@@ -44,6 +44,8 @@ def register(app: Flask) -> None:
 
     app.add_template_global(utc_now, name="current_time")
     app.add_template_global(local_now, name="local_current_time")
+    app.add_template_global(min, name="min")
+    app.add_template_global(max, name="max")
 
 
 def _nl2br_filter(text: str | None) -> str:


### PR DESCRIPTION
## Summary
This change exposes Python's built-in `min` and `max` functions to Jinja2 templates by registering them as global template functions.

## Changes
- Added `min` function as a global template function
- Added `max` function as a global template function

## Details
These built-in functions are now available for use directly in Jinja2 templates without requiring custom filter implementations. This allows templates to perform min/max comparisons and selections inline, improving template flexibility and reducing the need for custom template filters.

https://claude.ai/code/session_012g79L7hzALWSYkGp3AJV7N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template developers can now use Python's built-in `min` and `max` functions directly within templates for value comparisons and selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->