### PR TITLE
Fix DTMF and QC-II chime duration controls

### DIFF
--- a/app_core/_models_settings.py
+++ b/app_core/_models_settings.py
@@ -597,9 +597,9 @@ class EASSettings(db.Model):
     # Allowed values: 'none', 'bell', 'beep', 'three_tone', 'qc2', 'dtmf'.
 
     pre_alert_chime_duration = db.Column(db.Float, nullable=False, default=2.0)
-    # Duration in seconds for the pre-alert chime (0.1–10.0). For QC-II,
-    # split 25%/75% between Tone A and Tone B (standard 1 s / 3 s ratio).
-    # Ignored for DTMF, which uses standard 100 ms tone / 50 ms gap timing.
+    # Duration in seconds for the pre-alert chime (0.1–10.0). Applies only
+    # to free-form profiles (bell, beep, three_tone). Ignored for DTMF
+    # (fixed 100 ms tone / 50 ms gap per digit) and QC-II (fixed 1 s + 3 s).
 
     post_alert_chime_duration = db.Column(db.Float, nullable=False, default=2.0)
     # Duration in seconds for the post-alert chime (0.1–10.0). See note above.

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1622,10 +1622,10 @@ def _generate_chime(
         - 'beep':       sustained 1000 Hz sine for the full duration.
         - 'three_tone': three ascending tones (440, 880, 1320 Hz),
                         each occupying ~1/3 of the duration.
-        - 'qc2':        Motorola Quick Call II two-tone paging — Tone A
-                        (``qc2_tone_a_freq``) for ~25% of the duration,
-                        followed by Tone B (``qc2_tone_b_freq``) for ~75%.
-                        The 25/75 split matches the standard 1 s / 3 s ratio.
+        - 'qc2':        Motorola Quick Call II two-tone paging — fixed
+                        1 s Tone A (``qc2_tone_a_freq``) followed by
+                        3 s Tone B (``qc2_tone_b_freq``), 4 s total.
+                        ``duration`` is ignored to keep timing on-spec.
         - 'dtmf':       Plays each character of ``dtmf_sequence`` (digits
                         0-9, letters A-D, * or #) as its standard DTMF
                         low+high tone pair, using ITU-T Q.24 timing
@@ -1634,7 +1634,8 @@ def _generate_chime(
     Args:
         profile: Chime profile name (case-insensitive).
         duration: Total duration in seconds (clamped to 0.1–10.0).
-            Ignored when ``profile == 'dtmf'``.
+            Ignored when ``profile`` is ``'dtmf'`` or ``'qc2'`` — both use
+            standardized fixed timings.
         sample_rate: Output sample rate in Hz.
         amplitude: Peak signed-int amplitude (e.g. 0.7 * 32767).
         qc2_tone_a_freq: Tone A frequency in Hz when ``profile == 'qc2'``.
@@ -1719,8 +1720,11 @@ def _generate_chime(
         return samples
 
     if name in ('qc2', 'qcii', 'quickcall', 'quick_call', 'two_tone'):
-        # Standard QC-II split: Tone A occupies 25% (≈1 s of a 4 s chime),
-        # Tone B occupies the remaining 75% (≈3 s of a 4 s chime).
+        # Motorola Quick Call II is a standardized two-tone paging protocol
+        # with fixed timing: 1 s Tone A followed by 3 s Tone B (4 s total).
+        # `duration` is intentionally ignored — pagers time against the
+        # absolute 1 s / 3 s segments, so any other ratio produces a
+        # non-spec signal that real receivers may refuse to decode.
         try:
             freq_a = float(qc2_tone_a_freq)
         except (TypeError, ValueError):
@@ -1729,19 +1733,19 @@ def _generate_chime(
             freq_b = float(qc2_tone_b_freq)
         except (TypeError, ValueError):
             freq_b = 1500.0
-        # Clamp frequencies to the audible-but-paging-realistic range.
         freq_a = max(50.0, min(4000.0, freq_a))
         freq_b = max(50.0, min(4000.0, freq_b))
 
-        a_samples = max(1, total_samples // 4)
-        b_samples = max(1, total_samples - a_samples)
+        a_samples = max(1, int(1.0 * sample_rate))
+        b_samples = max(1, int(3.0 * sample_rate))
+        out: List[int] = []
         for n in range(a_samples):
             t = n / sample_rate
-            samples.append(int(math.sin(2 * math.pi * freq_a * t) * amplitude))
+            out.append(int(math.sin(2 * math.pi * freq_a * t) * amplitude))
         for n in range(b_samples):
             t = n / sample_rate
-            samples.append(int(math.sin(2 * math.pi * freq_b * t) * amplitude))
-        return samples
+            out.append(int(math.sin(2 * math.pi * freq_b * t) * amplitude))
+        return out
 
     # Unknown profile: be safe and emit no chime rather than raise.
     return []

--- a/static/js/admin/location-settings.js
+++ b/static/js/admin/location-settings.js
@@ -962,17 +962,20 @@ function initEasSettings() {
  * Show/hide tone-specific settings fields based on the selected chime types.
  * QC-II frequencies appear only when either chime is QC-II; DTMF sequence
  * appears only when either chime is DTMF; per-side duration appears only
- * when that side has a chime selected.
+ * for free-form profiles (bell/beep/three_tone) — DTMF and QC-II have
+ * standardized timings and ignore the duration field.
  */
 function updateToneFieldVisibility() {
     const pre = document.getElementById('easPreAlertChime')?.value || 'none';
     const post = document.getElementById('easPostAlertChime')?.value || 'none';
 
+    const isFreeform = (v) => v !== 'none' && v !== 'dtmf' && v !== 'qc2';
+
     const visibility = {
         'qc2': pre === 'qc2' || post === 'qc2',
         'dtmf': pre === 'dtmf' || post === 'dtmf',
-        'pre-duration': pre !== 'none',
-        'post-duration': post !== 'none',
+        'pre-duration': isFreeform(pre),
+        'post-duration': isFreeform(post),
     };
 
     document.querySelectorAll('.eas-tone-conditional').forEach(el => {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -908,9 +908,9 @@
                                                 <div class="col-12 eas-tone-conditional" data-eas-tone-show="qc2">
                                                     <div class="alert alert-light border small mb-0">
                                                         <i class="fas fa-info-circle me-2 text-info"></i>
-                                                        <strong>QC-II (Motorola Quick Call II)</strong> two-tone paging uses Tone&nbsp;A
-                                                        (≈25% of the chime duration) followed by Tone&nbsp;B (≈75%). Set the tone-pair
-                                                        frequencies below to match your dispatch protocol.
+                                                        <strong>QC-II (Motorola Quick Call II)</strong> two-tone paging uses a fixed
+                                                        1&nbsp;s Tone&nbsp;A followed by a 3&nbsp;s Tone&nbsp;B (4&nbsp;s total). Timing is
+                                                        standardized — only the tone-pair frequencies below are configurable.
                                                     </div>
                                                 </div>
                                                 <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="qc2">


### PR DESCRIPTION
DTMF timing is fixed by ITU-T Q.24 (100 ms tone / 50 ms gap) and the
duration value was already silently discarded.  Quick Call II is a
standardized two-tone protocol with fixed 1 s Tone A + 3 s Tone B
timing — letting the operator rescale that produced a non-spec signal
real pagers may refuse to decode.

- Hide the per-side duration field when the chime is dtmf or qc2.
- Force QC-II to emit the standardized 1 s / 3 s segments regardless
  of the stored duration.
- Update docstrings, model comments, and admin helper text to match.

https://claude.ai/code/session_0171AgDjeSbuW6PXHaXzydP4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QC-II chimes now use fixed Motorola Quick Call II timing (1 second Tone A, 3 seconds Tone B).

* **Bug Fixes**
  * Duration configuration fields are now hidden for QC-II and DTMF chimes since they use fixed timing.

* **Documentation**
  * Updated help text to clarify QC-II timing pattern and that only tone frequencies are configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->