### PR TITLE
RBDS: filter legacy stringified None from API response

### DIFF
--- a/app_core/audio/worker_coordinator_redis.py
+++ b/app_core/audio/worker_coordinator_redis.py
@@ -361,8 +361,20 @@ def read_shared_metrics() -> Optional[Dict[str, Any]]:
                     metrics[decoded_key] = json.loads(decoded_value)
                 except json.JSONDecodeError:
                     # Legacy entries written before the type-preserving fix
-                    # are plain strings; keep them as-is.
-                    metrics[decoded_key] = decoded_value
+                    # are plain strings — including the literal "None",
+                    # "True", "False" produced when redis-py stringified
+                    # Python scalars via str().  Without this normalization
+                    # those leak to the audio monitor UI as truthy strings
+                    # ("PS: None", phantom "Yes" badges) until the master
+                    # rewrites every key.
+                    if decoded_value == "None":
+                        metrics[decoded_key] = None
+                    elif decoded_value == "True":
+                        metrics[decoded_key] = True
+                    elif decoded_value == "False":
+                        metrics[decoded_key] = False
+                    else:
+                        metrics[decoded_key] = decoded_value
             else:
                 metrics[decoded_key] = decoded_value
 

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -384,9 +384,12 @@
     position: relative;
     height: 10px;
     border-radius: 5px;
+    /* Reference gradient (red weak → green strong) sits at full strength
+       so the fill below renders at its real opacity.  Putting opacity on
+       the track itself dimmed the fill too, which made an "Excellent"
+       reading visually look like an empty bar. */
     background: linear-gradient(90deg, var(--danger-color) 0%, var(--warning-color) 40%, var(--success-color) 70%);
     overflow: hidden;
-    opacity: 0.35;
 }
 
 .rssi-fill {
@@ -395,9 +398,13 @@
     top: 0;
     bottom: 0;
     width: 0%;
-    background: rgba(255, 255, 255, 0.0);
-    border-right: 2px solid rgba(255, 255, 255, 0.85);
-    box-shadow: 0 0 6px rgba(255,255,255,0.45);
+    /* Same translucent-white treatment as .vu-fill: a visible bar that
+       grows from the left, letting the underlying gradient still hint at
+       weak/strong zones.  The previous fully-transparent background plus
+       a 2px right-edge marker was invisible at 100% fill (clipped by
+       overflow:hidden) and barely visible elsewhere. */
+    background: rgba(255, 255, 255, 0.75);
+    box-shadow: 0 0 6px rgba(255,255,255,0.4);
     transition: width 0.2s ease-out;
 }
 

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -545,6 +545,18 @@ function updateMetricsOnly() {
                 rmsLabel.textContent = `RMS: ${formatDbLabel(source.metrics.rms_level_db)}`;
             }
 
