### PR TITLE
Add KR8MER EAS Station FSK trill fingerprint (3 × 0xAA)

### DIFF
--- a/app_core/migrations/versions/20260413_add_endec_fingerprint_to_eas_settings.py
+++ b/app_core/migrations/versions/20260413_add_endec_fingerprint_to_eas_settings.py
@@ -1,0 +1,30 @@
+"""Add endec_fingerprint to eas_settings.
+
+Adds a boolean flag controlling whether the KR8MER EAS Station trill
+fingerprint (3 × 0xAA bytes after each SAME burst) is included in
+generated audio. Defaults to True.
+
+Revision ID: 20260413_add_endec_fingerprint_to_eas_settings
+Revises: 20260402_add_max_activation_seconds_to_eas_settings
+Create Date: 2026-04-13
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260413_add_endec_fingerprint_to_eas_settings"
+down_revision = "20260402_add_max_activation_seconds_to_eas_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE eas_settings"
+        " ADD COLUMN IF NOT EXISTS endec_fingerprint BOOLEAN NOT NULL DEFAULT TRUE"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("eas_settings", "endec_fingerprint")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -1281,6 +1281,9 @@ class EASSettings(db.Model):
     audio_player = db.Column(db.String(255), nullable=False, default='aplay')
     # Command to play audio (aplay, paplay, etc.)
 
+    endec_fingerprint = db.Column(db.Boolean, nullable=False, default=True)
+    # Append 3 × 0xAA trill bytes after each SAME burst to fingerprint this station
+
     # ========================================================================
     # Authorized Broadcast Areas
     # ========================================================================
@@ -1313,6 +1316,7 @@ class EASSettings(db.Model):
             "max_activation_seconds": self.max_activation_seconds,
             "sample_rate": self.sample_rate,
             "audio_player": self.audio_player,
+            "endec_fingerprint": self.endec_fingerprint,
             "authorized_fips_codes": list(self.authorized_fips_codes or []),
             "authorized_event_codes": list(self.authorized_event_codes or []),
             "forwarded_event_codes": list(self.forwarded_event_codes or []),

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1833,6 +1833,15 @@ class EASAudioGenerator:
             logger.info("EASAudioGenerator: No TTS provider configured")
         
         self.tts_engine = TTSEngine(config, logger, self.sample_rate)
+        # Opt-out flag: set config key 'endec_fingerprint' to False to suppress
+        # the 3 × 0xAA trill appended after each SAME burst.  Defaults to True.
+        self._fingerprint_enabled = bool(config.get('endec_fingerprint', True))
+
+    def _terminator_samples(self, amplitude: float) -> List[int]:
+        """Return the station fingerprint samples, or [] when fingerprinting is disabled."""
+        if not self._fingerprint_enabled:
+            return []
+        return _generate_station_terminator_samples(amplitude, self.sample_rate)
 
     def build_files(
         self,
@@ -1860,7 +1869,7 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
-        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
+        terminator_samples = self._terminator_samples(amplitude)
 
         samples: List[int] = []
         segment_samples: Dict[str, List[int]] = {
@@ -2153,7 +2162,7 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
-        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
+        terminator_samples = self._terminator_samples(amplitude)
 
         samples: List[int] = []
         for burst_index in range(3):
@@ -2222,7 +2231,7 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
-        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
+        terminator_samples = self._terminator_samples(amplitude)
 
         repeats = max(1, int(repeats))
         same_samples: List[int] = []

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -46,6 +46,7 @@ from .eas_fsk import (
     SAME_MARK_FREQ,
     SAME_SPACE_FREQ,
     encode_same_bits,
+    encode_terminator_bits,
     generate_fsk_samples,
 )
 from .eas_tts import TTSEngine
@@ -1393,6 +1394,26 @@ def _generate_silence(duration: float, sample_rate: int) -> List[int]:
     return [0] * max(1, int(duration * sample_rate))
 
 
+def _generate_station_terminator_samples(amplitude: float, sample_rate: int) -> List[int]:
+    """Generate the KR8MER EAS Station FSK fingerprint: 3 × 0xAA terminator bytes.
+
+    0xAA (10101010 binary) alternates between space (1562 Hz) and mark (2083 Hz)
+    on every bit, producing a ~46 ms trill appended after each SAME burst.
+    Other ENDEC decoders gracefully exit post-message mode on the first 0xAA byte
+    (the message is already decoded at that point) while our own decoder
+    recognises the run and reports ENDEC_MODE_EAS_STATION.
+    """
+    bits = encode_terminator_bits(0xAA, 3)
+    return generate_fsk_samples(
+        bits,
+        sample_rate=sample_rate,
+        bit_rate=float(SAME_BAUD),
+        mark_freq=SAME_MARK_FREQ,
+        space_freq=SAME_SPACE_FREQ,
+        amplitude=amplitude,
+    )
+
+
 def _normalize_audio_amplitude(samples: List[int], target_amplitude: float) -> List[int]:
     """Normalize audio samples to match the target amplitude using RMS.
 
