### PR TITLE
audio: quarantine failing streams and enable live SDR retune

### DIFF
--- a/app_core/audio/ingest.py
+++ b/app_core/audio/ingest.py
@@ -178,6 +178,15 @@ class AudioSourceAdapter(ABC):
         self._restart_count = 0
         self._last_restart = 0.0
         self._last_error: Optional[str] = None
+        # Circuit breaker: a source that fails to restart repeatedly is
+        # quarantined for a cooldown period so the monitor stops hammering it.
+        # This prevents one broken stream (bad URL, missing hardware, persistent
+        # exception) from monopolizing CPU and log volume, and isolates it from
+        # the rest of the audio system.
+        self._consecutive_failed_restarts = 0
+        self._quarantine_threshold = 3      # failed restarts before quarantine
+        self._quarantine_seconds = 60.0      # cooldown before retrying
+        self._quarantined_until = 0.0
 
     @abstractmethod
     def _start_capture(self) -> None:
@@ -517,6 +526,10 @@ class AudioSourceAdapter(ABC):
 
         self._last_metrics_update = current_time
 
+    def is_quarantined(self) -> bool:
+        """Return True if this source is in restart cooldown after repeated failures."""
+        return time.time() < self._quarantined_until
+
     def restart(
         self,
         reason: str,
@@ -524,12 +537,30 @@ class AudioSourceAdapter(ABC):
         delay: float = 0.25,
         max_attempts: int = 2,
     ) -> bool:
-        """Attempt to restart the adapter when it becomes unhealthy."""
+        """Attempt to restart the adapter when it becomes unhealthy.
+
+        A source that fails to restart ``_quarantine_threshold`` consecutive
+        times is placed in quarantine for ``_quarantine_seconds`` so the
+        monitor loop stops trying.  This prevents one broken stream from
+        consuming CPU, log volume, and lock contention shared with healthy
+        sources.
+        """
 
         if not self.config.enabled:
             logger.debug(
                 "Skipping restart for %s because the source is disabled",
                 self.config.name,
+            )
+            return False
+
+        if self.is_quarantined():
+            remaining = max(0.0, self._quarantined_until - time.time())
+            logger.debug(
+                "%s: quarantined after %d failed restarts; %.1fs remaining (%s)",
+                self.config.name,
+                self._consecutive_failed_restarts,
+                remaining,
+                reason,
             )
             return False
 
@@ -543,13 +574,33 @@ class AudioSourceAdapter(ABC):
                     attempt,
                     attempts,
                 )
-                self.stop()
+                try:
+                    self.stop()
+                except Exception as exc:
+                    logger.error(
+                        "%s: error during stop() before restart: %s",
+                        self.config.name,
+                        exc,
+                        exc_info=True,
+                    )
                 if delay > 0:
                     time.sleep(delay)
-                if self.start():
+                try:
+                    started = self.start()
+                except Exception as exc:
+                    logger.error(
+                        "%s: unexpected exception during restart: %s",
+                        self.config.name,
+                        exc,
+                        exc_info=True,
+                    )
+                    started = False
+                if started:
                     self._restart_count += 1
                     self._last_restart = time.time()
                     self._last_error = None
