### PR TITLE
Improve RBDS synced-mode polarity recovery and CRC failure tracking

### DIFF
--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -1309,31 +1309,43 @@ class RBDSWorker:
                     self._rbds_block_bit_counter += 1
                 else:
                     # Complete 26-bit block received - check CRC
+                    def _crc_ok_for_block(block_word_value: int, block_number: int) -> bool:
+                        dataword_value = (block_word_value >> 10) & 0xFFFF
+                        block_calculated_crc_value = self._calc_syndrome(dataword_value, 16)
+                        checkword_value = block_word_value & 0x3FF
+                        if block_number == 2:
+                            # Block C can be C or C' offset word.
+                            return (
+                                (checkword_value ^ offset_word[2]) == block_calculated_crc_value
+                                or (checkword_value ^ offset_word[4]) == block_calculated_crc_value
+                            )
+                        return (checkword_value ^ offset_word[block_number]) == block_calculated_crc_value
+
                     good_block = False
                     block_word = self._rbds_reg ^ 0x3FFFFFF if self._rbds_inverted_polarity else self._rbds_reg
-                    dataword = (block_word >> 10) & 0xFFFF
-                    block_calculated_crc = self._calc_syndrome(dataword, 16)
-                    checkword = block_word & 0x3FF
-                    
-                    if self._rbds_block_number == 2:
-                        # Block C can be C or C' offset word
-                        block_received_crc = checkword ^ offset_word[self._rbds_block_number]
-                        if block_received_crc == block_calculated_crc:
-                            good_block = True
-                        else:
-                            block_received_crc = checkword ^ offset_word[4]
-                            if block_received_crc == block_calculated_crc:
-                                good_block = True
-                            else:
-                                self._rbds_wrong_blocks_counter += 1
-                                good_block = False
+
+                    if _crc_ok_for_block(block_word, self._rbds_block_number):
+                        good_block = True
                     else:
-                        block_received_crc = checkword ^ offset_word[self._rbds_block_number]
-                        if block_received_crc == block_calculated_crc:
+                        # If current polarity suddenly fails CRC but opposite polarity passes,
+                        # recover immediately instead of waiting for a full sync-loss window.
+                        alternate_block_word = block_word ^ 0x3FFFFFF
+                        if _crc_ok_for_block(alternate_block_word, self._rbds_block_number):
+                            self._rbds_inverted_polarity = not self._rbds_inverted_polarity
+                            block_word = alternate_block_word
                             good_block = True
+                            logger.info(
+                                "RBDS polarity flipped while synced; continuing decode (%s polarity)",
+                                "inverted" if self._rbds_inverted_polarity else "normal",
+                            )
                         else:
                             self._rbds_wrong_blocks_counter += 1
-                            good_block = False
+
+                    dataword = (block_word >> 10) & 0xFFFF
+                    if good_block:
+                        self._rbds_consecutive_crc_failures = 0
+                    else:
+                        self._rbds_consecutive_crc_failures += 1
                     
                     # Group assembly (python-radio logic)
                     if self._rbds_block_number == 0 and good_block:


### PR DESCRIPTION
### Motivation
- Field logs showed `RBDS SYNCHRONIZED` immediately followed by `RBDS SYNC LOST` with zero groups decoded, indicating fragile synced-mode handling when polarity flips or intermittent CRC failures occur.
- The synced-mode CRC checking was duplicated and fragile for the special C / C' offset case, making recovery harder and telemetry (`crc_fails`) unhelpful.

### Description
- Refactored synced-mode block CRC validation into a local helper `_crc_ok_for_block` that correctly handles the C / C' offset semantics and reduces duplicated logic in `RBDSWorker._decode_rbds_groups` (`app_core/radio/demodulation.py`).
- Added in-sync polarity recovery that immediately flips `_rbds_inverted_polarity` and continues decoding if the alternate polarity yields a valid CRC, avoiding waiting for the 50-block sync-loss window.
- Maintain and update `_rbds_consecutive_crc_failures` per-block by resetting it on a good block and incrementing it on failure so runtime telemetry/log messages reflect real CRC health.
- Emit an informative `logger.info` when a polarity flip is detected while synced to aid diagnostics.

### Testing
- Ran `python -m compileall app_core/radio/demodulation.py`, which completed successfully.
- Ran `pytest -q tests/test_rbds_demodulation.py` in this environment but collection failed with `ModuleNotFoundError: No module named 'numpy'`, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b834e4ec83209dae40df944e14ef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic detection and handling of inverted radio signal polarity during decoding
  * Enhanced error tracking for CRC failures in radio reception

* **Refactor**
  * Streamlined CRC validation logic for radio signal processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->