### PR TITLE
Add Lightning theme with electric-yellow bolts and arc-blue plasma

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -827,6 +827,64 @@
     --shadow-color: rgba(92, 107, 192, 0.2);
 }
 
+/* Lightning Theme - Stormcloud sky with electric-yellow bolts and arc-blue plasma */
+[data-theme="lightning"] {
+    --primary-color: #ffeb3b;
+    --primary-soft: #fff176;
+    --primary-dark: #fbc02d;
+    --secondary-color: #40c4ff;
+    --secondary-soft: #80d8ff;
+    --secondary-dark: #00b0ff;
+    --accent-color: #ffffff;
+    --success-color: #00e676;
+    --danger-color: #ff5252;
+    --warning-color: #ffab40;
+    --info-color: #40c4ff;
+    --critical-color: #ff1744;
+    --light-color: #fff9c4;
+    --dark-color: #0d1b2a;
+    --bg-color: #0a1128;
+    --surface-color: #111d3d;
+    --bg-card: #18264d;
+    --bg-primary: #1b2a4e;
+    --text-color: #fffde7;
+    --text-secondary: #e3f2fd;
+    --text-muted: #9fa8b8;
+    --border-color: #2d3e66;
+    --shadow-color: rgba(255, 235, 59, 0.25);
+}
+
+/* Lightning Theme - Electric glow on bolt icons */
+[data-theme="lightning"] .fa-bolt {
+    color: var(--primary-color);
+    filter: drop-shadow(0 0 4px rgba(255, 235, 59, 0.7))
+            drop-shadow(0 0 10px rgba(64, 196, 255, 0.35));
+    animation: lightningFlicker 4.5s ease-in-out infinite;
+}
+
+@keyframes lightningFlicker {
+    0%, 40%, 44%, 100% {
+        opacity: 1;
+        filter: drop-shadow(0 0 4px rgba(255, 235, 59, 0.7))
+                drop-shadow(0 0 10px rgba(64, 196, 255, 0.35));
+    }
+    42% {
+        opacity: 0.55;
+        filter: drop-shadow(0 0 1px rgba(255, 235, 59, 0.4));
+    }
+    43% {
+        opacity: 1;
+        filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.9))
+                drop-shadow(0 0 16px rgba(64, 196, 255, 0.6));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    [data-theme="lightning"] .fa-bolt {
+        animation: none;
+    }
+}
+
 
    2. BASE & RESET STYLES
 
@@ -4195,6 +4253,7 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="charcoal"] .logo-wordmark .logo-text-primary,
 [data-theme="obsidian"] .logo-wordmark .logo-text-primary,
 [data-theme="slate"] .logo-wordmark .logo-text-primary,
+[data-theme="lightning"] .logo-wordmark .logo-text-primary,
 [data-theme="dark"] .brand-logo .logo-text-primary,
 [data-theme="coffee"] .brand-logo .logo-text-primary,
 [data-theme="aurora"] .brand-logo .logo-text-primary,
@@ -4202,7 +4261,8 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="midnight"] .brand-logo .logo-text-primary,
 [data-theme="charcoal"] .brand-logo .logo-text-primary,
 [data-theme="obsidian"] .brand-logo .logo-text-primary,
-[data-theme="slate"] .brand-logo .logo-text-primary {
+[data-theme="slate"] .brand-logo .logo-text-primary,
+[data-theme="lightning"] .brand-logo .logo-text-primary {
     fill: #ffffff;
     filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.3))
             drop-shadow(0 2px 4px rgba(0, 0, 0, 0.4));
@@ -4216,6 +4276,7 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="charcoal"] .logo-wordmark .logo-text-secondary,
 [data-theme="obsidian"] .logo-wordmark .logo-text-secondary,
 [data-theme="slate"] .logo-wordmark .logo-text-secondary,
+[data-theme="lightning"] .logo-wordmark .logo-text-secondary,
 [data-theme="dark"] .brand-logo .logo-text-secondary,
 [data-theme="coffee"] .brand-logo .logo-text-secondary,
 [data-theme="aurora"] .brand-logo .logo-text-secondary,
@@ -4223,7 +4284,8 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="midnight"] .brand-logo .logo-text-secondary,
 [data-theme="charcoal"] .brand-logo .logo-text-secondary,
 [data-theme="obsidian"] .brand-logo .logo-text-secondary,
-[data-theme="slate"] .brand-logo .logo-text-secondary {
+[data-theme="slate"] .brand-logo .logo-text-secondary,
+[data-theme="lightning"] .brand-logo .logo-text-secondary {
     fill: rgba(255, 255, 255, 0.92);
     filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.25))
             drop-shadow(0 1px 3px rgba(0, 0, 0, 0.35));
@@ -4247,6 +4309,14 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="slate"] .brand-logo .logo-bar {
     filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.15))
             drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
+}
+
+/* Lightning Theme - Electric-yellow glow on logo bar */
+[data-theme="lightning"] .logo-wordmark .logo-bar,
+[data-theme="lightning"] .brand-logo .logo-bar {
+    filter: drop-shadow(0 0 6px rgba(255, 235, 59, 0.55))
+            drop-shadow(0 0 12px rgba(64, 196, 255, 0.35))
+            drop-shadow(0 2px 4px rgba(0, 0, 0, 0.4));
 }
 
 /* Hover effects */

--- a/static/js/core/theme.js
+++ b/static/js/core/theme.js
@@ -122,6 +122,12 @@
             mode: 'dark',
             description: 'Blue-gray professional dark theme',
             builtin: true
+        },
+        'lightning': {
+            name: 'Lightning',
+            mode: 'dark',
+            description: 'Stormcloud sky with electric-yellow bolts and arc-blue plasma',
+            builtin: true
         }
     };
 


### PR DESCRIPTION
Stormcloud-dark backdrop (#0a1128) with a brilliant electric-yellow primary
and arc-blue secondary so the EAS branding really sells the "alert" feel.
fa-bolt icons get a subtle flicker animation (respects prefers-reduced-motion)
and the wordmark bar picks up a yellow/cyan glow while the theme is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new lightning theme featuring animated visual effects, including glowing effects on icons and custom logo styling with reduced-motion accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->