### PR TITLE
Show county names alongside FIPS codes on alert detail page

### DIFF
--- a/templates/audio_received_detail.html
+++ b/templates/audio_received_detail.html
@@ -157,7 +157,12 @@
                     {% if alert.fips_codes %}
                     <div class="d-flex flex-wrap gap-2 mb-2">
                         {% for code in alert.fips_codes %}
-                        <span class="badge bg-info text-dark">{{ code }}</span>
+                        <span class="d-inline-flex flex-column align-items-center badge bg-info text-dark py-1 px-2" style="font-weight:normal;">
+                            <span class="fw-bold font-monospace">{{ code }}</span>
+                            {% if fips_names and fips_names.get(code) %}
+                            <span style="font-size:0.7em; opacity:0.85;">{{ fips_names[code] }}</span>
+                            {% endif %}
+                        </span>
                         {% endfor %}
                     </div>
                     {% else %}
@@ -168,7 +173,12 @@
                         <small class="text-muted">Matched configured codes:</small>
                         <div class="d-flex flex-wrap gap-2 mt-1">
                             {% for code in alert.matched_fips_codes %}
-                            <span class="badge bg-success">{{ code }}</span>
+                            <span class="d-inline-flex flex-column align-items-center badge bg-success py-1 px-2" style="font-weight:normal;">
+                                <span class="fw-bold font-monospace">{{ code }}</span>
+                                {% if fips_names and fips_names.get(code) %}
+                                <span style="font-size:0.7em; opacity:0.85;">{{ fips_names[code] }}</span>
+                                {% endif %}
+                            </span>
                             {% endfor %}
                         </div>
                     </div>

--- a/webapp/admin/audio/received.py
+++ b/webapp/admin/audio/received.py
@@ -156,9 +156,18 @@ def register_received_alerts_routes(app, logger) -> None:
         try:
             alert = ReceivedEASAlert.query.get_or_404(alert_id)
 
+            from app_utils.fips_codes import get_same_lookup
+            fips_lookup = get_same_lookup()
+            all_codes = list(alert.fips_codes or []) + [
+                c for c in (alert.matched_fips_codes or [])
+                if c not in (alert.fips_codes or [])
+            ]
+            fips_names = {code: fips_lookup.get(code, '') for code in all_codes}
+
             return render_template(
                 'audio_received_detail.html',
                 alert=alert,
+                fips_names=fips_names,
             )
 
         except Exception as e:


### PR DESCRIPTION
Passes a fips_names lookup dict to the audio_received_detail template
so each FIPS/SAME code badge also displays its human-readable county
name (e.g. "039003" → "Ottawa County, OH").

https://claude.ai/code/session_018Kn9wFwSiWisuQG8kT6dDX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FIPS/location codes now display with human-readable names for improved clarity and usability.

* **Style**
  * Enhanced badge layout with improved vertical stacking, formatting, and spacing for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->