### PR TITLE
Fix lightning-theme tone settings readability and hide irrelevant fields

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -6851,7 +6851,8 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="midnight"] .alert-light,
 [data-theme="charcoal"] .alert-light,
 [data-theme="obsidian"] .alert-light,
-[data-theme="slate"] .alert-light {
+[data-theme="slate"] .alert-light,
+[data-theme="lightning"] .alert-light {
     --bs-alert-color: var(--text-color);
     --bs-alert-bg: color-mix(in srgb, var(--surface-color) 90%, var(--border-color));
     --bs-alert-border-color: var(--border-color);
@@ -6867,7 +6868,8 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
 [data-theme="midnight"] .alert-secondary,
 [data-theme="charcoal"] .alert-secondary,
 [data-theme="obsidian"] .alert-secondary,
-[data-theme="slate"] .alert-secondary {
+[data-theme="slate"] .alert-secondary,
+[data-theme="lightning"] .alert-secondary {
     --bs-alert-color: var(--text-secondary);
     --bs-alert-bg: color-mix(in srgb, var(--secondary-color) 15%, var(--surface-color));
     --bs-alert-border-color: color-mix(in srgb, var(--secondary-color) 30%, var(--border-color));

--- a/static/js/admin/location-settings.js
+++ b/static/js/admin/location-settings.js
@@ -938,6 +938,12 @@ function initEasSettings() {
     // Form submission handler
     form.addEventListener('submit', handleEasSettingsSubmit);
 
+    // Toggle conditional tone fields when chime selection changes
+    const preChimeSelect = document.getElementById('easPreAlertChime');
+    const postChimeSelect = document.getElementById('easPostAlertChime');
+    if (preChimeSelect) preChimeSelect.addEventListener('change', updateToneFieldVisibility);
+    if (postChimeSelect) postChimeSelect.addEventListener('change', updateToneFieldVisibility);
+
     // Reset button handler
     const resetBtn = document.getElementById('resetEasSettings');
     if (resetBtn) {
@@ -950,6 +956,30 @@ function initEasSettings() {
             }
         });
     }
+}
+
+/**
+ * Show/hide tone-specific settings fields based on the selected chime types.
+ * QC-II frequencies appear only when either chime is QC-II; DTMF sequence
+ * appears only when either chime is DTMF; per-side duration appears only
+ * when that side has a chime selected.
+ */
+function updateToneFieldVisibility() {
+    const pre = document.getElementById('easPreAlertChime')?.value || 'none';
+    const post = document.getElementById('easPostAlertChime')?.value || 'none';
+
+    const visibility = {
+        'qc2': pre === 'qc2' || post === 'qc2',
+        'dtmf': pre === 'dtmf' || post === 'dtmf',
+        'pre-duration': pre !== 'none',
+        'post-duration': post !== 'none',
+    };
+
+    document.querySelectorAll('.eas-tone-conditional').forEach(el => {
+        const key = el.dataset.easToneShow;
+        const show = visibility[key];
+        el.style.display = show ? '' : 'none';
+    });
 }
 
 /**
@@ -1058,6 +1088,8 @@ function populateEasForm(settings) {
         cb.checked = forwarded.size === 0 ? false : forwarded.has(cb.value);
     });
     syncForwardedEventCodesHidden();
+
+    updateToneFieldVisibility();
 }
 
 /**

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -877,13 +877,13 @@
                                                     </select>
                                                     <small class="text-muted">Plays before the first SAME header burst.</small>
                                                 </div>
-                                                <div class="col-md-6">
+                                                <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="pre-duration">
                                                     <label for="easPreAlertChimeDuration" class="form-label fw-bold">Pre-Alert Chime Duration</label>
                                                     <div class="input-group">
                                                         <input type="number" class="form-control" id="easPreAlertChimeDuration" name="pre_alert_chime_duration" min="0.1" max="10" step="0.1" value="2.0">
                                                         <span class="input-group-text">seconds</span>
                                                     </div>
-                                                    <small class="text-muted">Total chime duration (0.1–10 seconds). Ignored when chime is None.</small>
+                                                    <small class="text-muted">Total chime duration (0.1–10 seconds).</small>
                                                 </div>
                                                 <div class="col-md-6">
                                                     <label for="easPostAlertChime" class="form-label fw-bold">Post-Alert Chime</label>
@@ -897,15 +897,15 @@
                                                     </select>
                                                     <small class="text-muted">Plays after the EOM sequence.</small>
                                                 </div>
-                                                <div class="col-md-6">
+                                                <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="post-duration">
                                                     <label for="easPostAlertChimeDuration" class="form-label fw-bold">Post-Alert Chime Duration</label>
                                                     <div class="input-group">
                                                         <input type="number" class="form-control" id="easPostAlertChimeDuration" name="post_alert_chime_duration" min="0.1" max="10" step="0.1" value="2.0">
                                                         <span class="input-group-text">seconds</span>
                                                     </div>
-                                                    <small class="text-muted">Total chime duration (0.1–10 seconds). Ignored when chime is None.</small>
+                                                    <small class="text-muted">Total chime duration (0.1–10 seconds).</small>
                                                 </div>
-                                                <div class="col-12">
+                                                <div class="col-12 eas-tone-conditional" data-eas-tone-show="qc2">
                                                     <div class="alert alert-light border small mb-0">
                                                         <i class="fas fa-info-circle me-2 text-info"></i>
                                                         <strong>QC-II (Motorola Quick Call II)</strong> two-tone paging uses Tone&nbsp;A
@@ -913,7 +913,7 @@
                                                         frequencies below to match your dispatch protocol.
                                                     </div>
                                                 </div>
-                                                <div class="col-md-6">
+                                                <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="qc2">
                                                     <label for="easQc2ToneAFreq" class="form-label fw-bold">QC-II Tone&nbsp;A Frequency</label>
                                                     <div class="input-group">
                                                         <input type="number" class="form-control" id="easQc2ToneAFreq" name="qc2_tone_a_freq" min="50" max="4000" step="0.1" value="1000.0">
@@ -921,7 +921,7 @@
                                                     </div>
                                                     <small class="text-muted">First (short) tone, 50–4000 Hz.</small>
                                                 </div>
-                                                <div class="col-md-6">
+                                                <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="qc2">
                                                     <label for="easQc2ToneBFreq" class="form-label fw-bold">QC-II Tone&nbsp;B Frequency</label>
                                                     <div class="input-group">
                                                         <input type="number" class="form-control" id="easQc2ToneBFreq" name="qc2_tone_b_freq" min="50" max="4000" step="0.1" value="1500.0">
@@ -929,7 +929,7 @@
                                                     </div>
                                                     <small class="text-muted">Second (long) tone, 50–4000 Hz.</small>
                                                 </div>
-                                                <div class="col-12">
+                                                <div class="col-12 eas-tone-conditional" data-eas-tone-show="dtmf">
                                                     <div class="alert alert-light border small mb-0">
                                                         <i class="fas fa-info-circle me-2 text-info"></i>
                                                         <strong>DTMF (Dual-Tone Multi-Frequency)</strong> plays each character of the sequence below as
@@ -937,7 +937,7 @@
                                                         <code>*</code>, <code>#</code>. Timing is fixed at 100&nbsp;ms tone / 50&nbsp;ms gap per digit.
                                                     </div>
                                                 </div>
-                                                <div class="col-12">
+                                                <div class="col-12 eas-tone-conditional" data-eas-tone-show="dtmf">
                                                     <label for="easDtmfSequence" class="form-label fw-bold">DTMF Sequence</label>
                                                     <input type="text" class="form-control" id="easDtmfSequence" name="dtmf_sequence" maxlength="32" placeholder="e.g. *1234#" pattern="[0-9A-Da-d*#]*" style="text-transform: uppercase;">
                                                     <small class="text-muted">Up to 32 valid digits; invalid characters are stripped on save.</small>


### PR DESCRIPTION
The Lightning theme rendered .alert-light with cream text on near-white
because lightning was missing from the dark-theme alert overrides while
.alert still inherited --text-color (#fffde7). Adds lightning to the
.alert-light and .alert-secondary override lists so info boxes use the
deep-storm surface color and remain legible.

Tone settings also showed every field at all times, even when the chosen
chime type didn't use them. Wraps the duration, QC-II, and DTMF fields
in conditional containers and toggles them based on the selected pre/post
chime types so users only see the inputs that apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-theme alert visibility and contrast support for the lightning theme alongside existing slate theme

* **New Features**
  * EAS admin form now dynamically displays or hides tone configuration fields based on the selected chime option

* **Bug Fixes**
  * Removed outdated user-facing note regarding ignored chime duration values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->