### PR TITLE
Update licensing and legal documentation: new commercial license, trademark policy, and Terms of Use revisions

### DIFF
--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,66 +1,178 @@
-COMMERCIAL LICENSE AGREEMENT
-EAS Station Software
+COMMERCIAL SOFTWARE LICENSE AGREEMENT
+EAS Station
 
 Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
 
-PROPRIETARY SOFTWARE LICENSE
+IMPORTANT: This Commercial License Agreement ("Agreement") is a legal contract between the
+licensor identified below ("Licensor") and the customer purchasing or otherwise accepting the
+commercial license ("Licensee"). By installing, copying, modifying, distributing, or using the
+Software under this Agreement, Licensee agrees to be bound by these terms.
 
-This is a commercial license agreement for EAS Station software.
+1. DEFINITIONS
 
-1. GRANT OF LICENSE
-   Subject to payment of applicable license fees, Licensor grants Licensee a
-   non-exclusive, non-transferable license to use, modify, and deploy this
-   software without the copyleft obligations of the AGPL v3 license.
+1.1 "Software" means the EAS Station software, source code, object code, related scripts,
+configuration templates, and accompanying documentation made available by Licensor.
 
-2. PERMITTED USE
-   - Internal use within Licensee's organization
-   - Modification for internal purposes
-   - Deployment without source code disclosure requirements
-   - Integration into proprietary systems
+1.2 "Licensed Deployment" means each production, staging, development, or test installation of the
+Software operated by or for Licensee, unless otherwise defined in an executed order form.
+
+1.3 "Order Form" means a quote, invoice, purchase order, or other writing accepted by both parties
+that specifies commercial terms (including fees, deployment count, term, and support scope).
+
+2. LICENSE GRANT
+
+2.1 Subject to this Agreement and full payment of applicable fees, Licensor grants Licensee a
+non-exclusive, non-transferable, non-sublicensable license to:
+  (a) install and use the Software for internal business purposes;
+  (b) modify the Software for Licensee's internal use; and
+  (c) deploy the Software without AGPL copyleft obligations.
+
+2.2 License scope (number of deployments, sites, or users) is defined in the applicable Order Form.
+Use beyond that scope requires additional licensing.
 
 3. RESTRICTIONS
-   - May not redistribute or resell the software
-   - May not remove or modify copyright notices
-   - May not sublicense to third parties
-   - May not use "EAS Station" trademark without written permission
 
-4. PRICING
-   Contact: sales@easstation.com
+Licensee must not, except as expressly authorized in this Agreement or an Order Form:
+  (a) redistribute, resell, host for unaffiliated third parties, or otherwise commercialize access to the
+      Software as a service bureau without written permission;
+  (b) remove or alter copyright, license, or proprietary notices;
+  (c) sublicense, assign, transfer, lease, or lend the Software except as permitted under Section 14;
+  (d) represent that Licensor endorses Licensee or Licensee's modified version;
+  (e) use Licensor trademarks except as explicitly allowed in writing.
 
-   License tiers available:
-   - Single Station License
-   - Multi-Station License (up to 10 installations)
-   - Enterprise License (unlimited installations)
-   - OEM/Integration License (redistribution rights)
-   - Complete Acquisition (all IP and assets)
+4. FEES, PAYMENT, AND TAXES
 
-   Pricing covers the software license only; hardware acquisition and deployment costs are not included.
+4.1 Fees are specified in the Order Form.
 
-   For detailed pricing and terms, contact sales@easstation.com
+4.2 Unless otherwise stated in the Order Form, invoices are due within thirty (30) days of invoice date.
 
-5. SUPPORT AND MAINTENANCE
-   Commercial licenses include:
-   - Priority technical support
-   - Security updates and patches
-   - Version upgrades
-   - Custom integration assistance
+4.3 Late amounts may accrue interest at the lesser of 1.5% per month or the maximum rate permitted
+by applicable law.
 
