### PR TITLE
RBDS: preserve FIR filter state across chunks

### DIFF
--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -363,7 +363,7 @@ class RBDSWorker:
             self._rbds_bandpass = None
             logger.warning(
                 "RBDS: Sample rate %d Hz too low for 57 kHz subcarrier extraction (need >%d Hz). "
-                "RBDS decoding will not work.", 
+                "RBDS decoding will not work.",
                 self._sample_rate,
                 self.RBDS_MIN_SAMPLE_RATE
             )
@@ -371,6 +371,17 @@ class RBDSWorker:
         # Lowpass filter for post-mixing (removes aliases, keeps baseband RBDS at 0-7.5 kHz)
         # Design this at sample_rate since we mix BEFORE lowpass filtering
         self._rbds_lowpass = self._design_fir_lowpass(7500.0, self._sample_rate, taps=101)
+
+        # Filter delay-line state, preserved across _process_rbds calls. FIR
+        # filters implemented with np.convolve are stateless, so every chunk
+        # produced ~(N_taps - 1) samples of transient at its start. With
+        # 101-tap filters on 205-sample chunks the transient ate half the
+        # output, which looked like noise to the RBDS bit synchroniser. Using
+        # scipy.signal.lfilter with a persisted zi delay line eliminates the
+        # seam between consecutive chunks.
+        self._rbds_bandpass_zi: Optional[np.ndarray] = None
+        self._rbds_lowpass_zi_real: Optional[np.ndarray] = None
+        self._rbds_lowpass_zi_imag: Optional[np.ndarray] = None
 
         # CRITICAL: 19 kHz pilot extraction for phase-coherent demodulation
         # Redsea/GNU Radio architecture: Use pilot × 3 to generate 57 kHz carrier
@@ -701,8 +712,17 @@ class RBDSWorker:
 
         # Step 2: Bandpass filter to extract 57 kHz RBDS subcarrier (54-60 kHz)
         # CRITICAL: Do this BEFORE decimation that would remove the 57 kHz signal!
+        # Use lfilter with persisted state (zi) so the filter's delay line
+        # carries over from the previous chunk; np.convolve zeroes it every
+        # call, which produced (ntaps-1) samples of transient at the start of
+        # every chunk and flooded the bit-sync with garbage.
         if self._rbds_bandpass is not None and sample_rate >= self.RBDS_MIN_SAMPLE_RATE:
-            x = np.convolve(x, self._rbds_bandpass, mode='same')
+            from scipy import signal as scipy_signal
+            if self._rbds_bandpass_zi is None or len(self._rbds_bandpass_zi) != len(self._rbds_bandpass) - 1:
+                self._rbds_bandpass_zi = np.zeros(len(self._rbds_bandpass) - 1, dtype=x.dtype)
+            x, self._rbds_bandpass_zi = scipy_signal.lfilter(
+                self._rbds_bandpass, [1.0], x, zi=self._rbds_bandpass_zi
+            )
             time.sleep(0)  # Yield GIL
 
         # Step 3: Frequency shift to baseband using PILOT-DERIVED carrier
@@ -722,8 +742,22 @@ class RBDSWorker:
             self._carrier_phase_57k = (self._carrier_phase_57k + phase_increment * n) % (2.0 * np.pi)
         time.sleep(0)  # Yield GIL
 
-        # Step 3: Lowpass filter (7.5 kHz) to remove mixing artifacts and aliases
-        x = np.convolve(x, self._rbds_lowpass, mode='same')
+        # Step 3: Lowpass filter (7.5 kHz) to remove mixing artifacts and aliases.
+        # After the 57 kHz mix x is complex; lfilter keeps real delay lines per
+        # component, so filter the real and imaginary parts separately with
+        # their own persisted zi arrays.
+        from scipy import signal as scipy_signal
+        lp_state_len = len(self._rbds_lowpass) - 1
+        if self._rbds_lowpass_zi_real is None or len(self._rbds_lowpass_zi_real) != lp_state_len:
+            self._rbds_lowpass_zi_real = np.zeros(lp_state_len, dtype=np.float64)
+            self._rbds_lowpass_zi_imag = np.zeros(lp_state_len, dtype=np.float64)
+        real_out, self._rbds_lowpass_zi_real = scipy_signal.lfilter(
+            self._rbds_lowpass, [1.0], x.real, zi=self._rbds_lowpass_zi_real
+        )
+        imag_out, self._rbds_lowpass_zi_imag = scipy_signal.lfilter(
+            self._rbds_lowpass, [1.0], x.imag, zi=self._rbds_lowpass_zi_imag
+        )
+        x = real_out + 1j * imag_out
         time.sleep(0)  # Yield GIL
 
         # Step 4: Decimate to intermediate rate (~25 kHz) to reduce processing load


### PR DESCRIPTION
The 57 kHz bandpass and the post-mix 7.5 kHz lowpass were being applied with np.convolve(..., mode='same'), which is stateless. Each _process_rbds call ran the filter on ~10-20 ms of samples (205 or 410 at 19 kHz) with the delay line zeroed, producing roughly (ntaps-1) samples of transient at the start of every chunk. With 101-tap filters on 205-sample chunks, the transient swallowed almost half the output and the RBDS bit synchroniser saw noise.

Real-world symptom was sync thrashing: every ~1 s block the sync gate counted 45-50 bad blocks out of 50, declared SYNC LOST, presync immediately latched onto the next false block, and 50 blocks later the cycle repeated. A strong 97% stereo pilot produced only ~25 decoded groups in 22 minutes.

Switch to scipy.signal.lfilter with zi state that persists on the worker: one delay line for the real-valued bandpass, and two delay lines (real + imag) for the complex lowpass that runs after the 57 kHz mix. States are reinitialised by _init_rbds_state so frequency-change resets continue to work cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signal transients at chunk boundaries in RBDS demodulation, improving bit synchronization quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->