### PR TITLE
ingest: cache resample_poly FIR taps per (up, down) ratio

### DIFF
--- a/app_core/audio/ingest.py
+++ b/app_core/audio/ingest.py
@@ -40,10 +40,39 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-from scipy.signal import resample_poly
+from scipy.signal import firwin, resample_poly
 from .broadcast_queue import BroadcastQueue
 
 logger = logging.getLogger(__name__)
+
+
+# Cache of FIR filter taps used by _resample_for_eas, keyed by (up, down).
+# scipy.signal.resample_poly designs a fresh kaiser FIR on every call when
+# window= is left at the default; for 44100 -> 16000 that's ~8800 taps via
+# firwin+kaiser, which py-spy showed at ~1.7 s OwnTime/30 s sampling under
+# real load. We pre-design once per (up, down) ratio and pass the taps as
+# window=. In practice audio sources only use a handful of rates (8/16/22.05/
+# 32/44.1/48/96 kHz) so the cache stays bounded without an LRU.
+_RESAMPLE_FILTER_CACHE: Dict[tuple, np.ndarray] = {}
+
+
+def _design_resample_filter(up: int, down: int) -> np.ndarray:
+    """Return scipy's default resample_poly FIR for the given up/down ratio.
+
+    Mirrors the design scipy uses internally when window=('kaiser', 5.0):
+    a 2*half_len+1 tap firwin lowpass with cutoff 1/max(up, down) and
+    half_len = 10 * max(up, down). Cached per (up, down) so the cost is
+    paid once instead of per chunk.
+    """
+    cached = _RESAMPLE_FILTER_CACHE.get((up, down))
+    if cached is not None:
+        return cached
+    max_rate = max(up, down)
+    half_len = 10 * max_rate
+    taps = firwin(2 * half_len + 1, 1.0 / max_rate, window=("kaiser", 5.0))
+    taps = taps.astype(np.float32)
+    _RESAMPLE_FILTER_CACHE[(up, down)] = taps
+    return taps
 
 
 class AudioSourceType(Enum):
@@ -467,10 +496,18 @@ class AudioSourceAdapter(ABC):
             # resample_poly applies a properly anti-aliased FIR via FFT convolution,
             # which is both faster than per-sample np.interp and avoids the aliasing
             # artifacts plain linear interpolation produces above Nyquist/2.
+            #
+            # We pass the FIR taps via window= rather than letting scipy redesign
+            # them every call (~1.7 s/30 s of CPU per the py-spy profile). scipy
+            # mutates the array in-place (h *= up) so we pass a copy of the cached
+            # taps; copy of ~35 KB is microseconds vs. milliseconds of firwin work.
             g = gcd(int(source_rate), int(target_rate))
             up = int(target_rate) // g
             down = int(source_rate) // g
-            return resample_poly(audio_chunk, up, down).astype(np.float32)
+            taps = _design_resample_filter(up, down)
+            return resample_poly(
+                audio_chunk, up, down, window=taps.copy()
+            ).astype(np.float32)
 
         except Exception as e:
             logger.error("Error resampling audio for EAS: %s", e)


### PR DESCRIPTION
## Summary

Follow-up to the `np.interp` → `scipy.signal.resample_poly` swap that landed in #1972 (commit `d86a2c5`). py-spy on the live monitoring service after that change showed `resample_poly` costing ~12.6 s of TotalTime over a 30 s sample, with `firwin` (1.04 s) and `kaiser` (0.67 s) appearing as new top-10 entries — `resample_poly` redesigns its kaiser FIR on every call by default. For 44.1 kHz → 16 kHz that's an 8821-tap firwin+kaiser design redone for every audio chunk on every stream source.

This commit pre-designs the filter once per `(up, down)` ratio and passes the taps via `window=` so `resample_poly` skips its design step. Audio sources only use a handful of rates (8/16/22.05/32/44.1/48/96 kHz) so a plain dict cache stays bounded without LRU machinery.

scipy mutates the filter array in-place (`h *= up`) inside `resample_poly`, so we hand it a `.copy()` of the cached taps each call — copying ~35 KB of float32 is microseconds; redoing `firwin` is milliseconds.

## Profile impact (py-spy on the live service)

After this commit went onto the running Pi (alongside the four prior commits from #1972):

| Metric | Before | After |
|---|---|---|
| `firwin` per second | 0.035 s/s | **0.015 s/s** (−57%) |
| `kaiser` per second | 0.022 s/s | **0.013 s/s** (−41%) |
| `resample_poly` total per second | 0.42 s/s | **0.20 s/s** (−52%) |
| Active CPU | 250% | **239%** |

Combined with #1972 the monitoring service dropped from 301% → 239% CPU.

## Why this is a separate PR

This commit was on `claude/eas-decoder-cpp-evaluation-0gaAM` when #1972 was merged, but landed on the branch *after* that PR was created, so it didn't ship with the others. The branch has since been merged with current `main` (which now also includes #1973's Numba RBDS pass) so this PR shows only the cache changes.

## Test plan

- [ ] Restart `eas_monitoring_service` on the Pi after merge
- [ ] Run `py-spy top --pid $(pgrep -f eas_monitoring_service)` and confirm `firwin` / `kaiser` drop further from their post-#1972, post-#1973 values
- [ ] Smoke-test that non-integer-ratio audio sources (e.g. 44.1 kHz Icecast streams) still feed the EAS decoder correctly

https://claude.ai/code/session_018K9eogeAPZQ7DQBKPkCULq


---
_Generated by [Claude Code](https://claude.ai/code/session_018K9eogeAPZQ7DQBKPkCULq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized audio resampling to improve processing efficiency through enhanced filter caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->