+                    self._consecutive_failed_restarts = 0
+                    self._quarantined_until = 0.0
                     logger.info(
                         "%s: audio source restarted successfully after %s",
                         self.config.name,
@@ -560,12 +611,24 @@ class AudioSourceAdapter(ABC):
                 if backoff > 0:
                     time.sleep(backoff)
 
-            logger.error(
-                "%s: failed to restart audio source after %s attempt(s) (%s)",
-                self.config.name,
-                attempts,
-                reason,
-            )
+            self._consecutive_failed_restarts += 1
+            if self._consecutive_failed_restarts >= self._quarantine_threshold:
+                self._quarantined_until = time.time() + self._quarantine_seconds
+                logger.error(
+                    "%s: quarantining audio source for %.0fs after %d consecutive "
+                    "failed restarts (last reason: %s)",
+                    self.config.name,
+                    self._quarantine_seconds,
+                    self._consecutive_failed_restarts,
+                    reason,
+                )
+            else:
+                logger.error(
+                    "%s: failed to restart audio source after %s attempt(s) (%s)",
+                    self.config.name,
+                    attempts,
+                    reason,
+                )
             return False
 
     def get_waveform_data(self) -> np.ndarray:
@@ -956,22 +1019,42 @@ class AudioIngestController:
             self._active_source = None
 
     def _monitor_loop(self) -> None:
-        """Background monitor that auto-recovers unhealthy sources."""
+        """Background monitor that auto-recovers unhealthy sources.
+
+        The outer try/except is the firewall that prevents one source's bug
+        (DB error, exception in restart, AttributeError on a partially-
+        initialized adapter, etc.) from killing the monitor thread for the
+        entire audio system.  Each source is evaluated in isolation; a failure
+        in one cannot affect the others or stop future monitoring iterations.
+        """
         while not self._monitor_stop.is_set():
-            now = time.time()
-            with self._lock:
-                snapshot = list(self._sources.items())
-            
-            # Wrap health evaluation in Flask app context if available
-            # This allows database operations during source restarts
-            if self._flask_app:
-                with self._flask_app.app_context():
-                    for name, adapter in snapshot:
-                        self._evaluate_source_health(name, adapter, now)
-            else:
+            try:
+                now = time.time()
+                with self._lock:
+                    snapshot = list(self._sources.items())
+
                 for name, adapter in snapshot:
-                    self._evaluate_source_health(name, adapter, now)
-            
+                    try:
+                        if self._flask_app:
+                            with self._flask_app.app_context():
+                                self._evaluate_source_health(name, adapter, now)
+                        else:
+                            self._evaluate_source_health(name, adapter, now)
+                    except Exception as exc:
+                        # Isolate per-source failures so they cannot take down
+                        # other healthy sources or the monitor itself.
+                        logger.error(
+                            "Error evaluating health of source %s: %s",
+                            name,
+                            exc,
+                            exc_info=True,
+                        )
+            except Exception as exc:
+                # Last-line-of-defense for anything unexpected (e.g. lock
+                # acquisition failure, snapshot iteration issue).  Logged and
+                # swallowed so the monitor stays alive.
+                logger.error("Unexpected error in audio monitor loop: %s", exc, exc_info=True)
+
             self._monitor_stop.wait(timeout=self._monitor_interval)
 
     def _evaluate_source_health(
@@ -981,6 +1064,12 @@ class AudioIngestController:
         now: float,
     ) -> None:
         if not adapter.config.enabled:
+            return
+
+        # Quarantined sources are skipped to break the restart-storm cycle
+        # that otherwise has the monitor flooding logs and CPU on a stream
+        # that simply cannot be brought up right now.
+        if adapter.is_quarantined():
             return
 
         status = adapter.status

--- a/app_core/audio/source_manager.py
+++ b/app_core/audio/source_manager.py
@@ -237,53 +237,94 @@ class AudioSourceManager:
         logger.info("AudioSourceManager stopped")
 
     def _monitor_loop(self) -> None:
-        """Monitor source health and trigger failover if needed."""
+        """Monitor source health and trigger failover if needed.
+
+        The double try/except is intentional: the inner block isolates a
+        single iteration's failure (so the loop can continue to the next
+        source/iteration), the outer block guarantees the thread itself never
+        dies from an unhandled exception (e.g. dictionary mutation during
+        iteration, callback bug).  Without these guards, a single source's
+        exception could silently kill the monitor for the entire audio system.
+        """
         logger.debug("Source monitor loop started")
 
         while not self._stop_event.wait(1.0):
             try:
-                # Check if active source is still healthy
-                if self._active_source:
-                    source = self._sources[self._active_source]
-                    metrics = source.get_metrics()
+                try:
+                    # Check if active source is still healthy
+                    if self._active_source:
+                        source = self._sources.get(self._active_source)
+                        if source is None:
+                            # Active source was removed under us; reselect.
+                            self._select_best_source(reason=FailoverReason.SOURCE_FAILED)
+                            continue
+                        metrics = source.get_metrics()
 
-                    # Check if source failed
-                    if metrics.health == SourceHealth.FAILED:
-                        logger.warning(f"Active source {self._active_source} failed")
-                        self._select_best_source(reason=FailoverReason.SOURCE_FAILED)
-                        continue
+                        # Check if source failed
+                        if metrics.health == SourceHealth.FAILED:
+                            logger.warning(f"Active source {self._active_source} failed")
+                            self._select_best_source(reason=FailoverReason.SOURCE_FAILED)
+                            continue
 
-                    # Check for silence
-                    config = self._source_configs[self._active_source]
-                    if self._check_silence(self._active_source, config):
-                        logger.warning(f"Silence detected on {self._active_source}")
-                        self._select_best_source(reason=FailoverReason.SILENCE_DETECTED)
-                        continue
+                        # Check for silence
+                        config = self._source_configs[self._active_source]
+                        if self._check_silence(self._active_source, config):
+                            logger.warning(f"Silence detected on {self._active_source}")
+                            self._select_best_source(reason=FailoverReason.SILENCE_DETECTED)
+                            continue
 
-                # Check if a higher priority source became available
-                self._check_priority_failover()
+                    # Check if a higher priority source became available
+                    self._check_priority_failover()
 
+                except Exception as e:
+                    logger.error(f"Error in monitor loop iteration: {e}", exc_info=True)
             except Exception as e:
-                logger.error(f"Error in monitor loop: {e}")
+                # Last-resort guard so a programming error cannot kill the thread.
+                logger.error(f"Unhandled error in monitor loop: {e}", exc_info=True)
 
         logger.debug("Source monitor loop stopped")
 
     def _mixer_loop(self) -> None:
-        """Mix active source audio into master buffer."""
+        """Mix active source audio into master buffer.
+
+        Stall detection: if the active source returns no samples for longer
+        than ``_mixer_stall_seconds``, we trigger a failover instead of
+        silently starving the EAS decoder.  Without this, a stalled source
+        keeps the audio system "running" while delivering zero audio — the
+        worst possible failure mode for emergency alert monitoring.
+        """
         logger.debug("Audio mixer loop started")
         chunk_samples = int(self.sample_rate * 0.05)  # 50ms chunks
 
-        while not self._stop_event.is_set():
-            if not self._active_source:
-                # No active source, sleep
-                time.sleep(0.1)
-                continue
+        # Stall detection state (per active-source).  Reset whenever the
+        # active source changes or successfully returns audio.
+        last_audio_at = time.time()
+        last_active_source: Optional[str] = None
+        mixer_stall_seconds = 5.0
 
+        while not self._stop_event.is_set():
             try:
-                source = self._sources[self._active_source]
+                if not self._active_source:
+                    # No active source, sleep
+                    time.sleep(0.1)
+                    last_audio_at = time.time()
+                    last_active_source = None
+                    continue
+
+                if self._active_source != last_active_source:
+                    last_active_source = self._active_source
+                    last_audio_at = time.time()
+
+                source = self._sources.get(self._active_source)
+                if source is None:
+                    # Active source disappeared; let monitor reselect.
+                    time.sleep(0.05)
+                    continue
+
                 samples = source.read_samples(chunk_samples)
 
                 if samples is not None:
+                    last_audio_at = time.time()
                     # Write to master buffer
                     written = self.master_buffer.write(samples, block=False)
                     if written == 0:
@@ -292,8 +333,21 @@ class AudioSourceManager:
                     # No data available, yield briefly
                     time.sleep(0.05)  # 50ms sleep to prevent CPU spinning
 
+                    if time.time() - last_audio_at > mixer_stall_seconds:
+                        logger.warning(
+                            "Mixer detected stall on %s after %.1fs of no samples; "
+                            "triggering failover",
+                            self._active_source,
+                            time.time() - last_audio_at,
+                        )
+                        self._select_best_source(reason=FailoverReason.SOURCE_FAILED)
+                        last_audio_at = time.time()  # avoid back-to-back failovers
+
             except Exception as e:
-                logger.error(f"Error in mixer loop: {e}")
+                # Per-iteration guard prevents a single bad source or buffer
+                # error from killing the mixer thread (which would silently
+                # starve the EAS decoder).
+                logger.error(f"Error in mixer loop: {e}", exc_info=True)
                 time.sleep(0.1)
 
         logger.debug("Audio mixer loop stopped")

--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -490,6 +490,98 @@ class _SoapySDRReceiver(ReceiverInterface):
         self._cancel_capture_requests(RuntimeError("Receiver stopped"), teardown=False)
         self._update_status(locked=False)
 
+    def set_frequency(self, frequency_hz: float) -> bool:  # noqa: D401 - documented in base class
+        """Retune the live SDR stream to ``frequency_hz`` without restarting it.
+
+        SoapySDR's ``setFrequency`` is safe to call concurrently with an active
+        ``readStream``, so we can change the tuner mid-flight.  The new
+        frequency is also persisted into ``self.config`` so subsequent samples
+        published to Redis report the correct ``center_frequency`` and the
+        downstream demodulator/RBDS state can reset cleanly.
+        """
+        from dataclasses import replace as _replace_dc
+
+        try:
+            freq_hz = float(frequency_hz)
+        except (TypeError, ValueError):
+            self._interface_logger.error(
+                "set_frequency: invalid frequency value %r for %s",
+                frequency_hz,
+                self.config.identifier,
+            )
+            return False
+
+        if freq_hz <= 0:
+            self._interface_logger.error(
+                "set_frequency: non-positive frequency %s for %s",
+                freq_hz,
+                self.config.identifier,
+            )
+            return False
+
+        handle = self._handle
+        if handle is None or not self._running.is_set():
+            self._interface_logger.warning(
+                "set_frequency: cannot retune %s while device is not open/running",
+                self.config.identifier,
+            )
+            return False
+
+        # Apply the same PPM correction as the initial tune so the actual
+        # tuner frequency matches what the operator selected after correction.
+        corrected_freq = freq_hz
+        if self.config.frequency_correction_ppm:
+            correction_factor = 1.0 + (self.config.frequency_correction_ppm / 1_000_000.0)
+            corrected_freq = freq_hz * correction_factor
+
+        channel = self.config.channel if self.config.channel is not None else 0
+
+        try:
+            handle.device.setFrequency(handle.sdr.SOAPY_SDR_RX, channel, corrected_freq)
+        except Exception as exc:
+            self._interface_logger.error(
+                "Live retune failed for %s to %.6f MHz: %s",
+                self.config.identifier,
+                freq_hz / 1_000_000,
+                exc,
+            )
+            self._update_status(last_error=f"Live retune failed: {exc}", context="set_frequency")
+            return False
+
+        # Persist the new frequency so status payloads, Redis sample messages,
+        # and any subsequent restart use the new value.  ReceiverConfig is a
+        # frozen dataclass, so we rebind ``self.config`` to a new instance.
+        self.config = _replace_dc(self.config, frequency_hz=freq_hz)
+
+        # Best-effort readback for diagnostics.
+        try:
+            actual_freq = handle.device.getFrequency(handle.sdr.SOAPY_SDR_RX, channel)
+            self._interface_logger.info(
+                "Live-retuned %s to %.6f MHz (corrected: %.6f MHz, readback: %.6f MHz)",
+                self.config.identifier,
+                freq_hz / 1_000_000,
+                corrected_freq / 1_000_000,
+                actual_freq / 1_000_000,
+            )
+        except Exception:
+            self._interface_logger.info(
+                "Live-retuned %s to %.6f MHz",
+                self.config.identifier,
+                freq_hz / 1_000_000,
+            )
+
+        self._emit_event(
+            "INFO",
+            f"{self.config.identifier} retuned to {freq_hz / 1_000_000:.6f} MHz",
+            module_suffix="set_frequency",
+            details={
+                "identifier": self.config.identifier,
+                "frequency_hz": freq_hz,
+                "ppm_corrected_hz": corrected_freq,
+            },
+        )
+        return True
+
     # ------------------------------------------------------------------
     # Status reporting
     # ------------------------------------------------------------------
@@ -1795,6 +1887,33 @@ class AirspyReceiver(_SoapySDRReceiver):
             ) from exc
 
         return handle