-6. WARRANTY DISCLAIMER
-   SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+4.4 Licensee is responsible for all applicable taxes, duties, and levies (excluding taxes based solely on
+Licensor's net income).
 
-7. LIMITATION OF LIABILITY
-   IN NO EVENT SHALL LICENSOR BE LIABLE FOR ANY DAMAGES ARISING FROM USE.
+5. AUDIT RIGHTS
 
-8. TERM AND TERMINATION
-   License is perpetual unless terminated for breach.
-   Upon termination, Licensee must cease all use and destroy all copies.
+Upon reasonable written notice, and no more than once per twelve (12) months, Licensor may verify
+Licensee's compliance with deployment and usage limits. Audits must occur during normal business
+hours and in a manner that minimizes operational disruption. If under-licensing exceeds five percent
+(5%), Licensee will promptly pay applicable true-up fees.
 
-9. GOVERNING LAW
-   This agreement shall be governed by the laws of [Your State/Country].
+6. SUPPORT AND MAINTENANCE
 
-To obtain a commercial license, contact:
-Timothy Kramer (KR8MER)
+6.1 Any support, maintenance, update cadence, response targets, or service levels are provided only as
+specified in the applicable Order Form or support addendum.
+
+6.2 Unless expressly included in writing, Licensor is not obligated to provide custom development,
+on-site support, integrations, or regulatory consulting.
+
+7. OWNERSHIP AND FEEDBACK
+
+7.1 Licensor retains all right, title, and interest in and to the Software, including all intellectual property
+rights, except for the limited license rights expressly granted.
+
+7.2 Licensee retains ownership of Licensee data and independently created materials.
+
+7.3 Unless otherwise agreed in writing, any suggestions, enhancement ideas, or feedback provided by
+Licensee may be used by Licensor without restriction or compensation.
+
+8. REGULATORY STATUS AND SAFETY LIMITATIONS
+
+8.1 The Software is experimental and is not represented as FCC-certified EAS encoder/decoder equipment.
+
+8.2 THE SOFTWARE IS NOT APPROVED FOR LIFE-SAFETY, MISSION-CRITICAL, OR REGULATORY-
+MANDATED ALERTING USE. LICENSEE IS SOLELY RESPONSIBLE FOR COMPLIANCE WITH FCC,
+STATE, LOCAL, AND OTHER APPLICABLE REGULATORY REQUIREMENTS.
+
+8.3 Licensor makes no representation that use of the Software satisfies certification obligations under
+47 C.F.R. Part 11 or any equivalent regulatory framework.
+
+9. EXPORT AND SANCTIONS COMPLIANCE
+
+Licensee agrees to comply with all applicable export control, sanctions, and trade laws, including
+United States laws administered by OFAC, BIS, and other competent authorities. Licensee must not
+export, re-export, transfer, or make the Software available in violation of applicable law.
+
+10. WARRANTIES AND DISCLAIMER
+
+10.1 Licensor warrants that it has the right to license the Software under this Agreement.
+
+10.2 EXCEPT FOR THE LIMITED WARRANTY IN SECTION 10.1, THE SOFTWARE AND ANY SERVICES
+ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF ANY KIND, WHETHER
+EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+
+11. LIMITATION OF LIABILITY
+
+11.1 TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR SHALL NOT BE LIABLE FOR ANY
+INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR
+LOST PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS INTERRUPTION.
+
+11.2 LICENSOR'S AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THIS AGREEMENT SHALL
+NOT EXCEED THE TOTAL FEES PAID OR PAYABLE BY LICENSEE TO LICENSOR FOR THE SOFTWARE
+DURING THE TWELVE (12) MONTHS PRECEDING THE EVENT GIVING RISE TO LIABILITY.
+
+11.3 The exclusions and limits in this section apply regardless of legal theory and even if a remedy fails
+of its essential purpose.
+
+12. INDEMNIFICATION
+
+12.1 By Licensor. Licensor will defend and indemnify Licensee against third-party claims alleging that
+unmodified Software infringes a U.S. copyright or trademark, subject to prompt notice, Licensor control
+of defense, and Licensee cooperation.
+
+12.2 Exclusions. Licensor has no obligation for claims arising from: (a) modifications not made by
+Licensor; (b) combinations with items not supplied by Licensor; (c) use outside the Agreement scope;
+or (d) continued use after notice of an alleged infringement that Licensor can reasonably mitigate.
+
+12.3 By Licensee. Licensee will defend and indemnify Licensor from third-party claims arising from
+Licensee's deployment, configuration, misuse, regulatory violations, or unlawful operation.
+
+13. TERM AND TERMINATION
+
+13.1 Term. This Agreement begins on the effective date of the applicable Order Form and continues for
+the term stated in that Order Form, or if none is specified, until terminated under this Section.
+
+13.2 Termination for Breach. Either party may terminate this Agreement for material breach if the
+breaching party fails to cure within thirty (30) days after written notice.
+
+13.3 Immediate Termination. Licensor may terminate immediately for non-payment, unauthorized
+redistribution, or material violation of Sections 3, 8, or 9.
+
+13.4 Effect of Termination. Upon termination, Licensee must cease use and destroy or return all copies
+of the Software, except one archival copy retained solely for legal compliance purposes.
+
+14. ASSIGNMENT
+
+Neither party may assign this Agreement without the other party's prior written consent, except in
+connection with a merger, acquisition, or sale of substantially all assets, provided the assignee agrees
+to be bound by this Agreement.
+
+15. GOVERNING LAW AND VENUE
+
+This Agreement is governed by the laws of the State of Ohio, United States, excluding conflict-of-law
+principles. Any legal action arising out of this Agreement shall be brought exclusively in state or federal
+courts located in Ohio, and each party consents to personal jurisdiction and venue in those courts.
+
+16. GENERAL
+
+16.1 Entire Agreement. This Agreement and applicable Order Forms constitute the entire agreement and
+supersede prior understandings concerning the Software.
+
+16.2 Amendments. Changes must be in writing and signed by authorized representatives of both parties.
+
+16.3 Severability. If any provision is held unenforceable, the remaining provisions remain in effect.
+
+16.4 Waiver. Failure to enforce a provision is not a waiver of future enforcement.
+
+16.5 Independent Contractors. The parties are independent contractors; no partnership, joint venture,
+or agency relationship is created.
+
+17. CONTACT
+
+Licensor: Timothy Kramer (KR8MER)
 Email: sales@easstation.com
-Website: https://github.com/KR8MER/eas-station
+GitHub: https://github.com/KR8MER/eas-station
 
-For open-source use under AGPL v3, see LICENSE file.
+For open-source use under AGPL v3, see LICENSE.

--- a/NOTICE
+++ b/NOTICE
@@ -11,59 +11,38 @@ This software is available under two licenses:
 
 1. GNU AFFERO GENERAL PUBLIC LICENSE v3 (AGPL-3.0)
    - See LICENSE file
-   - Free for open-source use
-   - REQUIRES source code disclosure for web service deployments
-   - REQUIRES attribution and copyright notices to remain intact
+   - Available to users who comply with AGPL v3 obligations
+   - Includes source disclosure obligations for modified network deployments
 
 2. COMMERCIAL LICENSE
    - See LICENSE-COMMERCIAL file
    - For proprietary/closed-source use
-   - No source code disclosure requirements
+   - No AGPL source disclosure requirements
    - Contact copyright holder for pricing
 
 ================================================================================
-MANDATORY ATTRIBUTION REQUIREMENTS (BOTH LICENSES)
+AGPL NOTICE PRESERVATION REQUIREMENTS
 ================================================================================
 
-All uses of this software MUST include the following attribution:
+When using this software under AGPL v3, you must comply with AGPL terms,
+including preserving applicable copyright and license notices.
+
+Recommended attribution string:
 
   "Powered by EAS Station - Copyright (c) 2025-2026 Timothy Kramer (KR8MER)"
 
-This attribution MUST appear:
-- In the web interface footer (if deployed as web service)
-- In the software's about/credits section
-- In any documentation distributed with the software
-- In any derivative works
-
-You may NOT:
-- Remove or obscure copyright notices
-- Remove or obscure author attributions
-- Claim this software as your own creation
-- Rebrand this software without explicit written permission
-- Remove the "EAS Station" name from the software
-
 ================================================================================
-ANTI-REBRANDING PROTECTION
+TRADEMARKS AND BRANDING
 ================================================================================
 
-The name "EAS Station" and associated branding are protected. You may NOT:
+"EAS Station", associated logos, and branding are not licensed under AGPL v3
+or the commercial software license except as expressly permitted.
 
-1. Rename the software and distribute it as your own product
-2. Remove references to the original author (Timothy Kramer/KR8MER)
-3. Present modified versions as original works without attribution
-4. Use confusingly similar names that imply official endorsement
+Use of trademarks and branding is governed by the project Trademark Policy:
+  docs/policies/TRADEMARK_POLICY.md
 
-Derivative works MUST clearly indicate:
-- The original software name: "EAS Station"
-- The original author: Timothy Kramer (KR8MER)
-- That it is a modified version (e.g., "Based on EAS Station")
-
-================================================================================
-TRADEMARK NOTICE
-================================================================================
-
-"EAS Station" is a trademark of Timothy Kramer.
-Unauthorized use of this trademark is prohibited.
+You may not imply endorsement by Timothy Kramer or the EAS Station project
+without explicit written permission.
 
 ================================================================================
 LICENSE SELECTION
@@ -72,11 +51,11 @@ LICENSE SELECTION
 By using this software, you agree to comply with one of the two licenses:
 
 - If you deploy as a web service or distribute modified versions:
-  You MUST either (a) comply with AGPL v3 and share your source code, OR
+  You MUST either (a) comply with AGPL v3 and provide required source access, OR
   (b) obtain a commercial license
 
 - If you use internally without distribution:
-  You may use under AGPL v3 with attribution requirements
+  You may use under AGPL v3 if you comply with its terms
 
 ================================================================================
 CONTACT
@@ -91,15 +70,5 @@ For open-source questions:
 See GitHub Issues: https://github.com/KR8MER/eas-station/issues
 
 ================================================================================
-ENFORCEMENT
-================================================================================
 
-Violation of attribution requirements or unauthorized rebranding will result in:
-- License termination
-- Legal action for copyright infringement
-- Legal action for trademark infringement
-- Damages as provided by law
-
-================================================================================
-
-Last updated: 2025-01-20
+Last updated: 2026-04-13

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ python app.py
 
     Always work in shielded test environments. Never connect to production broadcast chains.
 
-See [Terms of Use](docs/policies/TERMS_OF_USE) and [FCC Compliance](docs/reference/ABOUT) for details.
+See [Terms of Use](docs/policies/TERMS_OF_USE.md), [FCC Compliance](docs/reference/ABOUT.md), and [Trademark Policy](docs/policies/TRADEMARK_POLICY.md) for details.
 
 ## 📈 Roadmap
 
@@ -659,14 +659,15 @@ EAS Station is available under **dual licensing**:
 
 ### Open Source License (AGPL v3)
 
-For open-source projects and non-commercial use, EAS Station is licensed under the [GNU Affero General Public License v3 (AGPL-3.0)](LICENSE).
+For users who comply with AGPL v3 obligations, EAS Station is licensed under the [GNU Affero General Public License v3 (AGPL-3.0)](LICENSE).
 
 **Key requirements:**
 - ✅ Free to use, modify, and distribute
 - ✅ Must keep source code open
 - ✅ Must share modifications if you deploy as a web service
-- ✅ Must retain copyright and attribution notices
-- ❌ Cannot remove author attribution or rebrand
+- ✅ Must retain copyright and license notices
+- ✅ Must mark modified network deployments with source availability as required by AGPL v3
+- ✅ Must avoid implying endorsement by the upstream project
 
 See [LICENSE](LICENSE) file for full AGPL terms.
 
@@ -691,15 +692,15 @@ Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
 EAS Station - https://github.com/KR8MER/eas-station
 ```
 
-**IMPORTANT:** All derivative works must retain attribution to the original author.
-Rebranding or removing attribution is prohibited under both licenses.
-See [NOTICE](NOTICE) file for complete terms.
+**IMPORTANT:** Preserve required legal notices under your chosen license.
+Branding and logo usage are governed separately by the [Trademark Policy](docs/policies/TRADEMARK_POLICY.md).
+See [NOTICE](NOTICE) for licensing notice details.
 
 ### Why Dual Licensing?
 
-- **For hobbyists & open-source**: Free to use under AGPL
-- **For commercial use**: Option to license without copyleft obligations
-- **For everyone**: Protects the author's rights and prevents unauthorized rebranding
+- **For open-source and commercial users**: AGPL is available for anyone who complies with copyleft requirements
+- **For proprietary use**: Commercial licensing is available without AGPL obligations
+- **For branding clarity**: Trademark usage is handled by separate trademark policy terms
 
 ## 🙏 Acknowledgments
 

--- a/docs/policies/TERMS_OF_USE.md
+++ b/docs/policies/TERMS_OF_USE.md
@@ -1,6 +1,6 @@
 # ⚖️ Terms of Use
 
-_Last updated: February 14, 2026_
+_Last updated: April 13, 2026_
 
 > **Critical Safety Notice:** EAS Station is experimental software. It must not be used for life-safety, mission-critical, or FCC-mandated alerting. Commercially certified EAS equipment remains the only acceptable solution for regulatory compliance.
 
@@ -16,10 +16,10 @@ _Last updated: February 14, 2026_
 - You assume all risk for evaluating the software in lab or demonstration environments. The project is provided strictly on an “AS IS” basis without warranties of any kind.
 
 ## 3. Disclaimer of Liability & Indemnification
-- The authors, maintainers, and contributors disclaim any and all liability—civil, criminal, and regulatory—for damages, injuries, penalties, data loss, downtime, enforcement actions, or criminal proceedings that may arise from use or misuse of EAS Station—including malicious, unauthorized, or noncompliant uses by you or anyone who gains access to your deployment.
-- **The developer and contributors of this project bear absolutely no responsibility for any criminal activity conducted using this software.**
-- No emergency responses, broadcast activations, or public warning decisions should be based on this project. Use at your own risk.
-- You agree to indemnify, defend, and hold harmless the project authors, maintainers, and contributors from any and all claims, demands, damages, losses, costs, and liabilities—including attorneys' fees and criminal defense costs—arising out of your deployment, configuration, redistribution, or failure to control access to the project.
+- To the maximum extent permitted by law, the authors, maintainers, and contributors disclaim liability for damages, penalties, data loss, downtime, enforcement actions, or claims arising from your use, misuse, deployment, or redistribution of EAS Station.
+- No emergency response, broadcast activation, or public warning decision should be based on this project.
+- You are solely responsible for securing your deployment, controlling access, and complying with applicable law.
+- You agree to defend, indemnify, and hold harmless the project authors, maintainers, and contributors from third-party claims, losses, and expenses (including reasonable attorneys' fees) arising from your deployment, operation, or misuse of the software.
 
 ## 4. Acceptable Use & Prohibited Activities
 - Operate the software only in controlled, non-production lab or development environments.
@@ -47,7 +47,7 @@ Misuse of EAS Station—including unauthorized broadcast, spoofing, or interfere
   - **Ohio Revised Code § 2917.32** (Making False Alarms) — prohibits initiating or announcing a false alarm of fire, explosion, flood, avalanche, or other disaster requiring emergency response, or causing another to initiate or announce such a false alarm. A violation is a **first-degree misdemeanor** and escalates to a **fourth-degree felony** if it results in serious physical harm to any person, or if the offender has a prior conviction for the same offense.
   - **Ohio Revised Code § 2921.31** (Obstructing Official Business) — prohibits knowingly hampering or impeding a public official or employee in the performance or discharge of any authorized duty. Misuse that interferes with authorized emergency broadcasts, disrupts emergency response coordination, or prevents lawful EAS relay is a violation. A violation is a **second-degree misdemeanor** and escalates to a **fifth-degree felony** when the conduct creates a risk of physical harm to any person.
 - In jurisdictions outside the United States, equivalent or more severe criminal statutes may apply, and international law enforcement cooperation may result in prosecution across borders.
-- **The developer, maintainers, and contributors of EAS Station bear absolutely no criminal, civil, or regulatory liability for any act, omission, or crime committed by any person using this software.** Your use of this software constitutes your sole and exclusive acceptance of all criminal, civil, and regulatory risk and liability arising from that use.
+- To the maximum extent permitted by law, the developer, maintainers, and contributors disclaim criminal, civil, and regulatory liability for acts or omissions committed by persons using this software. You remain responsible for your own conduct and legal compliance.
 - The project authors are not accomplices, aiders, or abettors of any misuse and explicitly disclaim any knowledge of, participation in, or responsibility for any illegal activity conducted using this software. The existence of this software does not constitute authorization, endorsement, or facilitation of any unlawful act.
 
 ## 4b. Documented Real-World Enforcement Cases
@@ -102,7 +102,7 @@ Applicable rules: 47 C.F.R. § 11.45 (prohibition on EAS code/Attention Signal u
 - Third-party libraries, firmware, container images, and hardware integrations are subject to their own licenses and warranties. You are responsible for reviewing and complying with those terms.
 
 ## 9. Licensing & Contributions
-- The EAS Station source code is dual-licensed under the [GNU Affero General Public License v3 (AGPL-3.0)](../../LICENSE) for open-source use and a [Commercial License](../../LICENSE-COMMERCIAL) for proprietary use. Copyright remains with Timothy Kramer (KR8MER).
+- The EAS Station source code is dual-licensed under the [GNU Affero General Public License v3 (AGPL-3.0)](../../LICENSE) and a [Commercial License](../../LICENSE-COMMERCIAL). AGPL availability is not limited to non-commercial users; commercial users may also use AGPL if they comply with its terms. Copyright remains with Timothy Kramer (KR8MER).
 - By submitting code, documentation, or other content, contributors agree that their work is provided under the AGPL-3.0 license unless a separate commercial agreement is in place.
 - All commits must include a Developer Certificate of Origin (DCO) sign-off line (`Signed-off-by`) affirming that the contributor has the right to submit the work under the project license. Instructions are provided in [CONTRIBUTING.md](../process/CONTRIBUTING).
 
@@ -118,7 +118,21 @@ Applicable rules: 47 C.F.R. § 11.45 (prohibition on EAS code/Attention Signal u
 - Questions about these terms can be directed through the GitHub issue tracker.
 - Do **not** submit emergency requests, personal data, or public warning content through that channel.
 
-## 13. AMPR Network (44.0.0.0/8) — Non-Commercial Use
+## 13. General Contract Terms
+- **Governing Law and Venue:** Unless superseded by a separate written agreement, these terms are governed by the laws of the State of Ohio, United States, without regard to conflict-of-law principles. Any dispute arising from these terms must be brought in state or federal courts located in Ohio.
+- **Severability:** If any provision is held unenforceable, remaining provisions remain in full force.
+- **Waiver:** Failure to enforce any provision is not a waiver of future enforcement.
+- **Entire Agreement for Site Terms:** These Terms of Use, together with referenced policy pages, form the entire agreement for use of this website and related project resources.
+- **Updates to Terms:** We may update these terms from time to time by posting a revised version with a new "Last updated" date.
+- **Capacity:** By using this site, you represent that you have legal capacity to enter into this agreement in your jurisdiction.
+- **Legal Notices Contact:** For legal notices, contact sales@easstation.com.
+
+## 14. Relationship to Software Licenses
+- These Terms of Use govern access to and use of the website, documentation, and related resources.
+- These Terms of Use do **not** replace, modify, or override the software copyright licenses.
+- Use, modification, and distribution of source code are governed by the [AGPL-3.0 License](../../LICENSE) or the [Commercial License](../../LICENSE-COMMERCIAL), as applicable.
+
+## 15. AMPR Network (44.0.0.0/8) — Non-Commercial Use
 
 This service may be accessible via the **AMPRNet** IPv4 address block (`44.0.0.0/8`), which is allocated globally to the licensed amateur radio community by the [Amateur Radio Digital Communications (ARDC)](https://www.ampr.org/) foundation and managed under amateur radio service rules (FCC 47 CFR Part 97 in the United States).
 

--- a/docs/policies/TRADEMARK_POLICY.md
+++ b/docs/policies/TRADEMARK_POLICY.md
@@ -1,0 +1,52 @@
+# ™️ EAS Station Trademark Policy
+
+_Last updated: April 13, 2026_
+
+This policy explains permitted and prohibited use of the **EAS Station** name, logos, and branding.
+
+## 1. Scope
+
+This policy governs use of:
+- The name **EAS Station**
+- Project logos, icons, and wordmarks
+- Any confusingly similar names, branding, or visual identity
+
+## 2. License Separation
+
+The software copyright licenses (AGPL-3.0 and the commercial license) do **not** grant trademark rights except as expressly stated.
+
+- You may use, modify, and redistribute software under the applicable software license.
+- Trademark rights are separate and are governed by this policy.
+
+## 3. Permitted Uses (No Separate Approval Required)
+
+You may, without prior written approval:
+- Use the unmodified project name to refer to the upstream project factually
+- State that your fork is "based on EAS Station"
+- Preserve required legal notices and attribution from upstream materials
+- Describe compatibility in a truthful, non-confusing way
+
+## 4. Prohibited Uses
+
+You may not, without explicit written permission:
+- Use "EAS Station" as the primary name of a modified fork in a way that implies official endorsement
+- Use project logos/wordmarks for your modified distribution branding
+- Use confusingly similar names, logos, or trade dress
+- State or imply sponsorship, certification, or endorsement by Timothy Kramer or the EAS Station project
+
+## 5. Fork Naming Guidance
+
+If you distribute a modified version, choose distinct branding that avoids confusion.
+
+Recommended format:
+- "<Your Product Name> (based on EAS Station)"
+
+## 6. Enforcement
+
+Unauthorized trademark use may result in requests to rename, remove branding, or other legal enforcement available under applicable trademark law.
+
+## 7. Questions and Permissions
+
+For trademark permissions:
+- Email: sales@easstation.com
+- GitHub: https://github.com/KR8MER/eas-station

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -41,15 +41,13 @@
                     </section>
                     <section class="mb-4">
                         <h2 class="h4 text-primary">3. Disclaimer of Liability &amp; Indemnification</h2>
-                        <p>The authors, maintainers, and contributors disclaim any and all liability—civil, criminal, and regulatory—for
-                           damages, injuries, penalties, data loss, downtime, enforcement actions, or criminal proceedings that may arise
-                           from use or misuse of EAS Station—including malicious, unauthorized, or noncompliant uses by you or anyone
-                           who gains access to your deployment. <strong>The developer and contributors of this project bear absolutely
-                           no responsibility for any criminal activity conducted using this software.</strong> No emergency responses,
-                           broadcast activations, or public warning decisions should be based on this project. You agree to indemnify,
-                           defend, and hold harmless the project authors, maintainers, and contributors from any and all claims, demands,
-                           damages, losses, costs, and liabilities—including attorneys' fees and criminal defense costs—arising out of
-                           your deployment, configuration, redistribution, or failure to control access to the project.</p>
+                        <p>To the maximum extent permitted by law, the authors, maintainers, and contributors disclaim liability for
+                           damages, penalties, data loss, downtime, enforcement actions, or claims arising from your use, misuse,
+                           deployment, or redistribution of EAS Station. No emergency response, broadcast activation, or public
+                           warning decision should be based on this project. You are solely responsible for securing your deployment,
+                           controlling access, and complying with applicable law. You agree to defend, indemnify, and hold harmless
+                           the project authors, maintainers, and contributors from third-party claims, losses, and expenses (including
+                           reasonable attorneys' fees) arising from your deployment, operation, or misuse of the software.</p>
                     </section>
                     <section class="mb-4">
                         <h2 class="h4 text-primary">4. Acceptable Use &amp; Prohibited Activities</h2>
@@ -138,10 +136,9 @@
                             </li>
                             <li>In jurisdictions outside the United States, equivalent or more severe criminal statutes may apply,
                                 and international law enforcement cooperation may result in prosecution across borders.</li>
-                            <li><strong>The developer, maintainers, and contributors of EAS Station bear absolutely no criminal,
-                                civil, or regulatory liability for any act, omission, or crime committed by any person using this
-                                software.</strong> Your use of this software constitutes your sole and exclusive acceptance of all
-                                criminal, civil, and regulatory risk and liability arising from that use.</li>
+                            <li>To the maximum extent permitted by law, the developer, maintainers, and contributors disclaim
+                                criminal, civil, and regulatory liability for acts or omissions committed by persons using this
+                                software. You remain responsible for your own conduct and legal compliance.</li>
                             <li>The project authors are not accomplices, aiders, or abettors of any misuse and explicitly disclaim
                                 any knowledge of, participation in, or responsibility for any illegal activity conducted using
                                 this software. The existence of this software does not constitute authorization, endorsement, or
@@ -347,10 +344,11 @@
                     </section>
                     <section class="mb-4">
                         <h2 class="h4 text-primary">9. Licensing &amp; Contributions</h2>
-                        <p>The EAS Station source code is dual-licensed under the GNU Affero General Public License v3 (AGPL-3.0)
-                           for open-source use and a Commercial License for proprietary use. By submitting code, documentation, or
-                           other content, contributors agree their work is provided under AGPL-3.0 unless a separate commercial
-                           agreement is in place. All commits must include a Developer Certificate of Origin (DCO) sign-off line</p>
+                        <p>The EAS Station source code is dual-licensed under AGPL-3.0 and a Commercial License. AGPL use is not
+                           limited to non-commercial users; commercial users may also choose AGPL if they comply with AGPL terms.
+                           By submitting code, documentation, or other content, contributors agree their work is provided under
+                           AGPL-3.0 unless a separate commercial agreement is in place. All commits must include a Developer
+                           Certificate of Origin (DCO) sign-off line.</p>
                     </section>
                     <section class="mb-4">
                         <h2 class="h4 text-primary">10. Updates &amp; Change Control</h2>
@@ -373,10 +371,31 @@
                            emergency requests, personal data, or public warning content through that channel.</p>
                     </section>
 
+                                        <section class="mb-4">
+                        <h2 class="h4 text-primary">13. General Contract Terms</h2>
+                        <ul>
+                            <li><strong>Governing Law and Venue:</strong> Unless superseded by a separate written agreement, these terms are governed by the laws of the State of Ohio, United States. Any dispute arising from these terms must be brought in state or federal courts located in Ohio.</li>
+                            <li><strong>Severability:</strong> If any provision is unenforceable, the remaining provisions remain in effect.</li>
+                            <li><strong>Waiver:</strong> Failure to enforce any provision is not a waiver of future enforcement.</li>
+                            <li><strong>Entire Agreement for Site Terms:</strong> These Terms of Use, together with referenced policy pages, form the entire agreement for use of this website and related project resources.</li>
+                            <li><strong>Updates:</strong> We may update these terms by posting a revised version with a new “Last updated” date.</li>
+                            <li><strong>Capacity:</strong> By using this site, you represent that you have legal capacity to enter this agreement in your jurisdiction.</li>
+                            <li><strong>Legal Notices:</strong> Legal notices may be sent to <a href="mailto:sales@easstation.com">sales@easstation.com</a>.</li>
+                        </ul>
+                    </section>
+
+                    <section class="mb-4">
+                        <h2 class="h4 text-primary">14. Relationship to Software Licenses</h2>
+                        <p>These Terms of Use govern access to and use of the website, documentation, and related resources.
+                           They do <strong>not</strong> replace, modify, or override the software copyright licenses.
+                           Use, modification, and distribution of source code are governed by AGPL-3.0 or the Commercial License,
+                           as applicable.</p>
+                    </section>
+
                     <hr class="my-4">
 
                     <section class="mb-0">
-                        <h2 class="h4 text-primary">13. AMPR Network (44.0.0.0/8) &mdash; Non-Commercial Use</h2>
+                        <h2 class="h4 text-primary">15. AMPR Network (44.0.0.0/8) &mdash; Non-Commercial Use</h2>
                         <div class="alert alert-warning d-flex align-items-start" role="alert">
                             <i class="fas fa-network-wired fa-lg me-3 mt-1 flex-shrink-0"></i>
                             <div>


### PR DESCRIPTION
### Motivation

- Provide a complete, enforceable commercial license alternative to the AGPL and clarify permitted commercial uses. 
- Separate and document trademark rights and branding rules distinct from software copyright and licensing. 
- Improve safety, compliance, and contract language across public notices, README, and Terms to reduce legal ambiguity and update governance (governing law, venue, and last-updated dates).

### Description

- Replace `LICENSE-COMMERCIAL` with a full Commercial Software License Agreement including definitions, license grant, restrictions, fees, audit, support, warranties, indemnities, termination, governing law (Ohio), and contact details. 
- Simplify and clarify the `NOTICE` file to explain dual licensing, AGPL obligations, and trademark/branding rules, and update the last-updated date. 
- Update `README.md` to clarify AGPL availability, link to `LICENSE-COMMERCIAL`, reference the new Trademark Policy, and adjust attribution/branding guidance. 
- Add `docs/policies/TRADEMARK_POLICY.md` and revise `docs/policies/TERMS_OF_USE.md` and `templates/terms.html` to align site Terms of Use with the new commercial license, trademark policy, governing-law clauses, and updated liability/indemnity language.

### Testing

- Built the documentation site with `mkdocs build` to validate markdown and links and confirmed the build completed without errors. 
- Ran repository pre-commit hooks / linters (markdown/template checks) to verify formatting and template consistency, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcddf334b08320af57b43ac51b36b9)