+            // The big PEAK/RMS cards below the bar read the same field but
+            // were only painted at full-render time, so they drifted behind
+            // the bar label.  Keep them in lockstep here.
+            const peakCard = document.getElementById(`peak-card-${safeId}`);
+            const rmsCard = document.getElementById(`rms-card-${safeId}`);
+            if (peakCard) {
+                peakCard.textContent = formatDbCard(source.metrics.peak_level_db);
+            }
+            if (rmsCard) {
+                rmsCard.textContent = formatDbCard(source.metrics.rms_level_db);
+            }
+
             // RF RSSI meter live update (polling-fallback path).
             const rfSignal = source.metrics?.metadata?.rf_signal_strength;
             if (typeof rfSignal === 'number' && Number.isFinite(rfSignal)) {
@@ -675,11 +687,11 @@ function renderAudioSources(fullRender = true) {
                         <div class="metrics-grid">
                             <div class="metric-item">
                                 <div class="metric-label">Peak</div>
-                                <div class="metric-value">${typeof source.metrics.peak_level_db === 'number' ? source.metrics.peak_level_db.toFixed(1) : '--'} dB</div>
+                                <div class="metric-value" id="peak-card-${safeId}">${formatDbCard(source.metrics.peak_level_db)}</div>
                             </div>
                             <div class="metric-item">
                                 <div class="metric-label">RMS</div>
-                                <div class="metric-value">${typeof source.metrics.rms_level_db === 'number' ? source.metrics.rms_level_db.toFixed(1) : '--'} dB</div>
+                                <div class="metric-value" id="rms-card-${safeId}">${formatDbCard(source.metrics.rms_level_db)}</div>
                             </div>
                             <div class="metric-item">
                                 <div class="metric-label">Sample Rate</div>
@@ -1132,6 +1144,16 @@ function formatDbLabel(value) {
         return '-- dBFS';
     }
     return `${value.toFixed(1)} dBFS`;
+}
+
+// Same numeric format as formatDbLabel but with the bare " dB" suffix used
+// inside the metric cards.  Kept identical to its inline counterpart so the
+// bar label and the card never disagree on a digit.
+function formatDbCard(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return '-- dB';
+    }
+    return `${value.toFixed(1)} dB`;
 }
 
 function calculateFillWidth(value) {
@@ -1913,6 +1935,17 @@ function updateLevelMetersFromSnapshot(snapshot) {
         }
         if (rmsLabel) {
             rmsLabel.textContent = `RMS: ${formatDbLabel(metric.rms_level_db)}`;
+        }
+
+        // Mirror the raw measurements into the PEAK/RMS cards so they
+        // always agree with the bar label above (broadcast path).
+        const peakCard = document.getElementById(`peak-card-${safeId}`);
+        const rmsCard = document.getElementById(`rms-card-${safeId}`);
+        if (peakCard) {
+            peakCard.textContent = formatDbCard(metric.peak_level_db);
+        }
+        if (rmsCard) {
+            rmsCard.textContent = formatDbCard(metric.rms_level_db);
         }
 
         // RF RSSI meter - updates every broadcast when the demodulator reports

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -920,10 +920,41 @@ function renderAudioSources(fullRender = true) {
                                         </div>
                                     ` : ''}
                                     
-                                    ${source.metrics.metadata.rbds_ps_name || source.metrics.metadata.rbds_pi_code || source.metrics.metadata.rbds_pty !== undefined ? `
-                                        <hr class="my-2">
-                                        <div class="text-muted mb-1"><strong>RBDS/RDS Metadata</strong></div>
-                                    ` : ''}
+                                    ${(() => {
+                                        const md = source.metrics.metadata;
+                                        const lockState = md.rbds_lock_state;
+                                        const hasDecoded = md.rbds_ps_name || md.rbds_pi_code
+                                            || (md.rbds_pty !== undefined && md.rbds_pty !== null)
+                                            || md.rbds_radio_text || md.rbds_pty_name
+                                            || md.rbds_clock_time_local || md.rbds_clock_time_utc;
+                                        // Show the section whenever the source is RBDS-capable
+                                        // (LOCKING / LOCKED) so users aren't left guessing whether
+                                        // the empty space means "no transmission" or "still
+                                        // acquiring sync".  UNAVAILABLE means non-FM modulation,
+                                        // for which no section is appropriate.
+                                        if (!hasDecoded && lockState !== 'LOCKING' && lockState !== 'LOCKED') {
+                                            return '';
+                                        }
+                                        let badge = '';
+                                        if (lockState === 'LOCKED') {
+                                            badge = '<span class="badge bg-success ms-2"><i class="fas fa-check-circle"></i> Locked</span>';
+                                        } else if (lockState === 'LOCKING') {
+                                            badge = '<span class="badge bg-warning text-dark ms-2"><i class="fas fa-sync fa-spin"></i> Acquiring sync…</span>';
+                                        }
+                                        const hint = !hasDecoded
+                                            ? (lockState === 'LOCKED'
+                                                ? '<div class="text-muted small fst-italic mb-1">Decoder locked — waiting for the station to transmit RBDS groups.</div>'
+                                                : '<div class="text-muted small fst-italic mb-1">Decoder is acquiring sync; PS/PI/RT will appear once enough valid groups arrive.</div>')
+                                            : '';
+                                        return `
+                                            <hr class="my-2">
+                                            <div class="d-flex justify-content-between align-items-center mb-1">
+                                                <strong class="text-muted">RBDS/RDS Metadata</strong>
+                                                ${badge}
+                                            </div>
+                                            ${hint}
+                                        `;
+                                    })()}
                                     
                                     ${source.metrics.metadata.rbds_ps_name ? `
                                         <div class="d-flex justify-content-between mb-1">

--- a/webapp/admin/audio_ingest.py
+++ b/webapp/admin/audio_ingest.py
@@ -841,6 +841,15 @@ def _sanitize_metadata_value(value: Any) -> Any:
     if value is None:
         return None
 
+    # Treat the literal string "None" as missing.  AudioSourceMetrics rows
+    # written before the Redis scalar round-trip fix (commit 44162d8) stored
+    # Python None as the JSON string "None" in the source_metadata JSONB
+    # column, and that value still leaks through _merge_metadata as a truthy
+    # string — rendering "Station Name (PS): None", "PI: None" etc. in the
+    # audio monitor instead of hiding those rows.
+    if isinstance(value, str) and value == "None":
+        return None
+
     if isinstance(value, (str, int)):
         return value
 


### PR DESCRIPTION
Stations whose RBDS state was written by pre-44162d8 code stored Python
None as the literal string "None" in Redis hashes (and the same shape
shows up in AudioSourceMetrics.source_metadata JSONB rows).  The audio
monitor template treats any truthy string as a real value to render,
so legacy state was producing "Station Name (PS): None", "PI: None",
"PTY: None (None)" labels alongside fields decoded by the current
master — the contradiction users saw versus their car radio decoding
the same broadcast.

- read_shared_metrics now normalizes the legacy "None"/"True"/"False"
  strings back to their Python types when JSON-decode fails, completing
  the round-trip fix from 44162d8 for stale reads.
- _sanitize_metadata_value drops the literal string "None" so stale
  source_metadata JSONB rows can no longer paint phantom labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata sanitization to prevent "None" string values from appearing in audio station information display.
  * Improved handling of legacy audio data to ensure proper conversion of boolean and null values.

* **New Features**
  * Audio monitoring now displays RBDS/RDS metadata section while decoder is locking or locked, with status badges indicating lock state and explanatory hints for pending data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->