### PR TITLE
RBDS: accept PS on first read; allow RT to grow past a stale 0x0D

### DIFF
--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -2138,11 +2138,7 @@ class RBDSDecoder:
         self.clock_time_utc = None
         self.clock_time_local = None
         self._radio_text_ab = 0
-        # PS debounce: the 10-bit CRC lets through roughly 1-in-1024
-        # uncorrectable errors, so a single-pass accept occasionally
-        # flashes garbage. Only commit a PS character after seeing the
-        # same value at the same position in two consecutive broadcasts.
-        self._ps_tentative = [' '] * 8
+        self._rt_saw_cr_this_group = False
 
     def process_group(self, group_data: Tuple[int, int, int, int]) -> Optional[bool]:
         """
@@ -2220,7 +2216,13 @@ class RBDSDecoder:
             if ab_flag != self._radio_text_ab:
                 self._radio_text_ab = ab_flag
                 self.radio_text = [' '] * 64
+                self._radio_text_len = 64
                 changed = True
+            # Within this single group, any chars arriving after a 0x0D are
+            # the padding that fills the final segment. Track it so
+            # _update_radio_text can reject those without mistaking them
+            # for the station extending its RT in a later broadcast.
+            self._rt_saw_cr_this_group = False
 
             # RDS characters are 8-bit (Annex E of EN 50067 / Annex F of
             # NRSC-4). Masking to 0x7F strips the high bit and silently
@@ -2306,16 +2308,20 @@ class RBDSDecoder:
         )
 
     def _update_ps_name(self, address: int, chars: int) -> bool:
-        """Commit PS characters, debouncing only *replacements* of
-        already-displayed characters.
+        """Accept PS characters on first read.
 
-        The 10-bit CRC lets through roughly 1-in-1024 uncorrectable
-        errors, so a glitch that passed CRC could replace a correct
-        character with garbage. Requiring two consecutive identical
-        reads before *overwriting* prevents that. But an empty slot
-        has no value to protect, so we fill it immediately — otherwise
-        a clean signal needlessly waits one extra PS cycle before any
-        station name appears.
+        An earlier version required two consecutive identical reads to
+        overwrite a committed slot, as protection against CRC
+        pass-throughs (~1-in-1024 rate). But many US stations broadcast
+        *dynamic PS* that rotates among several 8-character strings
+        ("KISS-FM ", "Your-FM ", "103-5   ", a song title, a slogan).
+        Each rotation read differed from the previous tentative, so the
+        debounce never confirmed any of them — the displayed PS got
+        frozen at whatever happened to commit first (often from an
+        unstable early read) and never updated again. Accepting each
+        read immediately means the PS follows the rotation; the worst
+        case is a single-character flicker for one cycle if a block
+        happens to pass CRC despite corruption.
         """
         idx = address * 2
         updated = False
@@ -2325,40 +2331,33 @@ class RBDSDecoder:
             pos = idx + offset
             if pos >= len(self.ps_name):
                 continue
-            current = self.ps_name[pos]
-            if current == ' ':
-                # First observation at this slot: accept immediately.
-                if char != ' ':
-                    self.ps_name[pos] = char
-                    self._ps_tentative[pos] = char
-                    updated = True
-            elif current == char:
-                # Re-confirmation of the current value; keep tentative in sync.
-                self._ps_tentative[pos] = char
-            elif self._ps_tentative[pos] == char:
-                # Second consecutive read of a new value — commit the change.
+            if self.ps_name[pos] != char:
                 self.ps_name[pos] = char
                 updated = True
-            else:
-                # First read of a new value: stash it but don't display yet.
-                self._ps_tentative[pos] = char
         return updated
 
     def _update_radio_text(self, index: int, code: int) -> bool:
         if index >= len(self.radio_text):
             return False
-        # RDS spec: 0x0D (carriage return) terminates the Radio Text and
-        # everything beyond it is padding to fill out the final segment.
+        # RDS spec: 0x0D (carriage return) terminates the Radio Text.
+        # Everything that follows 0x0D *within the same group* is padding.
         if code == 0x0D:
+            self._rt_saw_cr_this_group = True
             if self._radio_text_len > index:
                 self._radio_text_len = index
                 return True
             return False
-        # Drop characters past a previously-seen terminator: they are
-        # padding and must not appear in the displayed text.
-        if index >= self._radio_text_len:
+        # Post-CR characters in this same group are padding → drop.
+        if self._rt_saw_cr_this_group and index >= self._radio_text_len:
             return False
         char = chr(code) if 32 <= code < 127 else ' '
+        # A later group writing past the current terminator with a
+        # non-space character means the station extended its RT without
+        # re-sending the terminator — push the visible length back out.
+        if index >= self._radio_text_len:
+            if char == ' ':
+                return False
+            self._radio_text_len = min(64, index + 1)
         if self.radio_text[index] != char:
             self.radio_text[index] = char
             return True

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -377,27 +377,58 @@ def test_ps_name_fills_empty_slots_immediately():
     assert decoder.get_current_data().ps_name == "XY"
 
 
-def test_ps_name_debounces_replacements():
-    """Once a slot is displayed, a single conflicting read must NOT
-    overwrite it; replacement requires two consecutive identical reads.
+def test_ps_name_follows_dynamic_ps_rotation():
+    """Dynamic PS (rotating through multiple 8-char strings) must be
+    reflected immediately, not stuck on whatever committed first.
 
