### PR TITLE
Override stream metadata with alert text while forwarding

### DIFF
--- a/app_core/audio/alert_metadata.py
+++ b/app_core/audio/alert_metadata.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed under AGPL-3.0 and a Commercial License.
+See LICENSE and LICENSE-COMMERCIAL for details.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Alert Metadata Coordinator
+
+Holds a global handle to the active AutoStreamingService and exposes
+``set_alert_metadata`` / ``clear_alert_metadata`` helpers used by the
+auto-forwarder. While an alert is being forwarded, the stream metadata on
+every active Icecast mount is overridden with the alert text so listeners
+see the alert headline instead of the upstream source's now-playing info.
+
+Usage
+-----
+At app startup (after AutoStreamingService is created)::
+
+    from app_core.audio import alert_metadata
+    alert_metadata.set_service(auto_streaming_service)
+
+When an alert is being forwarded::
+
+    from app_core.audio.alert_metadata import (
+        set_alert_metadata, clear_alert_metadata,
+    )
+    set_alert_metadata("Tornado Warning — Logan County")
+    try:
+        broadcaster.handle_alert(...)
+    finally:
+        clear_alert_metadata()
+"""
+
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_service = None  # AutoStreamingService
+
+
+def set_service(service) -> None:
+    """Register the global AutoStreamingService (called once at startup)."""
+    global _service
+    with _lock:
+        _service = service
+    logger.info("Alert metadata coordinator: service registered")
+
+
+def set_alert_metadata(title: str, artist: Optional[str] = "EAS Alert") -> int:
+    """Push *title* (and optional *artist*) onto every active Icecast stream
+    as an override.
+
+    Returns the number of streamers that accepted the override (0 when no
+    service is registered or no streams are active).
+    """
+    if not title:
+        return 0
+    with _lock:
+        service = _service
+    if service is None:
+        return 0
+    try:
+        return service.update_alert_metadata(title, artist)
+    except Exception as exc:
+        logger.warning("Alert metadata override failed: %s", exc)
+        return 0
+
+
+def clear_alert_metadata() -> None:
+    """Clear the alert metadata override on every active Icecast stream."""
+    with _lock:
+        service = _service
+    if service is None:
+        return
+    try:
+        service.clear_alert_metadata()
+    except Exception as exc:
+        logger.warning("Alert metadata clear failed: %s", exc)
+
+
+__all__ = ["set_service", "set_alert_metadata", "clear_alert_metadata"]

--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -335,8 +335,26 @@ def auto_forward_cap_alert(
     payload['forwarding_decision'] = 'forwarded'
     payload['forwarded'] = True
 
+    # Push the alert text onto every active Icecast stream while the broadcast
+    # is on the air; clear it once handle_alert() returns so normal source
+    # metadata (song titles, etc.) resumes.
+    from app_core.audio.alert_metadata import (
+        clear_alert_metadata,
+        set_alert_metadata,
+    )
+
+    alert_title = (getattr(cap_alert, 'headline', '') or '').strip()
+    if not alert_title:
+        alert_title = (getattr(cap_alert, 'event', '') or '').strip()
+    if alert_title:
+        set_alert_metadata(alert_title)
+
     try:
-        broadcast_result = broadcaster.handle_alert(cap_alert, payload)
+        try:
+            broadcast_result = broadcaster.handle_alert(cap_alert, payload)
+        finally:
+            if alert_title:
+                clear_alert_metadata()
     except Exception as exc:
         reason = f"EASBroadcaster.handle_alert() failed: {exc}"
         log.error("Auto-forward failed for %s: %s", result['identifier'], reason, exc_info=True)
@@ -585,8 +603,24 @@ def auto_forward_ota_alert(
         log.error("OTA auto-forward failed: %s", result['reason'])
         return result
 
+    # Push the alert text onto every active Icecast stream while the broadcast
+    # is on the air; clear it once handle_alert() returns so normal source
+    # metadata resumes.
+    from app_core.audio.alert_metadata import (
+        clear_alert_metadata,
+        set_alert_metadata,
+    )
+
+    alert_title = (alert_object.headline or '').strip()
+    if alert_title:
+        set_alert_metadata(alert_title)
+
     try:
-        broadcast_result = broadcaster.handle_alert(alert_object, payload)
+        try:
+            broadcast_result = broadcaster.handle_alert(alert_object, payload)
+        finally:
+            if alert_title:
+                clear_alert_metadata()
     except Exception as exc:
         result['reason'] = f"EASBroadcaster.handle_alert() failed: {exc}"
         log.error("OTA auto-forward failed: %s", result['reason'], exc_info=True)

--- a/app_core/audio/auto_streaming.py
+++ b/app_core/audio/auto_streaming.py
@@ -373,6 +373,38 @@ class AutoStreamingService:
         """
         return self.enabled and bool(self.icecast_password)
 