+
+    def set_frequency(self, frequency_hz: float) -> bool:  # noqa: D401 - documented in base class
+        """Live-retune Airspy, including the explicit "RF" component."""
+        if not super().set_frequency(frequency_hz):
+            return False
+
+        # _open_handle() sets the "RF" component explicitly because some
+        # SoapyAirspy builds need it.  Mirror that here so a live retune
+        # actually moves the tuner instead of leaving it on the previous LO.
+        handle = self._handle
+        if handle is None:
+            return True  # parent already logged; treat as success of the main set
+
+        try:
+            channel = self.config.channel if self.config.channel is not None else 0
+            corrected_freq = self.config.frequency_hz
+            if self.config.frequency_correction_ppm:
+                corrected_freq *= 1.0 + (self.config.frequency_correction_ppm / 1_000_000.0)
+            handle.device.setFrequency(handle.sdr.SOAPY_SDR_RX, channel, "RF", corrected_freq)
+        except Exception as exc:
+            # Best-effort: parent already moved the main frequency; log and continue.
+            self._interface_logger.debug(
+                "Airspy %s: could not set RF component during live retune: %s",
+                self.config.identifier,
+                exc,
+            )
+        return True
 
 
 def register_builtin_drivers(manager: RadioManager) -> None:

--- a/app_core/radio/manager.py
+++ b/app_core/radio/manager.py
@@ -129,6 +129,15 @@ class ReceiverInterface(ABC):
     ) -> Path:
         """Capture a block of samples and persist them to disk."""
 