@@ -1839,6 +1860,7 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
+        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
 
         samples: List[int] = []
         segment_samples: Dict[str, List[int]] = {
@@ -1850,6 +1872,8 @@ class EASAudioGenerator:
         for burst_index in range(3):
             samples.extend(header_samples)
             segment_samples['same'].extend(header_samples)
+            samples.extend(terminator_samples)
+            segment_samples['same'].extend(terminator_samples)
             silence = _generate_silence(1.0, self.sample_rate)
             samples.extend(silence)
             segment_samples['same'].extend(silence)
@@ -2035,6 +2059,7 @@ class EASAudioGenerator:
         eom_raw_samples: List[int] = []
         for burst_index in range(3):
             eom_raw_samples.extend(eom_header_samples)
+            eom_raw_samples.extend(terminator_samples)
             if burst_index < 2:
                 eom_raw_samples.extend(_generate_silence(1.0, self.sample_rate))
         eom_raw_samples.extend(_generate_silence(1.0, self.sample_rate))
@@ -2128,10 +2153,12 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
+        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
 
         samples: List[int] = []
         for burst_index in range(3):
             samples.extend(header_samples)
+            samples.extend(terminator_samples)
             if burst_index < 2:
                 samples.extend(_generate_silence(1.0, self.sample_rate))
 
@@ -2195,11 +2222,13 @@ class EASAudioGenerator:
             space_freq=SAME_SPACE_FREQ,
             amplitude=amplitude,
         )
+        terminator_samples = _generate_station_terminator_samples(amplitude, self.sample_rate)
 
         repeats = max(1, int(repeats))
         same_samples: List[int] = []
         for burst_index in range(repeats):
             same_samples.extend(header_samples)
+            same_samples.extend(terminator_samples)
             if burst_index < repeats - 1:
                 same_samples.extend(_generate_silence(silence_between_headers, self.sample_rate))
 
@@ -2296,6 +2325,7 @@ class EASAudioGenerator:
         eom_samples: List[int] = []
         for burst_index in range(3):
             eom_samples.extend(eom_header_samples)
+            eom_samples.extend(terminator_samples)
             if burst_index < 2:
                 eom_samples.extend(_generate_silence(1.0, self.sample_rate))
 

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -331,6 +331,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
     db_attention_tone_seconds = None
     db_max_activation_seconds = None
     db_audio_player = None
+    db_endec_fingerprint = None
     db_forwarded_event_codes: List[str] = []
     try:
         from app_core.models import EASSettings
@@ -343,6 +344,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
             db_attention_tone_seconds = eas_settings.attention_tone_seconds
             db_max_activation_seconds = eas_settings.max_activation_seconds
             db_audio_player = eas_settings.audio_player