+    def update_alert_metadata(
+        self, title: str, artist: Optional[str] = "EAS Alert"
+    ) -> int:
+        """Override metadata on every active streamer with alert text.
+
+        Returns the number of streamers that accepted the override.
+        """
+        if not title:
+            return 0
+        count = 0
+        with self._lock:
+            for key, streamer in self._streamers.items():
+                try:
+                    if streamer.update_alert_metadata(title, artist):
+                        count += 1
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to set alert metadata on %s: %s", key, exc
+                    )
+        return count
+
+    def clear_alert_metadata(self) -> None:
+        """Release the alert metadata override on every active streamer."""
+        with self._lock:
+            for key, streamer in self._streamers.items():
+                try:
+                    streamer.clear_alert_metadata()
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to clear alert metadata on %s: %s", key, exc
+                    )
+
     def _add_eas_ingest_stream(self, source_name: str, source_adapter, mount_name: str = "eas-ingest") -> bool:
         """
         Create an Icecast stream for the EAS decoder input (16 kHz mono).

--- a/app_core/audio/icecast_output.py
+++ b/app_core/audio/icecast_output.py
@@ -139,6 +139,9 @@ class IcecastStreamer:
         self._last_metadata_payload: Optional[Tuple[str, Optional[str]]] = None
         self._last_metadata_song: Optional[str] = None
         self._last_metadata_check = 0.0
+        # When an alert is being forwarded, an override is set so the
+        # source-metadata poller doesn't overwrite the alert text mid-broadcast.
+        self._alert_metadata_override: Optional[Tuple[str, Optional[str]]] = None
         self._metadata_poll_interval = max(self.config.metadata_poll_interval, 0.5)
         self._source_timeout = max(getattr(self.config, 'source_timeout', 30.0) or 0.0, 0.0)
         self._last_write_time = 0.0
@@ -841,6 +844,11 @@ class IcecastStreamer:
         if not (self.config.admin_user and self.config.admin_password):
             return
 
+        # An alert metadata override takes precedence over the upstream
+        # source's now-playing info until clear_alert_metadata() is called.
+        if self._alert_metadata_override is not None:
+            return
+
         metrics = getattr(self.audio_source, 'metrics', None)
         metadata = getattr(metrics, 'metadata', None)
         if not isinstance(metadata, dict):
@@ -1320,6 +1328,44 @@ class IcecastStreamer:
             return True
 
         return False
+
+    def update_alert_metadata(
+        self, title: str, artist: Optional[str] = "EAS Alert"
+    ) -> bool:
+        """Override stream metadata with alert text and suppress source polling.
+
+        The override stays in effect until :meth:`clear_alert_metadata` is
+        called, so the next ``_maybe_update_metadata`` poll will not replace
+        the alert title with the upstream source's now-playing info.
+        """
+        safe_title = self._sanitize_metadata_value(title, "")
+        safe_title = safe_title.strip() if safe_title else ""
+        if not safe_title:
+            return False
+
+        safe_artist = self._sanitize_metadata_value(artist, "") if artist else ""
+        safe_artist = safe_artist.strip() if safe_artist else None
+
+        self._alert_metadata_override = (safe_title, safe_artist)
+
+        sent_value = self._send_metadata_update(safe_title, safe_artist or "")
+        if sent_value:
+            cache_key = (safe_title, safe_artist)
+            self._last_metadata_payload = cache_key
+            self._last_metadata_song = sent_value
+            return True
+
+        return False
+
+    def clear_alert_metadata(self) -> None:
+        """Release the alert metadata override; source metadata resumes on next poll."""
+        if self._alert_metadata_override is None:
+            return
+        self._alert_metadata_override = None
+        # Force the next source-metadata sync to push an update by clearing
+        # the cache key — otherwise the poller's "no change" guard would
+        # leave the alert text on the stream until the song genuinely changes.
+        self._last_metadata_payload = None
 
     def get_stats(self) -> dict:
         """Get streaming statistics."""

--- a/eas_monitoring_service.py
+++ b/eas_monitoring_service.py
@@ -585,6 +585,14 @@ def initialize_auto_streaming(app, audio_controller):
             else:
                 logger.warning("Icecast auto-streaming service failed to start")
 
+            # Register with the alert-metadata coordinator so the auto-forwarder
+            # can override stream titles with the alert text mid-broadcast.
+            try:
+                from app_core.audio import alert_metadata
+                alert_metadata.set_service(_auto_streaming_service)
+            except Exception as exc:
+                logger.warning("Failed to register alert metadata coordinator: %s", exc)
+
             return _auto_streaming_service
 
     except Exception as exc:


### PR DESCRIPTION
When an alert is being auto-forwarded, push the alert headline (or
event name) onto every active Icecast mount and suppress the
source-metadata poller so listeners see the alert text for the full
broadcast window. Metadata reverts to normal source info as soon as
handle_alert() returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emergency alerts now automatically update stream metadata to display alert information across all active audio streams, ensuring listeners see alert details instead of regular content
  * Alert metadata overrides are automatically cleared after alert broadcasting completes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->