+    def set_frequency(self, frequency_hz: float) -> bool:
+        """Retune the live SDR stream to ``frequency_hz`` without stopping it.
+
+        Drivers that can retune the active stream override this and return
+        True on success.  The default implementation returns False, which
+        signals to callers that a full reconfigure/restart is required.
+        """
+        return False
+
     # ------------------------------------------------------------------
     # Event logging helpers
     # ------------------------------------------------------------------

--- a/sdr_hardware_service.py
+++ b/sdr_hardware_service.py
@@ -920,6 +920,74 @@ def process_commands(redis_client):
                         "success": False,
                         "error": f"Receiver {receiver_id} not found"
                     }
+            elif action == "tune_frequency":
+                # Live retune of an active receiver — does NOT stop the stream
+                # so the audio system keeps decoding without interruption.
+                # On failure the webapp can fall back to reload_receivers.
+                receiver = radio_manager.get_receiver(receiver_id)
+                if not receiver:
+                    result = {
+                        "command_id": command_id,
+                        "success": False,
+                        "error": f"Receiver {receiver_id} not found",
+                    }
+                else:
+                    freq_hz = command.get("frequency_hz")
+                    try:
+                        freq_hz = float(freq_hz) if freq_hz is not None else None
+                    except (TypeError, ValueError):
+                        freq_hz = None
+                    if freq_hz is None or freq_hz <= 0:
+                        result = {
+                            "command_id": command_id,
+                            "success": False,
+                            "error": "frequency_hz is required and must be positive",
+                        }
+                    else:
+                        try:
+                            tuned = receiver.set_frequency(freq_hz)
+                        except Exception as e:
+                            logger.error(
+                                "tune_frequency failed for %s: %s",
+                                receiver_id, e, exc_info=True,
+                            )
+                            tuned = False
+                        if tuned:
+                            # Persist to database so a future restart keeps the tune.
+                            try:
+                                if _state.flask_app:
+                                    with _state.flask_app.app_context():
+                                        from app_core.models import RadioReceiver
+                                        from app_core.extensions import db
+                                        row = RadioReceiver.query.filter_by(
+                                            identifier=receiver_id
+                                        ).first()
+                                        if row is not None:
+                                            row.frequency_hz = freq_hz
+                                            db.session.commit()
+                            except Exception as e:
+                                logger.warning(
+                                    "tune_frequency: retune ok but DB update failed for %s: %s",
+                                    receiver_id, e,
+                                )
+                            result = {
+                                "command_id": command_id,
+                                "success": True,
+                                "frequency_hz": freq_hz,
+                                "live": True,
+                            }
+                        else:
+                            # Driver can't live-retune (or device not running) —
+                            # caller should fall back to reload_receivers.
+                            result = {
+                                "command_id": command_id,
+                                "success": False,
+                                "live": False,
+                                "error": (
+                                    "Live retune not supported or device not running; "
+                                    "caller should fall back to reload_receivers"
+                                ),
+                            }
             elif action == "stop":
                 receiver = radio_manager.get_receiver(receiver_id)
                 if receiver:

