### PR TITLE
RBDS: reset per-sync stats on every lock acquisition

### DIFF
--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -1796,6 +1796,12 @@ class RBDSWorker:
                                     # immediate sync loss for stations broadcasting Group 2B.
                                     self._rbds_block_number = (offset_pos[j] + 1) % 4
                                     self._rbds_group_assembly_started = False
+                                    # Stale failure streak from the previous lock would
+                                    # otherwise trip the burst-FEC suppression gate on
+                                    # the very first blocks of this new lock — silently
+                                    # disabling the corrector that's most useful right
+                                    # when we're trying to ratify a tentative sync.
+                                    self._rbds_consecutive_crc_failures = 0
                                     # Update polarity to match the triggering block so synced-mode
                                     # CRC checks use the correct inversion flag.
                                     self._rbds_inverted_polarity = polarity
@@ -1806,6 +1812,23 @@ class RBDSWorker:
                                     # groups (see _RBDS_TENTATIVE_GOOD_GROUPS).
                                     self._rbds_sync_tentative = True
                                     self._rbds_tentative_good_groups = 0
+                                    # Reset per-lock health stats so BLER and FEC
+                                    # counts reflect the *current* sync window, as
+                                    # the RBDSDecoderStats docstring promises.  The
+                                    # prior behaviour silently violated that contract:
+                                    # blocks_total / blocks_uncorrected accumulated
+                                    # across every marginal lock since boot, so a
+                                    # receiver that had bounced sync 78 times showed
+                                    # 65% BLER even when the live signal was clean.
+                                    # sync_lost_count is preserved (it's documented
+                                    # as the one cumulative counter) so the operator-
+                                    # visible "sync drops since boot" still reflects
+                                    # lifetime drops on this station.
+                                    with self._stats_lock:
+                                        preserved_drops = self._stats.sync_lost_count
+                                        self._stats = RBDSDecoderStats(
+                                            sync_lost_count=preserved_drops,
+                                        )
                         break  # Syndrome found, exit j loop
             
             else:

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -398,6 +398,73 @@ def test_rbds_lock_starts_in_tentative_state():
     worker.stop()
 
 
+def test_rbds_lock_resets_per_sync_stats_but_keeps_sync_lost_count():
+    """Per-sync stats must reset on every new lock; sync_lost_count must persist.
+
+    Regression test for the displayed BLER drifting upward over a session: the
+    RBDSDecoderStats docstring promises blocks_total / blocks_uncorrected /
+    blocks_fec_* / groups_decoded / group_type_counts reset on every sync
+    acquisition, leaving only sync_lost_count cumulative.  Before this fix
+    those counters accumulated across every marginal lock since boot, so a
+    receiver that had bounced sync 78 times kept showing 65% net BLER even
+    after the live signal cleaned up.
+    """
+    worker = _make_worker()
+    # Pre-load stats with the kind of accumulated history a long-running
+    # session would have:  thousands of blocks, mostly uncorrected, plus a
+    # handful of operator-visible sync drops.
+    worker._stats.blocks_total = 12876
+    worker._stats.blocks_ok = 3173
+    worker._stats.blocks_fec_single = 538
+    worker._stats.blocks_fec_burst = 734
+    worker._stats.blocks_uncorrected = 8431
+    worker._stats.groups_decoded = 96
+    worker._stats.sync_lost_count = 78
+    worker._stats.group_type_counts = {"0A": 43, "2A": 47, "12A": 6}
+
+    # Drive presync with a buffer that ends *exactly* at the third syndrome
+    # hit, so the sync transition is the last thing the loop does before
+    # returning.  This isolates "the reset that happens on sync acquisition"
+    # from any post-sync block processing the helper would otherwise add.
+    worker._rbds_bit_buffer = [0] * 153
+    call_index = 0
+    hit_map = {100: 383, 126: 14, 152: 303}
+
+    def fake_calc_syndrome(_word: int, message_length: int) -> int:
+        nonlocal call_index
+        bit_index = call_index // 2
+        is_inverted_path = (call_index % 2) == 1
+        call_index += 1
+        if message_length == 26 and not is_inverted_path:
+            return hit_map.get(bit_index, 0)
+        return 0
+
+    worker._calc_syndrome = fake_calc_syndrome  # type: ignore[assignment]
+    worker._decode_rbds_groups()
+
+    assert worker._rbds_synced is True
+    assert worker._rbds_sync_tentative is True
+    # Per-sync counters wiped — BLER now reflects the new lock window only.
+    assert worker._stats.blocks_total == 0
+    assert worker._stats.blocks_ok == 0
+    assert worker._stats.blocks_fec_single == 0
+    assert worker._stats.blocks_fec_burst == 0
+    assert worker._stats.blocks_uncorrected == 0
+    assert worker._stats.groups_decoded == 0
+    assert worker._stats.group_type_counts == {}
+    # Cumulative drop counter survives so the operator-visible "drops since
+    # boot" indicator is unaffected.
+    assert worker._stats.sync_lost_count == 78
+    # And sync_acquired_unix is still None — a tentative lock is not yet a
+    # confirmed lock, regardless of the stats reset.
+    assert worker._stats.sync_acquired_unix is None
+    # The burst-FEC suppression streak from the prior lock must also be
+    # cleared so the corrector is available on the very first blocks of
+    # this fresh lock.
+    assert worker._rbds_consecutive_crc_failures == 0
+    worker.stop()
+
+
 def test_rbds_tentative_sync_confirms_with_enough_good_groups():
     """≥ _RBDS_TENTATIVE_GOOD_GROUPS fully-decoded groups in 50 blocks → CONFIRMED."""
     worker = _make_worker()


### PR DESCRIPTION
The RBDSDecoderStats docstring has always promised that blocks_total /
blocks_ok / blocks_fec_* / blocks_uncorrected / groups_decoded /
group_type_counts reset on every sync acquisition, leaving only
sync_lost_count cumulative.  The code never actually did that — those
fields only got cleared on _apply_reset (frequency change), so a
receiver that bounced sync 78 times since boot kept reporting every
marginal-lock block in its lifetime BLER.  In the field this surfaced
as ~65% net BLER even when the current sync window was clean, because
the stat was dominated by thousands of bad blocks from earlier
sub-second tentative locks that never decoded a usable group.

Reset blocks_* / groups_decoded / group_type_counts (and clear the
burst-FEC suppression streak _rbds_consecutive_crc_failures so the
corrector isn't pre-disabled on the new lock's first blocks) at the
moment the presync state machine fires TENTATIVELY SYNCED.  Preserve
sync_lost_count, the one counter explicitly documented as cumulative.

Regression test pre-loads stats with the screenshot's
(12876/8431/78/{0A:43, 2A:47, 12A:6}) numbers and drives presync; all
per-sync fields drop to zero, sync_lost_count stays at 78, and
sync_acquired_unix stays None (tentative != confirmed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed radio demodulation sync-state handling to prevent stale error conditions from affecting new lock acquisition.
  * Improved health metric accuracy by resetting per-session statistics on each new sync lock while preserving cumulative sync loss tracking.

* **Tests**
  * Added regression test to validate sync-transition state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->