### PR TITLE
Lay out navbar brand group as a single row

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1226,6 +1226,77 @@ small,
     width: auto;
 }
 
+/* Brand + status indicators row — keep on a single line next to the logo */
+.navbar-brand-group {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.navbar-brand-group .navbar-brand {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0;
+}
+
+/* System health pill — match the visual weight of the WS indicator */
+.health-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 0.7rem;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.04em;
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    white-space: nowrap;
+    cursor: default;
+    flex-shrink: 0;
+}
+
+.health-indicator .health-label {
+    text-transform: uppercase;
+    opacity: 0.7;
+    font-size: 0.65rem;
+}
+
+.health-indicator .health-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--text-muted);
+}
+
+.health-indicator .health-dot.health-good {
+    background: #2eb08d;
+    box-shadow: 0 0 6px rgba(46, 176, 141, 0.6);
+}
+.health-indicator .health-dot.health-warning {
+    background: #f6b968;
+    box-shadow: 0 0 6px rgba(246, 185, 104, 0.6);
+}
+.health-indicator .health-dot.health-danger {
+    background: #ef5a5a;
+    box-shadow: 0 0 6px rgba(239, 90, 90, 0.6);
+}
+
+/* Hide the noisier indicators on narrow screens to keep navbar single-row */
+@media (max-width: 991.98px) {
+    .health-indicator .health-label,
+    .health-indicator .health-text {
+        display: none;
+    }
+    .sl-tower {
+        display: none;
+    }
+}
+
 /* Hide duplicate footer logo */
 .footer .footer-brand .footer-logo {
     display: none;


### PR DESCRIPTION
The navbar was rendering as 4 stacked rows (logo, status pill, live pill, stack-light tower) because .navbar-brand-group and .health-indicator had no CSS — they fell back to block layout. Adds flex layout for the brand group, pill styling for the system health indicator, and a media query that drops the health label and stack light below the lg breakpoint so the navbar stays on one row on narrower viewports.

https://claude.ai/code/session_01Bw2Po6xzSAN1hsRqQHQr7A