-    This is the rare case (~1-in-1024 per block) where an uncorrected
-    CRC pass-through would flash a wrong character; we don't want that
-    visible.
+    Many US CHR stations alternate PS among 'KISS-FM ', 'Your-FM ',
+    slogans, song titles, etc. A prior version of the decoder required
+    two consecutive identical reads to commit a change, which meant an
+    A→B→A→B rotation's tentative buffer kept flipping and never
+    confirmed either — the displayed PS froze on the first value seen.
     """
     decoder = RBDSDecoder()
     b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0x00)
-    # Fill the slot with "XY"
-    decoder.process_group((0x5862, b, 0x0000, (ord("X") << 8) | ord("Y")))
-    assert decoder.get_current_data().ps_name == "XY"
+    # Initial commit
+    decoder.process_group((0x5862, b, 0x0000, (ord("Y") << 8) | ord("o")))
+    assert decoder.ps_name[0] == "Y"
+    # Station rotates to a different PS — must update on first read
+    decoder.process_group((0x5862, b, 0x0000, (ord("K") << 8) | ord("I")))
+    assert decoder.ps_name[0] == "K", f"rotation blocked: {decoder.ps_name[0]}"
+    # Rotate back — also immediate
+    decoder.process_group((0x5862, b, 0x0000, (ord("Y") << 8) | ord("o")))
+    assert decoder.ps_name[0] == "Y"
 
-    # Single spurious read of "Z" must NOT replace X
-    decoder.process_group((0x5862, b, 0x0000, (ord("Z") << 8) | ord("Y")))
-    assert decoder.get_current_data().ps_name == "XY"
 
-    # Second consecutive "Z" confirms the change
-    decoder.process_group((0x5862, b, 0x0000, (ord("Z") << 8) | ord("Y")))
-    assert decoder.get_current_data().ps_name == "ZY"
+def test_radio_text_grows_when_station_extends_without_cr():
+    """Some stations change their RT without re-sending 0x0D or toggling
+    the A/B flag; the decoder must let the visible length grow back out
+    when non-space characters arrive past the current terminator.
+    """
+    decoder = RBDSDecoder()
+    b0 = _pack_block_b(group_type=2, version_b=False, tp=False, pty=0, low_bits=0x00)
+    # Initial RT: "Hi!\r"  → terminator at 3
+    decoder.process_group((0x5862, b0, (ord("H") << 8) | ord("i"), (ord("!") << 8) | 0x0D))
+    assert decoder.get_current_data().radio_text == "Hi!"
+
+    # Station re-broadcasts segment 0 with a space in place of the CR,
+    # then fills segment 1 with "Worl" — the RT should grow back out.
+    decoder.process_group((0x5862, b0, (ord("H") << 8) | ord("i"), (ord("!") << 8) | ord(" ")))
+    b1 = _pack_block_b(group_type=2, version_b=False, tp=False, pty=0, low_bits=0x01)
+    decoder.process_group((0x5862, b1, (ord("W") << 8) | ord("o"), (ord("r") << 8) | ord("l")))
+    assert decoder.get_current_data().radio_text == "Hi! Worl"
+
+
+def test_radio_text_drops_padding_past_terminator():
+    """Spaces (padding) arriving in a later segment past a terminator
+    must not extend the RT — only real non-space content should.
+    """
+    decoder = RBDSDecoder()
+    b0 = _pack_block_b(group_type=2, version_b=False, tp=False, pty=0, low_bits=0x00)
+    decoder.process_group((0x5862, b0, (ord("H") << 8) | ord("i"), (ord("!") << 8) | 0x0D))
+    b1 = _pack_block_b(group_type=2, version_b=False, tp=False, pty=0, low_bits=0x01)
+    decoder.process_group((0x5862, b1, (ord(" ") << 8) | ord(" "), (ord(" ") << 8) | ord(" ")))
+    assert decoder.get_current_data().radio_text == "Hi!"
 
 
 def test_radio_text_trims_at_carriage_return():


### PR DESCRIPTION
Two user-visible freezes driven by overly strict post-CRC filtering:

1. PS never updated on dynamic-PS stations. The previous two-read debounce required two consecutive identical reads at the same position before committing; a rotation of ("KISS-FM ", "Your-FM ", ...) never confirmed any value because each read differed from the previous tentative. The UI froze on whatever committed first.

   Accept every PS character on first read. The 10-bit block CRC already filters ~99.9% of corruptions; a rare single-char flicker is vastly preferable to a PS that never updates.

2. Radio Text froze at whatever length the first 0x0D terminator had produced. Stations that change their RT without re-sending a CR got stuck at the old length because the terminator only moved inward.

   Allow the terminator to move back out when a non-space character arrives past it, while keeping CR within the same group strictly terminating (so padding after the CR in its own segment is still dropped). Tracked by a per-group _rt_saw_cr_this_group flag that resets at the top of every Group 2 process_group call.

Tests updated: the old ps-debounce test is replaced by a dynamic-PS rotation test; two new RT tests cover the extension-past-terminator path and the padding-drop path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Program Service (PS) name display responsiveness with immediate updates.
  * Enhanced Radio Text (RT) handling to better manage line breaks and padding, preventing erroneous display characters and allowing the visible text area to expand when new content arrives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->