### PR TITLE
Cache-bust styles.css with static_asset_version

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
     <link href="{{ url_for('static', filename='vendor/fontawesome/css/all.min.css') }}" rel="stylesheet">
 
     <!-- EAS Station Styles (Consolidated) -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}?v={{ static_asset_version }}">
 
     <script>
         window.CSRF_TOKEN = {{ csrf_token | tojson }};


### PR DESCRIPTION
The navbar layout fixes weren't reaching the browser because styles.css was being served without a version query string, so the browser kept returning the cached copy from before the layout change. Appends ?v={{ static_asset_version }} to force a fresh fetch when the version bumps.

https://claude.ai/code/session_01Bw2Po6xzSAN1hsRqQHQr7A