### PR TITLE
Add RF RSSI meter for FM/SDR sources

### DIFF
--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -446,6 +446,11 @@ class SDRSourceAdapter(AudioSourceAdapter):
                         metadata['stereo_pilot_strength'] = demod_status.stereo_pilot_strength
                         metadata['is_stereo'] = demod_status.is_stereo
 
+                        # RF RSSI (mean IQ magnitude).  Linear value; the UI
+                        # converts to dBFS for the signal meter.
+                        metadata['rf_signal_strength'] = float(demod_status.signal_strength)
+                        metadata['rf_signal_strength_updated'] = time.time()
+
                         # RBDS data (if available)
                         rbds_data = demod_status.rbds_data
                         if rbds_data:

--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -258,6 +258,10 @@ class DemodulatorStatus:
     stereo_pilot_locked: bool = False  # 19 kHz stereo pilot detected
     stereo_pilot_strength: float = 0.0  # Pilot signal strength (0.0 to 1.0)
     is_stereo: bool = False  # Stereo decoding active
+    # Mean magnitude of the IQ samples for this chunk (linear, 0.0-1.0 range
+    # for normalized float samples).  The UI converts this to dBFS for the
+    # RF RSSI meter.
+    signal_strength: float = 0.0
 
 
 class RBDSWorker:
@@ -271,6 +275,15 @@ class RBDSWorker:
     # RBDS processing constants
     RBDS_MIN_SAMPLE_RATE = 120000  # Minimum sample rate for 57 kHz subcarrier extraction (Hz)
     RBDS_INTERMEDIATE_RATE = 25000  # Target rate after decimation before resampling (Hz)