+            db_endec_fingerprint = eas_settings.endec_fingerprint
             db_forwarded_event_codes = list(eas_settings.forwarded_event_codes or [])
             load_logger.info(
                 'EASSettings loaded from DB: originator=%s station_id=%s broadcast_enabled=%s',
@@ -366,6 +368,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
                 db_attention_tone_seconds = eas_settings.attention_tone_seconds
                 db_max_activation_seconds = eas_settings.max_activation_seconds
                 db_audio_player = eas_settings.audio_player
+                db_endec_fingerprint = eas_settings.endec_fingerprint
                 db_forwarded_event_codes = list(eas_settings.forwarded_event_codes or [])
                 load_logger.info(
                     'EASSettings loaded from DB (direct session): originator=%s station_id=%s broadcast_enabled=%s',
@@ -394,6 +397,9 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
         'output_dir': _ensure_directory(output_dir),
         'web_subdir': web_subdir,
         'audio_player_cmd': os.getenv('EAS_AUDIO_PLAYER', '').strip() or (db_audio_player or ''),
+        'endec_fingerprint': (
+            db_endec_fingerprint if db_endec_fingerprint is not None else True
+        ),
         'attention_tone_seconds': float(
             os.getenv('EAS_ATTENTION_TONE_SECONDS')
             or (db_attention_tone_seconds if db_attention_tone_seconds is not None else 8)

--- a/app_utils/eas_demod.py
+++ b/app_utils/eas_demod.py
@@ -53,6 +53,7 @@ ENDEC_MODE_NWS_BMH = "NWS_BMH"         # NWS Broadcast Message Handler 2016+
 ENDEC_MODE_SAGE_3644 = "SAGE_DIGITAL_3644"
 ENDEC_MODE_SAGE_1822 = "SAGE_ANALOG_1822"
 ENDEC_MODE_TRILITHIC = "TRILITHIC"      # Trilithic EASyPLUS (~868 ms inter-burst gap)
+ENDEC_MODE_EAS_STATION = "EAS_STATION"  # KR8MER EAS Station (3 × 0xAA trill fingerprint)
 
 # Inter-burst gap windows (ms) for mode fingerprinting
 _ENDEC_GAP_TRILITHIC = (820, 920)   # 868 ms nominal
@@ -121,6 +122,7 @@ def detect_endec_mode(
        - SAGE ANALOG 1822:           1 × 0xFF per burst
        - SAGE DIGITAL 3644:          3 × 0xFF per burst  (+ leading 0x00 on 1st burst)
        - DEFAULT/DASDEC, TRILITHIC:  no terminator bytes
+       - KR8MER EAS Station:         3 × 0xAA per burst (alternating trill fingerprint)
 
     2. **Leading 0x00 before preamble** — SAGE DIGITAL 3644 prepends one 0x00
        byte before the 16-byte preamble on the first burst.
@@ -143,13 +145,14 @@ def detect_endec_mode(
         return ENDEC_MODE_UNKNOWN
 
     votes: dict = {
-        ENDEC_MODE_DEFAULT:   0.0,
-        ENDEC_MODE_NWS:       0.0,
-        ENDEC_MODE_NWS_CRS:   0.0,
-        ENDEC_MODE_NWS_BMH:   0.0,
-        ENDEC_MODE_SAGE_3644: 0.0,
-        ENDEC_MODE_SAGE_1822: 0.0,
-        ENDEC_MODE_TRILITHIC: 0.0,
+        ENDEC_MODE_DEFAULT:      0.0,
+        ENDEC_MODE_NWS:          0.0,
+        ENDEC_MODE_NWS_CRS:      0.0,
+        ENDEC_MODE_NWS_BMH:      0.0,
+        ENDEC_MODE_SAGE_3644:    0.0,
+        ENDEC_MODE_SAGE_1822:    0.0,
+        ENDEC_MODE_TRILITHIC:    0.0,
+        ENDEC_MODE_EAS_STATION:  0.0,
     }
 
     # 1. Terminator byte votes — primary ENDEC discriminator
@@ -182,6 +185,15 @@ def detect_endec_mode(
                 else:
                     votes[ENDEC_MODE_SAGE_1822] += 1.5
                     votes[ENDEC_MODE_SAGE_3644] += 1.5
+            elif byte_val == 0xAA:
+                # 0xAA terminator → KR8MER EAS Station trill fingerprint.
+                # 0xAA (10101010 binary) produces an alternating space/mark
+                # pattern in FSK, creating a distinctive trill sound.
+                # Three bytes is the canonical run length for this station.
+                if run_length >= 3:
+                    votes[ENDEC_MODE_EAS_STATION] += 4.0
+                else:
+                    votes[ENDEC_MODE_EAS_STATION] += run_length * 1.0
 
     # 2. Leading null byte (SAGE DIGITAL 3644 specific signature)
     if leading_null_detected:
@@ -519,7 +531,7 @@ class SAMEDemodulatorCore:
                         # FCC §11.31 encoding appends a trailing \r after the header,
                         # which must be ignored here to avoid prematurely exiting
                         # post-message capture before ENDEC terminator bytes arrive.
-                        if byte_val in (0x00, 0xFF):
+                        if byte_val in (0x00, 0xFF, 0xAA):
                             if self._terminator_byte is None:
                                 self._terminator_byte = byte_val
                                 self._terminator_run = 1

--- a/app_utils/eas_fsk.py
+++ b/app_utils/eas_fsk.py
@@ -48,6 +48,25 @@ def same_preamble_bits(repeats: int = SAME_PREAMBLE_REPETITIONS) -> List[int]:
     return bits
 
 
+def encode_terminator_bits(byte_val: int, count: int) -> List[int]:
+    """Encode ``count`` copies of ``byte_val`` as 8-bit LSB-first bitstreams.
+
+    Used to append ENDEC-identifying terminator bytes immediately after each
+    SAME burst, before the inter-burst silence.  Encoding matches the standard
+    SAME data encoding per FCC 47 CFR §11.31 (LSB first, no framing bits).
+
+    Example — EAS Station fingerprint (3 × 0xAA = 10101010):
+        bits: 0,1,0,1,0,1,0,1 × 3  →  24 alternating space/mark pulses
+        sound: rapid trill at ~521 Hz modulation rate (~46 ms)
+    """
+    bits: List[int] = []
+    byte_val = byte_val & 0xFF
+    for _ in range(count):
+        for i in range(8):
+            bits.append((byte_val >> i) & 1)
+    return bits
+
+
 def encode_same_bits(
     message: str,
     *,
@@ -125,5 +144,6 @@ __all__ = [
     "SAME_PREAMBLE_REPETITIONS",
     "same_preamble_bits",
     "encode_same_bits",
+    "encode_terminator_bits",
     "generate_fsk_samples",
 ]

--- a/static/js/admin/location-settings.js
+++ b/static/js/admin/location-settings.js
@@ -1012,6 +1012,10 @@ function populateEasForm(settings) {
     if (outputDirInput) {
         outputDirInput.value = settings.output_dir || 'static/eas_messages';
     }
+    const endecFingerprintCheckbox = document.getElementById('easEndecFingerprint');
+    if (endecFingerprintCheckbox) {
+        endecFingerprintCheckbox.checked = settings.endec_fingerprint !== false;
+    }
     if (authorizedEventsTextarea) {
         authorizedEventsTextarea.value = (settings.authorized_event_codes || []).join('\n');
     }
@@ -1151,6 +1155,7 @@ async function handleEasSettingsSubmit(e) {
         attention_tone_seconds: parseInt(document.getElementById('easAttentionTone')?.value, 10) || 8,
         audio_player: document.getElementById('easAudioPlayer')?.value?.trim() || 'aplay',
         output_dir: document.getElementById('easOutputDir')?.value?.trim() || 'static/eas_messages',
+        endec_fingerprint: document.getElementById('easEndecFingerprint')?.checked ?? true,
         authorized_event_codes: parseNewlineValues(document.getElementById('easAuthorizedEvents')?.value || ''),
         forwarded_event_codes: (document.getElementById('easForwardedEventCodes')?.value || '')
             .split(',').map(s => s.trim().toUpperCase()).filter(Boolean),

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -854,6 +854,14 @@
                                     <input type="text" class="form-control" id="easOutputDir" name="output_dir" placeholder="static/eas_messages">
                                     <small class="text-muted">Directory for generated EAS audio files</small>
                                 </div>
+                                <div class="col-md-4">
+                                    <label class="form-label fw-bold">Station Fingerprint</label>
+                                    <div class="form-check form-switch mt-1">
+                                        <input class="form-check-input" type="checkbox" id="easEndecFingerprint" name="endec_fingerprint">
+                                        <label class="form-check-label" for="easEndecFingerprint">Enable trill fingerprint</label>
+                                    </div>
+                                    <small class="text-muted">Appends a distinctive trill after each SAME burst to identify this station</small>
+                                </div>
 
                                 <!-- Note about FIPS codes -->
                                 <div class="col-12">

--- a/tests/test_eas_decode.py
+++ b/tests/test_eas_decode.py
@@ -417,6 +417,7 @@ from app_utils.eas_demod import (
     ENDEC_MODE_SAGE_3644,
     ENDEC_MODE_SAGE_1822,
     ENDEC_MODE_TRILITHIC,
+    ENDEC_MODE_EAS_STATION,
 )
 
 
@@ -662,4 +663,36 @@ def test_dll_endec_no_regression_on_plain_audio() -> None:
     assert len(core.messages) >= 1, "DLL must still decode plain audio after ENDEC refactor"
     assert any(header in m for m in core.messages), (
         f"Header not found in decoded messages: {core.messages!r}"
+    )
+
+
+def test_detect_endec_eas_station_aa_bytes() -> None:
+    """KR8MER EAS Station appends 3 × 0xAA after each burst → EAS_STATION."""
+    mode = detect_endec_mode(
+        ["ZCZC-WXR-TOR-029015+0030-0181500-KOAX/NWS-"],
+        [],
+        terminator_runs=[(0xAA, 3)],
+    )
+    assert mode == ENDEC_MODE_EAS_STATION, f"Expected EAS_STATION, got {mode}"
+
+
+def test_dll_endec_detection_eas_station_integration() -> None:
+    """SAMEDemodulatorCore must detect KR8MER EAS Station from 3 × 0xAA terminator bytes.
+
+    The 0xAA trill fingerprint produces an alternating mark/space FSK pattern.
+    The DLL must capture these bytes in post-message mode and report EAS_STATION
+    as the detected ENDEC — and the SAME message must decode correctly.
+    """
+    header = "ZCZC-WXR-TOR-029015+0030-0181500-KOAX/NWS-"
+    samples = _make_fsk_audio_with_terminator(
+        header, b"\xaa\xaa\xaa", sample_rate=44100
+    )
+
+    core = SAMEDemodulatorCore(44100, apply_bandpass=True)
+    core.process_samples(samples)
+
+    assert len(core.messages) >= 1, "DLL must decode at least one burst"
+    assert core.endec_mode == ENDEC_MODE_EAS_STATION, (
+        f"Expected EAS_STATION from 3×0xAA terminator bytes, got {core.endec_mode!r}. "
+        f"terminator_runs={core._all_terminator_runs!r}"
     )

--- a/webapp/admin/maintenance.py
+++ b/webapp/admin/maintenance.py
@@ -1486,6 +1486,10 @@ def admin_eas_settings():
             if audio_player:
                 settings.audio_player = audio_player
 
+        # Update station fingerprint toggle
+        if "endec_fingerprint" in payload:
+            settings.endec_fingerprint = bool(payload["endec_fingerprint"])
+
         # Update authorized FIPS codes
         if "authorized_fips_codes" in payload:
             fips = payload["authorized_fips_codes"]


### PR DESCRIPTION
Appends three 0xAA terminator bytes after each SAME burst so the station
can be fingerprinted in the same way as Sage/NWS hardware.  0xAA
(10101010 binary) alternates mark/space on every bit, producing a
distinctive ~46 ms trill rather than the pure-tone buzz of 0xFF or 0x00.

Other ENDEC decoders gracefully exit post-message mode on the first 0xAA
byte (the message is already decoded) while our own decoder captures the
full run and reports ENDEC_MODE_EAS_STATION.

Changes:
- eas_fsk.py: add encode_terminator_bits() helper, export it from __all__
- eas_demod.py: add ENDEC_MODE_EAS_STATION constant; extend detect_endec_mode
  voting with 0xAA branch; accept 0xAA in post-message terminator capture
- eas.py: add _generate_station_terminator_samples(); inject terminator after
  every burst in generate_alert_audio(), build_eom_file(), build_manual_components()
- test_eas_decode.py: add unit test and DLL integration test for EAS_STATION

https://claude.ai/code/session_01KXXLdm7ZvejhBi1g2xKhn6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Station Fingerprint" setting to EAS broadcast configuration, which appends a distinctive trill after each SAME burst to identify your station (enabled by default).
  * Enhanced detection logic to recognize station fingerprints from other broadcasting systems.

* **Tests**
  * Added test coverage for fingerprint detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->