### PR TITLE
RBDS: cycle-consistent PS assembly; RT no longer grows past CR; decoder heartbeat

### DIFF
--- a/app_core/audio/redis_sdr_adapter.py
+++ b/app_core/audio/redis_sdr_adapter.py
@@ -504,9 +504,18 @@ class RedisSDRSourceAdapter(AudioSourceAdapter):
                     self.metrics.metadata['rbds_di_dynamic_pty'] = rbds.di_dynamic_pty
                     self.metrics.metadata['rbds_clock_time_utc'] = rbds.clock_time_utc
                     self.metrics.metadata['rbds_clock_time_local'] = rbds.clock_time_local
-                    # Only bump timestamp when the decoded content actually changed
+                    # rbds_last_seen advances every time we observe a decoded
+                    # group, even if the content is identical to the last one.
+                    # This is the "decoder is alive" heartbeat: it lets the
+                    # UI distinguish "station is just playing stable content"
+                    # from "sync died and we're showing stale data".
+                    now = time.time()
+                    self.metrics.metadata['rbds_last_seen'] = now
+                    # rbds_last_updated only advances when decoded content
+                    # actually changes — this is the "content freshness" time
+                    # the user cares about for RT / PS rotation.
                     if signature != self._rbds_signature:
-                        self.metrics.metadata['rbds_last_updated'] = time.time()
+                        self.metrics.metadata['rbds_last_updated'] = now
                         self._rbds_signature = signature
                         logger.debug(
                             f"RBDS data updated: PS={rbds.ps_name}, "

--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -2139,6 +2139,25 @@ class RBDSDecoder:
         self.clock_time_local = None
         self._radio_text_ab = 0
         self._rt_saw_cr_this_group = False
+        # Dynamic-PS cycle assembly. Stations that rotate multiple
+        # 8-char PS strings send them one after another in complete
+        # cycles of 4 segments (addresses 0..3). To avoid displaying
+        # Frankenstein blends of two strings, accumulate segments into
+        # a staging buffer and only copy to the visible ps_name once a
+        # full self-consistent cycle has been observed. If a segment
+        # contradicts a previously-seen address in the current cycle,
+        # the station has begun a new PS and we discard the stale
+        # staging data and start over with the new content.
+        self._ps_pending = [' '] * 8
+        self._ps_pending_mask = 0
+        # Candidate PS (last *fully observed* cycle) and how many times
+        # it has repeated. A candidate only promotes to ps_name after
+        # being observed twice in a row, which prevents Frankenstein
+        # blends (one segment from string A + one from string B
+        # interleaving across four unique addresses would otherwise
+        # look like a valid cycle).
+        self._ps_candidate = None  # type: Optional[str]
+        self._ps_candidate_count = 0
 
     def process_group(self, group_data: Tuple[int, int, int, int]) -> Optional[bool]:
         """
@@ -2308,31 +2327,70 @@ class RBDSDecoder:
         )
 
     def _update_ps_name(self, address: int, chars: int) -> bool:
-        """Accept PS characters on first read.
+        """Stage PS segments into a pending buffer, display once a full
+        4-segment cycle has been observed as self-consistent.
 
-        An earlier version required two consecutive identical reads to
-        overwrite a committed slot, as protection against CRC
-        pass-throughs (~1-in-1024 rate). But many US stations broadcast
-        *dynamic PS* that rotates among several 8-character strings
-        ("KISS-FM ", "Your-FM ", "103-5   ", a song title, a slogan).
-        Each rotation read differed from the previous tentative, so the
-        debounce never confirmed any of them — the displayed PS got
-        frozen at whatever happened to commit first (often from an
-        unstable early read) and never updated again. Accepting each
-        read immediately means the PS follows the rotation; the worst
-        case is a single-character flicker for one cycle if a block
-        happens to pass CRC despite corruption.
+        Stations that broadcast *dynamic PS* rotate through multiple
+        8-char strings ("KISS-FM ", station slogan, song title, ...) by
+        sending each one as a complete cycle of four segments (address
+        0..3). If we committed each segment the moment it arrived, the
+        displayed PS would blend bytes from two different strings
+        whenever segments from different rotation slots interleaved —
+        "93.9 FM " and "Kiss-FM " can end up rendered as "93si-FM ".
+
+        Approach: keep a pending 8-char buffer and a 4-bit 'segments
+        seen' mask. When a new segment arrives at an address that was
+        already set in the current cycle:
+          - If its content matches what we already staged → keep going.
+          - Otherwise → the station started broadcasting a new PS;
+            discard staging and restart with just this segment.
+        When all four segments of a single cycle have been seen
+        consistently, copy pending to the visible ps_name.
         """
         idx = address * 2
+        chars_pair = [
+            chr((chars >> 8) & 0xFF) if 32 <= ((chars >> 8) & 0xFF) < 127 else ' ',
+            chr(chars & 0xFF) if 32 <= (chars & 0xFF) < 127 else ' ',
+        ]
+        bit = 1 << address
+        if self._ps_pending_mask & bit:
+            # Already staged this segment in the current cycle — is it
+            # still the same string?
+            if (self._ps_pending[idx] != chars_pair[0] or
+                    self._ps_pending[idx + 1] != chars_pair[1]):
+                # Station has started broadcasting a different PS.
+                # Discard staging and restart with just this segment.
+                self._ps_pending = [' '] * 8
+                self._ps_pending_mask = 0
+        self._ps_pending[idx] = chars_pair[0]
+        self._ps_pending[idx + 1] = chars_pair[1]
+        self._ps_pending_mask |= bit
+
+        if self._ps_pending_mask != 0xF:
+            return False
+        # A full cycle has been observed. Don't promote yet — require a
+        # second identical cycle to commit, which filters out blended
+        # mixes of two different rotation strings (the four segments
+        # from A and B can interleave without conflict because each
+        # address appears only once per cycle, so "no conflict" alone
+        # isn't enough evidence that the 8 chars all came from the
+        # same PS string).
+        candidate = ''.join(self._ps_pending)
+        if candidate == self._ps_candidate:
+            self._ps_candidate_count += 1
+        else:
+            self._ps_candidate = candidate
+            self._ps_candidate_count = 1
+        # Start a fresh pending cycle for the next 4 segments.
+        self._ps_pending = [' '] * 8
+        self._ps_pending_mask = 0
+        if self._ps_candidate_count < 2:
+            return False
+        # Two consecutive identical cycles — promote to the visible PS.
         updated = False
-        for offset in range(2):
-            char_code = (chars >> (8 * (1 - offset))) & 0xFF
-            char = chr(char_code) if 32 <= char_code < 127 else ' '
-            pos = idx + offset
-            if pos >= len(self.ps_name):
-                continue
-            if self.ps_name[pos] != char:
-                self.ps_name[pos] = char
+        for i, ch in enumerate(candidate):
+            if self.ps_name[i] != ch:
+                self.ps_name[i] = ch
                 updated = True
         return updated
 
@@ -2351,13 +2409,16 @@ class RBDSDecoder:
         if self._rt_saw_cr_this_group and index >= self._radio_text_len:
             return False
         char = chr(code) if 32 <= code < 127 else ' '
-        # A later group writing past the current terminator with a
-        # non-space character means the station extended its RT without
-        # re-sending the terminator — push the visible length back out.
+        # Characters past the current terminator are padding by default.
+        # An earlier pass extended the length on any non-space byte, but
+        # that let a single CRC-lucky garbage byte drag trailing junk
+        # into the displayed RT ("93.9 KISS-FM ... )["). Always drop
+        # past-terminator writes — when the station changes RT it should
+        # toggle the A/B flag (which clears everything) or re-send a
+        # later CR (which moves the terminator accordingly). This is
+        # conservative but matches how car receivers behave.
         if index >= self._radio_text_len:
-            if char == ' ':
-                return False
-            self._radio_text_len = min(64, index + 1)
+            return False
         if self.radio_text[index] != char:
             self.radio_text[index] = char
             return True

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -1051,11 +1051,18 @@ function renderAudioSources(fullRender = true) {
                                         ` : ''}
                                     ` : ''}
 
-                                    ${source.metrics.metadata.rbds_last_updated ? `
+                                    ${(source.metrics.metadata.rbds_last_updated || source.metrics.metadata.rbds_last_seen) ? `
                                         <hr class="my-2">
-                                        <small class="text-muted">
-                                            <i class="fas fa-clock"></i> Last updated: ${new Date(source.metrics.metadata.rbds_last_updated * 1000).toLocaleTimeString()}
-                                        </small>
+                                        ${source.metrics.metadata.rbds_last_seen ? `
+                                            <small class="text-muted d-block">
+                                                <i class="fas fa-satellite-dish"></i> Decoder last saw a group: ${new Date(source.metrics.metadata.rbds_last_seen * 1000).toLocaleTimeString()}
+                                            </small>
+                                        ` : ''}
+                                        ${source.metrics.metadata.rbds_last_updated ? `
+                                            <small class="text-muted d-block">
+                                                <i class="fas fa-clock"></i> Content last changed: ${new Date(source.metrics.metadata.rbds_last_updated * 1000).toLocaleTimeString()}
+                                            </small>
+                                        ` : ''}
                                     ` : ''}
                                 </div>
                             </div>

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -181,16 +181,20 @@ def test_group_0a_decodes_ta_ms_and_ps():
 
     # segment 0, TA=1, MS=1, DI=0 → low 5 bits = 0b11000 = 0x18
     b = _pack_block_b(group_type=0, version_b=False, tp=True, pty=5, low_bits=0x18)
-    # block D carries the two PS chars "EA"
     decoder.process_group((pi, b, 0x0000, (ord("E") << 8) | ord("A")))
 
+    # The flags read from any Group 0 land immediately.
     data = decoder.get_current_data()
     assert data.pi_code == "4FB5"
     assert data.pty == 5
     assert data.tp is True
     assert data.ta is True
     assert data.ms is True
-    assert data.ps_name.startswith("EA")
+
+    # PS only commits after a full self-consistent cycle has been
+    # confirmed twice (see test_ps_name_requires_two_identical_cycles),
+    # so after a single segment the visible PS is still blank.
+    assert data.ps_name == ""
 
 
 def test_group_2_does_not_clobber_ta_ms():
@@ -364,40 +368,64 @@ def test_decoder_di_bits_from_group_0():
     assert data.di_stereo is True         # address 3
 
 
-def test_ps_name_fills_empty_slots_immediately():
-    """Filling a still-blank PS slot must be instant — no debounce delay.
+def _send_ps_cycle(decoder, text: str, pi: int = 0x5862) -> None:
+    """Send a complete PS cycle (all 4 segments of an 8-char PS)."""
+    assert len(text) == 8
+    for seg in range(4):
+        b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=seg)
+        c1, c2 = text[seg * 2], text[seg * 2 + 1]
+        decoder.process_group((pi, b, 0x0000, (ord(c1) << 8) | ord(c2)))
 
-    There's no prior value worth protecting, and delaying the first
-    display by a whole PS cycle made time-to-first-station-name feel
-    noticeably slow on clean signals.
+
+def test_ps_name_requires_two_identical_cycles():
+    """PS commits only after two consecutive identical full cycles.
+
+    This debounces the 'Frankenstein blend' failure mode where four
+    segments from two different rotating PS strings interleave across
+    four distinct addresses (no per-segment conflict to catch) and
+    spell out 8 chars that were never broadcast together.
     """
     decoder = RBDSDecoder()
-    b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0x00)
-    decoder.process_group((0x5862, b, 0x0000, (ord("X") << 8) | ord("Y")))
-    assert decoder.get_current_data().ps_name == "XY"
+    _send_ps_cycle(decoder, "KISS-FM ")
+    assert "".join(decoder.ps_name) == " " * 8, "first cycle must not commit"
+    _send_ps_cycle(decoder, "KISS-FM ")
+    assert "".join(decoder.ps_name) == "KISS-FM "
 
 
 def test_ps_name_follows_dynamic_ps_rotation():
-    """Dynamic PS (rotating through multiple 8-char strings) must be
-    reflected immediately, not stuck on whatever committed first.
+    """Rotating PS transitions cleanly once each new string repeats."""
+    decoder = RBDSDecoder()
+    for _ in range(2):
+        _send_ps_cycle(decoder, "KISS-FM ")
+    assert "".join(decoder.ps_name) == "KISS-FM "
 
-    Many US CHR stations alternate PS among 'KISS-FM ', 'Your-FM ',
-    slogans, song titles, etc. A prior version of the decoder required
-    two consecutive identical reads to commit a change, which meant an
-    A→B→A→B rotation's tentative buffer kept flipping and never
-    confirmed either — the displayed PS froze on the first value seen.
+    # One rotation to a different string doesn't update yet — candidate
+    # needs confirmation.
+    _send_ps_cycle(decoder, "93-9 FM ")
+    assert "".join(decoder.ps_name) == "KISS-FM "
+    # The station's next cycle of '93-9 FM ' confirms it.
+    _send_ps_cycle(decoder, "93-9 FM ")
+    assert "".join(decoder.ps_name) == "93-9 FM "
+
+
+def test_ps_name_rejects_single_blended_cycle():
+    """A single cycle built from segments of two different PS strings
+    must not commit — the four-address blend could decode any plausible
+    8 chars and would corrupt the display.
     """
     decoder = RBDSDecoder()
-    b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0x00)
-    # Initial commit
-    decoder.process_group((0x5862, b, 0x0000, (ord("Y") << 8) | ord("o")))
-    assert decoder.ps_name[0] == "Y"
-    # Station rotates to a different PS — must update on first read
-    decoder.process_group((0x5862, b, 0x0000, (ord("K") << 8) | ord("I")))
-    assert decoder.ps_name[0] == "K", f"rotation blocked: {decoder.ps_name[0]}"
-    # Rotate back — also immediate
-    decoder.process_group((0x5862, b, 0x0000, (ord("Y") << 8) | ord("o")))
-    assert decoder.ps_name[0] == "Y"
+    for _ in range(2):
+        _send_ps_cycle(decoder, "KISS-FM ")
+    assert "".join(decoder.ps_name) == "KISS-FM "
+
+    # One cycle's worth of segments, each drawn from a different PS.
+    # "K", "I" from 'KISS-FM ', "-", "9" from '93-9 FM ', " ", "F"
+    # from '93-9 FM ', "M", " " from 'KISS-FM '.
+    for seg, pair in enumerate([("K", "I"), ("-", "9"), (" ", "F"), ("M", " ")]):
+        b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=seg)
+        decoder.process_group((0x5862, b, 0x0000, (ord(pair[0]) << 8) | ord(pair[1])))
+    assert "".join(decoder.ps_name) == "KISS-FM ", \
+        f"blended cycle committed: {decoder.ps_name}"
 
 
 def test_radio_text_grows_when_station_extends_without_cr():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed corrupted Program Service name displays during rotating broadcasts
  * Prevented invalid Radio Text data from corrupting the display with garbage characters
  * Improved RBDS timestamp precision for last-detected vs. last-changed tracking

* **New Features**
  * Added dual-status timestamp display for RBDS showing when data was last received and when content last changed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->