+
+    # Sliding-window decode thresholds (samples at the 19 kHz RBDS rate).
+    # Before the bit-level sync state machine locks we need a generous window so
+    # the M&M and Costas loops can converge (~3 seconds).  Once locked their
+    # state is carried forward between batches, so a 1-second slice is enough
+    # to keep them locked and PS/radiotext updates arrive roughly once per
+    # second - comparable to a car radio's head unit.
+    RBDS_UNSYNCED_WINDOW = 57000   # ~3 seconds @ 19 kHz - initial acquisition
+    RBDS_SYNCED_WINDOW = 19000     # ~1 second  @ 19 kHz - fast streaming updates
 
     def __init__(self, sample_rate: int, intermediate_rate: int):
         """Initialize RBDS worker thread.
@@ -639,10 +652,14 @@ class RBDSWorker:
 
         self._rbds_sample_buffer = np.concatenate([self._rbds_sample_buffer, x])
 
-        # This is SDR, not streaming! RBDS updates slowly (station name, radiotext).
-        # Process large batches like python-radio does with recordings.
-        # 10 seconds @ 19kHz = 190000 samples = ~11875 symbols
-        if len(self._rbds_sample_buffer) < 190000:
+        # Sliding-window decode: use a generous window until the block-level
+        # sync state machine locks, then switch to a short 1-second window so
+        # PS/radiotext changes surface quickly instead of waiting 10 s.  M&M
+        # and Costas state is preserved across batches (see comment below),
+        # so once locked the shorter window keeps the loops locked too.
+        locked = getattr(self, '_rbds_synced', False)
+        window = self.RBDS_SYNCED_WINDOW if locked else self.RBDS_UNSYNCED_WINDOW
+        if len(self._rbds_sample_buffer) < window:
             return self._decode_rbds_groups()
 
         # Use buffered samples and reset for next accumulation
@@ -1476,6 +1493,11 @@ class FMDemodulator:
         # FAST PATH: Using JIT-compiled functions when available
         iq_array = np.asarray(iq_samples, dtype=np.complex64)
 
+        # Mean IQ magnitude - raw RF signal strength for the RSSI meter.  Done
+        # on the input array before phase-continuity prepending so the value
+        # reflects the samples that just arrived from the SDR.
+        rf_signal_strength = float(np.mean(np.abs(iq_array))) if iq_array.size else 0.0
+
         # Phase continuity - prepend last sample from previous block
         if self._prev_sample is not None:
             iq_array = np.concatenate(([self._prev_sample], iq_array))
@@ -1619,7 +1641,8 @@ class FMDemodulator:
             rbds_data=rbds_data,
             stereo_pilot_locked=stereo_pilot_locked,
             stereo_pilot_strength=stereo_pilot_strength,
-            is_stereo=self._stereo_enabled and stereo_pilot_locked
+            is_stereo=self._stereo_enabled and stereo_pilot_locked,
+            signal_strength=rf_signal_strength,
         )
 
         return audio.astype(np.float32), status

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -370,6 +370,50 @@
 .vu-labels span {
     font-variant-numeric: tabular-nums;
 }
+
+/* RF RSSI meter - shares VU meter styling but with its own gradient */
+.rssi-meter {
+    background: var(--bg-primary);
+    border-radius: 10px;
+    padding: 0.55rem 0.75rem 0.7rem;
+    margin-top: 0.5rem;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04);
+}
+
+.rssi-track {
+    position: relative;
+    height: 10px;
+    border-radius: 5px;
+    background: linear-gradient(90deg, var(--danger-color) 0%, var(--warning-color) 40%, var(--success-color) 70%);
+    overflow: hidden;
+    opacity: 0.35;
+}
+
+.rssi-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 0%;
+    background: rgba(255, 255, 255, 0.0);
+    border-right: 2px solid rgba(255, 255, 255, 0.85);
+    box-shadow: 0 0 6px rgba(255,255,255,0.45);
+    transition: width 0.2s ease-out;
+}
+
+.rssi-labels {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    margin-bottom: 0.35rem;
+}
+
+.rssi-labels .rssi-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
 </style>
 
 <script src="https://cdn.socket.io/4.5.4/socket.io.min.js" crossorigin="anonymous"></script>
@@ -500,7 +544,13 @@ function updateMetricsOnly() {
             if (rmsLabel) {
                 rmsLabel.textContent = `RMS: ${formatDbLabel(source.metrics.rms_level_db)}`;
             }
-            
+
+            // RF RSSI meter live update (polling-fallback path).
+            const rfSignal = source.metrics?.metadata?.rf_signal_strength;
+            if (typeof rfSignal === 'number' && Number.isFinite(rfSignal)) {
+                updateRssiMeter(source.name, rfSignal);
+            }
+
             // Check if player needs to be updated due to stream state changes
             updateSourcePlayer(source);
         }
@@ -580,6 +630,19 @@ function renderAudioSources(fullRender = true) {
                             <div class="vu-fill rms" id="rms-meter-${safeId}" style="width: ${calculateFillWidth(rmsValue)}%"></div>
                         </div>
                     </div>
+
+                    ${hasRfSignalStrength(source) ? `
+                        <!-- RF RSSI meter (FM/SDR sources only) -->
+                        <div class="rssi-meter" aria-live="polite" data-rssi-container-for="${safeId}">
+                            <div class="rssi-labels">
+                                <span><i class="fas fa-signal"></i> RF Signal</span>
+                                <span class="rssi-value" id="rssi-label-${safeId}">${formatRssiLabel(getRfSignalStrength(source))}</span>
+                            </div>
+                            <div class="rssi-track" role="presentation">
+                                <div class="rssi-fill" id="rssi-meter-${safeId}" style="width: ${calculateRssiFillWidth(getRfSignalStrength(source))}%"></div>
+                            </div>
+                        </div>
+                    ` : ''}
 
                     <!-- Audio Player -->
                     <div class="audio-player-container" id="player-container-${source.name}">
@@ -984,15 +1047,75 @@ function calculateFillWidth(value) {
     const MIN_DB = -60;
     const MAX_DB = 0;
     const clamped = Math.max(MIN_DB, Math.min(MAX_DB, value));
-    
+
     // Convert to 0-1 range
     const normalized = (clamped - MIN_DB) / (MAX_DB - MIN_DB);
-    
+
     // Apply slight curve for better visual response at lower levels
     // This makes the meter more responsive in the typical operating range (-40 to -10 dBFS)
     const curved = Math.pow(normalized, 0.8);
-    
+
     return curved * 100;
+}
+
+// RF RSSI meter helpers.  `value` is the mean IQ magnitude (linear, 0-1
+// for normalized float samples) published by the demodulator; we convert
+// to dBFS so the meter matches the admin radio diagnostics panel.
+const RSSI_MIN_DB = -100;
+const RSSI_MAX_DB = -20;
+
+function getRfSignalStrength(source) {
+    const raw = source?.metrics?.metadata?.rf_signal_strength;
+    const num = Number(raw);
+    return Number.isFinite(num) ? num : null;
+}
+
+function hasRfSignalStrength(source) {
+    return getRfSignalStrength(source) !== null;
+}
+
+function rssiToDbfs(value) {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return null;
+    }
+    return 20 * Math.log10(value);
+}
+
+function formatRssiLabel(value) {
+    const db = rssiToDbfs(value);
+    if (db === null) {
+        return '-- dBFS';
+    }
+    let rating = 'No signal';
+    if (db > -50) rating = 'Excellent';
+    else if (db > -70) rating = 'Good';
+    else if (db > -85) rating = 'Fair';
+    else if (db > -100) rating = 'Poor';
+    return `${db.toFixed(1)} dBFS · ${rating}`;
+}
+
+function calculateRssiFillWidth(value) {
+    const db = rssiToDbfs(value);
+    if (db === null) {
+        return 0;
+    }
+    const clamped = Math.max(RSSI_MIN_DB, Math.min(RSSI_MAX_DB, db));
+    const normalized = (clamped - RSSI_MIN_DB) / (RSSI_MAX_DB - RSSI_MIN_DB);
+    return normalized * 100;
+}
+
+function updateRssiMeter(sourceId, value) {
+    if (!sourceId) return;
+    const safeId = sanitizeId(sourceId);
+    const bar = document.getElementById(`rssi-meter-${safeId}`);
+    const label = document.getElementById(`rssi-label-${safeId}`);
+    if (!bar && !label) return;
+    if (bar) {
+        bar.style.width = `${calculateRssiFillWidth(value)}%`;
+    }
+    if (label) {
+        label.textContent = formatRssiLabel(value);
+    }
 }
 
 function initializeAudioPlayers(playingStates = {}, currentTimes = {}) {
@@ -1694,6 +1817,13 @@ function updateLevelMetersFromSnapshot(snapshot) {
         }
         if (rmsLabel) {
             rmsLabel.textContent = `RMS: ${formatDbLabel(metric.rms_level_db)}`;
+        }
+
+        // RF RSSI meter - updates every broadcast when the demodulator reports
+        // mean IQ magnitude (FM/SDR sources only).
+        const rfSignal = metric?.metrics?.metadata?.rf_signal_strength;
+        if (typeof rfSignal === 'number' && Number.isFinite(rfSignal)) {
+            updateRssiMeter(metric.source_id, rfSignal);
         }
         updatedCount++;
     });


### PR DESCRIPTION
## Summary
This PR adds a real-time RF signal strength indicator (RSSI meter) to the audio monitoring dashboard for FM and SDR sources. The meter displays the mean IQ magnitude from the demodulator converted to dBFS with a visual bar and signal quality rating.

## Key Changes

- **Frontend UI Components** (`templates/audio_monitoring.html`):
  - Added `.rssi-meter`, `.rssi-track`, `.rssi-fill`, and `.rssi-labels` CSS classes for styling the RF signal meter with a red-to-green gradient
  - Implemented helper functions: `getRfSignalStrength()`, `hasRfSignalStrength()`, `rssiToDbfs()`, `formatRssiLabel()`, `calculateRssiFillWidth()`, and `updateRssiMeter()`
  - Integrated RSSI meter rendering in the source template (conditionally shown only for sources with RF signal data)
  - Added live updates via both polling fallback and WebSocket broadcast paths

- **Demodulator** (`app_core/radio/demodulation.py`):
  - Added `signal_strength` field to `DemodulatorStatus` to carry mean IQ magnitude (linear 0.0-1.0 range)
  - Implemented sliding-window RBDS decode strategy: uses a generous 3-second window during initial acquisition, then switches to a 1-second window once locked for faster PS/radiotext updates
  - Calculated mean IQ magnitude on input samples before phase-continuity processing to reflect actual RF signal strength

- **Audio Sources** (`app_core/audio/sources.py`):
  - Extracted `signal_strength` from demodulator status and stored in metadata as `rf_signal_strength`
  - Added timestamp tracking for signal strength updates

## Implementation Details

- The RF signal value is a linear magnitude (0.0-1.0 for normalized float samples) that the UI converts to dBFS using the formula: `20 * log10(value)`
- RSSI range is -100 to -20 dBFS with quality ratings: Excellent (>-50), Good (>-70), Fair (>-85), Poor (>-100)
- The meter updates smoothly with a 0.2s CSS transition and includes a glowing white indicator line
- RBDS decode now uses adaptive windowing to balance initial lock acquisition time (~3s) with streaming update responsiveness (~1s once locked)

https://claude.ai/code/session_01PQmc4mAJPVWdbaX7vktSr4