--- a/webapp/routes_settings_radio.py
+++ b/webapp/routes_settings_radio.py
@@ -706,6 +706,22 @@ def register(app: Flask, logger) -> None:
                 if conflict and conflict.id != receiver.id:
                     return jsonify({"error": "Another receiver already uses this identifier."}), 400
 
+            # Detect frequency-only changes so we can issue a live retune
+            # instead of bouncing the whole audio system.  A change counts as
+            # "frequency only" when nothing else (driver, sample rate, gain,
+            # modulation, enabled state, identifier, …) is being touched.
+            receiver_identifier = receiver.identifier
+            old_frequency = receiver.frequency_hz
+            new_frequency = data.get("frequency_hz")
+            non_freq_keys = {k for k in data.keys() if k != "frequency_hz"}
+            frequency_only_change = (
+                "frequency_hz" in data
+                and not non_freq_keys
+                and new_frequency is not None
+                and float(new_frequency) != float(old_frequency or 0)
+                and bool(receiver.enabled)
+            )
+
             for key, value in data.items():
                 setattr(receiver, key, value)
 
@@ -725,7 +741,37 @@ def register(app: Flask, logger) -> None:
                 )
                 return jsonify({"error": "Failed to update receiver."}), 500
 
-            manager_state = _sync_radio_manager_state(route_logger)
+            # Try a live retune first when only the frequency changed.  If the
+            # driver/device cannot retune live, fall back to the full reload.
+            manager_state: Optional[Dict[str, Any]] = None
+            if frequency_only_change:
+                tune_result = _send_sdr_command(
+                    "tune_frequency",
+                    receiver_id=receiver_identifier,
+                    frequency_hz=float(new_frequency),
+                )
+                if tune_result.get("success"):
+                    route_logger.info(
+                        "Live retune succeeded for %s: %.6f MHz -> %.6f MHz",
+                        receiver_identifier,
+                        float(old_frequency or 0) / 1_000_000,
+                        float(new_frequency) / 1_000_000,
+                    )
+                    manager_state = {
+                        "configured": 1,
+                        "auto_started": [],
+                        "errors": [],
+                        "live_retune": True,
+                    }
+                else:
+                    route_logger.warning(
+                        "Live retune unavailable for %s (%s); falling back to reload",
+                        receiver_identifier,
+                        tune_result.get("error", "unknown reason"),
+                    )
+
+            if manager_state is None:
+                manager_state = _sync_radio_manager_state(route_logger)
 
             # Explicitly re-query with a fresh session query to avoid DetachedInstanceError
             # We use filter_by + first() instead of get() to ensure a fresh query


