### PR TITLE
Harden RBDS presync lock against false synchronization

### DIFF
--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -606,6 +606,8 @@ class RBDSWorker:
         for attr in (
             '_rbds_synced',
             '_rbds_presync',
+            '_rbds_presync_hits',
+            '_rbds_presync_polarity',
             '_rbds_wrong_blocks_counter',
             '_rbds_blocks_counter',
             '_rbds_group_good_blocks_counter',
@@ -1212,6 +1214,8 @@ class RBDSWorker:
         if not hasattr(self, '_rbds_synced'):
             self._rbds_synced = False
             self._rbds_presync = False
+            self._rbds_presync_hits = 0
+            self._rbds_presync_polarity: Optional[bool] = None
             self._rbds_wrong_blocks_counter = 0
             self._rbds_blocks_counter = 0
             self._rbds_group_good_blocks_counter = 0
@@ -1253,6 +1257,8 @@ class RBDSWorker:
                             self._rbds_lastseen_offset = j
                             self._rbds_lastseen_offset_counter = global_i
                             self._rbds_inverted_polarity = polarity
+                            self._rbds_presync_polarity = polarity
+                            self._rbds_presync_hits = 0
                             self._rbds_presync = True
                             polarity_text = "inverted" if polarity else "normal"
                             logger.info(
@@ -1263,6 +1269,17 @@ class RBDSWorker:
                             )
                         else:
                             # Second valid block - check spacing
+                            if self._rbds_presync_polarity is not None and polarity != self._rbds_presync_polarity:
+                                # Mixed polarity during presync usually indicates a random
+                                # syndrome collision in noise.  Restart presync from this
+                                # block to avoid false "sync then immediate 50/50 CRC fail".
+                                self._rbds_lastseen_offset = j
+                                self._rbds_lastseen_offset_counter = global_i
+                                self._rbds_inverted_polarity = polarity
+                                self._rbds_presync_polarity = polarity
+                                self._rbds_presync_hits = 0
+                                break
+
                             if offset_pos[self._rbds_lastseen_offset] >= offset_pos[j]:
                                 block_distance = offset_pos[j] + 4 - offset_pos[self._rbds_lastseen_offset]
                             else:
@@ -1283,24 +1300,36 @@ class RBDSWorker:
                                 self._rbds_lastseen_offset = j
                                 self._rbds_lastseen_offset_counter = global_i
                                 self._rbds_inverted_polarity = polarity
+                                self._rbds_presync_polarity = polarity
+                                self._rbds_presync_hits = 0
                                 # Keep presync=True with new first block
                             else:
-                                # SYNC ACHIEVED!
-                                logger.info(f'RBDS SYNCHRONIZED at bit {global_i}')
-                                self._rbds_wrong_blocks_counter = 0
-                                self._rbds_blocks_counter = 0
-                                self._rbds_block_bit_counter = 0
-                                # CRITICAL FIX: Use offset_pos[j] to determine the next expected
-                                # block number, not j directly.  For C' (j=4), offset_pos[4]=2
-                                # (same slot as C), so the next block is D (3), not B (1).
-                                # Using (j+1)%4 gives 1 for j=4 which is wrong and causes
-                                # immediate sync loss for stations broadcasting Group 2B.
-                                self._rbds_block_number = (offset_pos[j] + 1) % 4
-                                self._rbds_group_assembly_started = False
-                                # Update polarity to match the triggering block so synced-mode
-                                # CRC checks use the correct inversion flag.
+                                # Require 3 consecutive correctly spaced presync blocks
+                                # (two spacing confirmations) before declaring lock.
+                                # This materially reduces false-lock events where random
+                                # syndrome hits produce "SYNCED" followed by 50/50 CRC loss.
+                                self._rbds_presync_hits += 1
+                                self._rbds_lastseen_offset = j
+                                self._rbds_lastseen_offset_counter = global_i
                                 self._rbds_inverted_polarity = polarity
-                                self._rbds_synced = True
+                                self._rbds_presync_polarity = polarity
+
+                                if self._rbds_presync_hits >= 2:
+                                    logger.info(f'RBDS SYNCHRONIZED at bit {global_i}')
+                                    self._rbds_wrong_blocks_counter = 0
+                                    self._rbds_blocks_counter = 0
+                                    self._rbds_block_bit_counter = 0
+                                    # CRITICAL FIX: Use offset_pos[j] to determine the next expected
+                                    # block number, not j directly.  For C' (j=4), offset_pos[4]=2
+                                    # (same slot as C), so the next block is D (3), not B (1).
+                                    # Using (j+1)%4 gives 1 for j=4 which is wrong and causes
+                                    # immediate sync loss for stations broadcasting Group 2B.
+                                    self._rbds_block_number = (offset_pos[j] + 1) % 4
+                                    self._rbds_group_assembly_started = False
+                                    # Update polarity to match the triggering block so synced-mode
+                                    # CRC checks use the correct inversion flag.
+                                    self._rbds_inverted_polarity = polarity
+                                    self._rbds_synced = True
                         break  # Syndrome found, exit j loop
             
             else:

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -152,6 +152,40 @@ def test_rbds_submit_samples_accepts_offset():
     worker.stop()
 
 
+def _run_presync_sequence(worker: RBDSWorker, hit_map: dict[int, int]) -> None:
+    """Drive _decode_rbds_groups with synthetic syndrome hits at specific bit indices."""
+    worker._rbds_bit_buffer = [0] * 220
+    call_index = 0
+
+    def fake_calc_syndrome(_word: int, message_length: int) -> int:
+        nonlocal call_index
+        bit_index = call_index // 2
+        is_inverted_path = (call_index % 2) == 1
+        call_index += 1
+        if message_length == 26 and not is_inverted_path:
+            return hit_map.get(bit_index, 0)
+        return 0
+
+    worker._calc_syndrome = fake_calc_syndrome  # type: ignore[assignment]
+    worker._decode_rbds_groups()
+
+
+def test_rbds_presync_requires_three_spaced_hits_before_lock():
+    """RBDS lock should only occur after 3 correctly spaced presync detections."""
+    worker = _make_worker()
+    # A -> B -> C detections with exact 26-bit spacing.
+    _run_presync_sequence(worker, {100: 383, 126: 14, 152: 303})
+    assert worker._rbds_synced is True
+
+
+def test_rbds_presync_two_hits_do_not_lock():
+    """Two spaced detections are insufficient; avoid false sync in noise."""
+    worker = _make_worker()
+    # Only A -> B (single spacing confirmation) should not lock.
+    _run_presync_sequence(worker, {100: 383, 126: 14})
+    assert worker._rbds_synced is False
+
+
 # ---------------------------------------------------------------------------
 # RBDSDecoder.process_group tests
 #


### PR DESCRIPTION
### Motivation
- Reduce frequent false RBDS presync locks that immediately devolve into rapid `SYNC LOST` / high CRC-fail counts by making presync decision more robust to random syndrome collisions and polarity jitter. 
- Ensure forced worker resets clear new presync tracking state so retunes always start cleanly. 
- Add deterministic unit tests that exercise presync hit sequences to prevent regressions. 

### Description
- Add presync tracking fields `_rbds_presync_hits` and `_rbds_presync_polarity` and initialize/clear them in `_decode_rbds_groups` and `_apply_reset`. 
- Require multiple consecutive correctly spaced presync detections (three presync blocks / two spacing confirmations) before setting `_rbds_synced`, instead of declaring sync after a single spacing confirmation. 
- Detect mixed polarity during presync and restart presync from the newest candidate block to avoid false locks caused by random syndrome collisions. 
- Add focused tests in `tests/test_rbds_demodulation.py` (`_run_presync_sequence`, `test_rbds_presync_requires_three_spaced_hits_before_lock`, `test_rbds_presync_two_hits_do_not_lock`) to simulate synthetic syndrome-hit patterns and validate the presync state machine. 

### Testing
- Ran `python3 -m py_compile app_core/radio/demodulation.py tests/test_rbds_demodulation.py`, which succeeded. 
- Ran `pytest -q tests/test_rbds_demodulation.py` in this environment, which failed at collection due to a missing test dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bae0314c8320b498d1f7c50dd5ef)