### PR TITLE
Fix lightning theme readability and footer color

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -907,6 +907,68 @@
     color: #0d1b2a;
 }
 
+/* Lightning Theme - .bg-light surfaces
+   --light-color resolves to pale yellow (#fff9c4) in this theme. Components
+   that declare their own text color (.metric-value, .metric-label, etc.)
+   beat the low-specificity `.bg-light * { color: inherit }` rule and render
+   cream-on-yellow, which is unreadable. Force dark text on any descendant
+   of a .bg-light region so those overrides lose. */
+[data-theme="lightning"] .bg-light,
+[data-theme="lightning"] .bg-light *,
+[data-theme="lightning"] .card-header.bg-light,
+[data-theme="lightning"] .card-header.bg-light * {
+    color: #0d1b2a !important;
+    text-shadow: none;
+}
+
+[data-theme="lightning"] .bg-light .text-muted,
+[data-theme="lightning"] .card-header.bg-light .text-muted {
+    color: #3a4d7a !important;
+}
+
+/* Lightning Theme - Navbar opacity
+   The default navbar mixes its gradient with 15-20% transparency. Combined
+   with the bright yellow body gradient of this theme, page content scrolls
+   visibly through the sticky navbar. Opaque gradient + stronger shadow
+   keeps the header readable. */
+[data-theme="lightning"] .navbar {
+    background: linear-gradient(135deg,
+        #1a2342 0%,
+        #2a1f4a 50%,
+        #162848 100%) !important;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-bottom: 1px solid rgba(255, 235, 59, 0.25);
+}
+
+[data-theme="lightning"] .navbar.scrolled {
+    background: linear-gradient(135deg,
+        #141c38 0%,
+        #241a42 50%,
+        #10203e 100%) !important;
+}
+
+/* Lightning Theme - Footer palette
+   Default footer fades from --primary-color (yellow) to --secondary-color
+   (cyan), producing a large saturated yellow band at the bottom of every
+   page. Replace with a deep-storm gradient so the footer reads as part of
+   the night sky instead of a giant highlight block. */
+[data-theme="lightning"] footer {
+    background: linear-gradient(135deg,
+        #0a1128 0%,
+        #132047 50%,
+        #0a1128 100%);
+    color: var(--text-color);
+}
+
+[data-theme="lightning"] footer a {
+    color: rgba(255, 253, 231, 0.85);
+}
+
+[data-theme="lightning"] footer a:hover {
+    color: var(--primary-color);
+}
+
 /* Lightning Theme - Atmospheric storm overlay.
    static/js/core/lightning.js drives the timing and injects fresh SVG bolts
    per strike. The CSS here does the heavy lifting for the *look*: stacked


### PR DESCRIPTION
The lightning theme rendered unreadable in three places:

- .bg-light surfaces (e.g. metric cards on the audio monitoring page)
  resolved to pale yellow (#fff9c4). Components that declare their own
  colors (.metric-value, .metric-label) beat the low-specificity
  .bg-light * { color: inherit } rule and rendered cream-on-yellow.
  Add a theme-scoped override with !important so descendant text stays
  dark on the pale surface.

- The navbar uses a semi-transparent indigo gradient. Under this theme's
  yellow body tint, page content scrolled visibly through the sticky
  header, which read as overlapping text. Swap to an opaque storm
  gradient and drop the backdrop-filter.

- The footer's default gradient runs from --primary-color to
  --secondary-color, which in this theme is yellow to cyan. The result
  was a large saturated yellow band at the bottom of every page that
  looked like wasted whitespace. Replace with a deep-storm gradient so
  the footer belongs to the night sky.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text readability on light-colored backgrounds with enhanced contrast and removal of visual shadows for clearer component display.
  * Updated navigation bar styling with a new opaque dark gradient background and refined scrolling state appearance.
  * Redesigned footer with a new dark gradient color palette, including enhanced link colors and improved hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->