### PR DESCRIPTION
Stream protection
- Add a circuit breaker to AudioSourceAdapter.restart(): three consecutive
  failed restart attempts now quarantine the source for 60 s instead of
  letting the monitor flood logs/CPU trying to recover a stream that
  cannot come up (bad URL, missing hardware, persistent exception).
- Wrap AudioIngestController._monitor_loop and source_manager's monitor
  and mixer loops in per-iteration and outer try/except guards so a
  bug or runtime error in one source cannot kill the thread that keeps
  every other source alive.
- Add a 5 s mixer stall watchdog that triggers failover when the active
  FFmpeg source stops producing samples, instead of silently starving
  the EAS decoder.

Live SDR frequency change
- Add ReceiverInterface.set_frequency() with a default that signals
  "not supported"; implement it on _SoapySDRReceiver (and AirspyReceiver
  for the explicit RF component) so the active stream is retuned via
  device.setFrequency without stopping readStream.
- Add a tune_frequency command to sdr_hardware_service that drives the
  live retune and also persists the new frequency to the database.
- In api_update_receiver, detect frequency-only updates and try the live
  tune first, falling back to reload_receivers only when the driver
  cannot retune. Frequency changes no longer bounce the audio system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live frequency retuning for radio receivers without stopping the stream
  * Automatic quarantine and recovery system for audio sources experiencing repeated restart failures

* **Improvements**
  * Enhanced audio monitoring robustness with improved error handling and stall detection
  * Increased system resilience through better exception management in monitoring loops
  * Graceful handling of missing or unavailable sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->