### PR TITLE
Add NMEA sentence logging and MTK3339 configuration to GPS manager

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -33,7 +33,7 @@ Hardware:
 Dependencies:
 - pyserial: Serial port I/O
 - pynmea2: NMEA-0183 sentence parser
-- RPi.GPIO (optional): PPS pulse reading
+- gpiozero (optional): PPS pulse reading via GPIO interrupt
 """
 
 import json
@@ -41,14 +41,38 @@ import logging
 import os
 import threading
 import time
+from collections import Counter, deque
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Deque, Dict, List, Optional
 
 
 # Redis key used for GPS status storage
 REDIS_KEY = "gps:status"
+# Redis key used for the rolling NMEA sentence log
+REDIS_NMEA_KEY = "gps:nmea"
 # TTL in seconds for the Redis key (refreshed every poll cycle)
 REDIS_TTL = 15
+# Maximum number of raw NMEA sentences kept in the rolling log
+NMEA_LOG_SIZE = 50
+
+def _nmea_checksum(payload: str) -> str:
+    """Return the two-character XOR checksum used in NMEA / PMTK sentences."""
+    cs = 0
+    for ch in payload:
+        cs ^= ord(ch)
+    return f"{cs:02X}"
+
+
+# MTK3339 PMTK command to enable RMC, GGA, GSA, GSV, VTG NMEA output.
+#   RMC=1Hz, VTG=1Hz, GGA=1Hz, GSA=1Hz, GSV every 5 fixes (≈5s @1Hz),
+#   all other sentences disabled.
+# Adafruit's Ultimate GPS HAT (#2324) ships emitting RMC+GGA only — without
+# this command the sky-view (GSV) and active-satellite (GSA) data never
+# arrive, so the UI shows "No satellite data yet…" indefinitely.
+_PMTK_SET_NMEA_OUTPUT_BODY = "PMTK314,0,1,1,1,1,5,0,0,0,0,0,0,0,0,0,0,0,0,0"
+PMTK_SET_NMEA_OUTPUT = (
+    f"${_PMTK_SET_NMEA_OUTPUT_BODY}*{_nmea_checksum(_PMTK_SET_NMEA_OUTPUT_BODY)}\r\n"
+)
 
 # NMEA fix quality codes
 _FIX_QUALITY = {
@@ -114,6 +138,17 @@ class GPSManager:
         self._gsv_buffer: Dict[int, Dict[str, Any]] = {}
         # PPS GPIO interrupt state
         self._pps_gpio_active: bool = False
+        self._pps_device = None  # gpiozero.DigitalInputDevice instance
+        self._pps_backend: Optional[str] = None  # 'gpiozero', 'rpi.gpio', or None
+        self._pps_error: Optional[str] = None    # human-readable failure reason
+
+        # Rolling raw NMEA sentence log (newest last) — protected by _lock
+        self._nmea_log: Deque[Dict[str, Any]] = deque(maxlen=NMEA_LOG_SIZE)
+        # Per-sentence-type counters (e.g. {"GGA": 17, "GSV": 4, ...})
+        self._nmea_counts: Counter = Counter()
+        # Counters for parse errors / sentence read errors
+        self._nmea_parse_errors: int = 0
+        self._nmea_total: int = 0
 
     # ------------------------------------------------------------------
     # Public API
@@ -155,6 +190,11 @@ class GPSManager:
             self._set_error_status("port_open_failed")
             return False
 
+        # Send the PMTK command to enable GGA/GSA/GSV/RMC/VTG output. The
+        # Adafruit GPS HAT only emits RMC+GGA out of the box, so without this
+        # nudge the sky view and active-satellite list stay empty.
+        self._configure_mtk3339()
+
         self._running = True
         self._thread = threading.Thread(
             target=self._reader_loop,
@@ -176,13 +216,19 @@ class GPSManager:
         self._running = False
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=3)
-        if self._pps_gpio_active:
+        if self._pps_device is not None:
+            try:
+                self._pps_device.close()
+            except Exception:
+                pass
+            self._pps_device = None
+        if self._pps_gpio_active and self._pps_backend == "rpi.gpio":
             try:
                 import RPi.GPIO as GPIO  # type: ignore[import]
                 GPIO.remove_event_detect(self._pps_pin)
             except Exception:
                 pass
-            self._pps_gpio_active = False
+        self._pps_gpio_active = False
         if self._ser:
             try:
                 self._ser.close()
@@ -195,6 +241,10 @@ class GPSManager:
         """Return the most-recently parsed GPS fix as a dictionary."""
         with self._lock:
             data = dict(self._fix)
+            data["nmea_counts"] = dict(self._nmea_counts)
+            data["nmea_total"] = self._nmea_total
+            data["nmea_parse_errors"] = self._nmea_parse_errors
+            data["nmea_recent"] = list(self._nmea_log)[-10:]
         # Compute age of the last PPS pulse so the UI can colour the blinkenlite
         last_pulse = data.get("pps_last_pulse_at")
         if last_pulse:
@@ -206,7 +256,30 @@ class GPSManager:
                 data["pps_pulse_age_s"] = None
         else:
             data["pps_pulse_age_s"] = None
+        data["pps_backend"] = self._pps_backend
+        data["pps_error"] = self._pps_error
+        data["pps_gpio_active"] = self._pps_gpio_active
         return data
+
+    def get_nmea_log(self, limit: int = NMEA_LOG_SIZE) -> Dict[str, Any]:
+        """Return the rolling NMEA sentence log + per-type counters."""
+        with self._lock:
+            log_items = list(self._nmea_log)
+            counts = dict(self._nmea_counts)
+            total = self._nmea_total
+            parse_errors = self._nmea_parse_errors
+        if limit > 0:
+            log_items = log_items[-limit:]
+        return {
+            "running": self._running,
+            "serial_port": self._serial_port,
+            "baudrate": self._baudrate,
+            "total_sentences": total,
+            "parse_errors": parse_errors,
+            "counts_by_type": counts,
+            "sentences": log_items,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -237,6 +310,9 @@ class GPSManager:
             # PPS pulse tracking
             "pps_last_pulse_at": None,
             "pps_pulse_count": 0,
+            "pps_backend": None,
+            "pps_error": None,
+            "pps_gpio_active": False,
         }
 
     def _reader_loop(self) -> None:
@@ -273,12 +349,20 @@ class GPSManager:
 
                 consecutive_errors = 0
 
+                # Log the raw sentence regardless of whether it parses cleanly
+                # so the diagnostics page can show the actual bytes coming
+                # off the serial port (talker IDs, checksums, missing fields).
+                parse_ok = True
                 try:
                     msg = pynmea2.parse(line)
                 except pynmea2.ParseError:
-                    continue
+                    parse_ok = False
+                    msg = None
 
-                self._handle_sentence(msg)
+                self._record_raw_sentence(line, parse_ok=parse_ok)
+
+                if parse_ok and msg is not None:
+                    self._handle_sentence(msg)
 
             except Exception as exc:
                 consecutive_errors += 1
@@ -425,14 +509,101 @@ class GPSManager:
         except Exception as exc:
             self._logger.debug("Failed to publish GPS status to Redis: %s", exc)
 
-    def _start_pps_monitor(self) -> None:
-        """Set up an RPi.GPIO rising-edge interrupt to detect PPS pulses.
+    def _record_raw_sentence(self, line: str, parse_ok: bool = True) -> None:
+        """Append a raw NMEA sentence to the rolling log and update counters."""
+        # Type code is the 3 chars after the talker (e.g. $GPGSV → GSV).
+        # If the line is malformed we still record it as 'UNKNOWN' so the
+        # diagnostics page can flag the operator to the bad bytes.
+        sentence_type = "UNKNOWN"
+        if parse_ok and line.startswith("$") and "," in line:
+            head = line.split(",", 1)[0]  # $GPGSV
+            if len(head) >= 6:
+                sentence_type = head[3:6]
+        now_iso = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            self._nmea_total += 1
+            if not parse_ok:
+                self._nmea_parse_errors += 1
+            self._nmea_counts[sentence_type] += 1
+            # Trim very long sentences so the JSON payload stays small
+            text = line if len(line) <= 200 else (line[:197] + "...")
+            self._nmea_log.append({
+                "ts": now_iso,
+                "type": sentence_type,
+                "ok": parse_ok,
+                "text": text,
+            })
 
-        Silently no-ops if RPi.GPIO is unavailable (e.g. development host)
-        or if the GPIO pin cannot be configured.
+    def _configure_mtk3339(self) -> None:
+        """Send the PMTK314 command to enable RMC/GGA/GSA/GSV/VTG output.
+
+        The Adafruit Ultimate GPS HAT (#2324) ships emitting only RMC + GGA.
+        Without this command the GSV (sky view) and GSA (active satellites)
+        sentences never arrive, so the polar plot on the hardware page sits
+        on "No satellite data yet…" forever even with a healthy 3D fix.
+
+        Failures are logged and ignored — a non-MTK receiver may simply not
+        understand the command.
+        """
+        if not self._ser:
+            return
+        try:
+            self._ser.reset_input_buffer()
+            self._ser.write(PMTK_SET_NMEA_OUTPUT.encode("ascii"))
+            self._ser.flush()
+            self._logger.info(
+                "Sent PMTK314 to GPS (enable RMC/GGA/GSA/GSV/VTG output)"
+            )
+        except Exception as exc:
+            self._logger.debug("Could not send PMTK314 command: %s", exc)
+
+    def _start_pps_monitor(self) -> None:
+        """Wire up a rising-edge GPIO callback so we can show PPS pulses.
+
+        Tries gpiozero first (uses lgpio/rpi-lgpio, works on Pi 5 + Bookworm
+        kernels). Falls back to the legacy RPi.GPIO library on older systems.
+        Silently no-ops if neither library is available — the rest of the GPS
+        manager keeps working, the UI just paints the PPS LED grey and shows
+        "No PPS signal detected" on hover.
         """
         if not self._pps_pin:
+            self._pps_error = "PPS GPIO pin not configured"
             return
+
+        # Preferred path: gpiozero. It auto-selects the best pin factory
+        # (LGPIOFactory on Pi 5, RPiGPIOFactory on older Pis) so we don't
+        # have to deal with /dev/mem deprecation by hand.
+        try:
+            from gpiozero import DigitalInputDevice  # type: ignore[import]
+
+            self._pps_device = DigitalInputDevice(
+                self._pps_pin,
+                pull_up=False,
+                bounce_time=None,
+            )
+            self._pps_device.when_activated = self._pps_pulse_callback
+            self._pps_gpio_active = True
+            self._pps_backend = "gpiozero"
+            self._pps_error = None
+            self._logger.info(
+                "PPS blinkenlite armed on GPIO BCM %d via gpiozero",
+                self._pps_pin,
+            )
+            return
+        except ImportError as exc:
+            self._logger.debug("gpiozero not available: %s", exc)
+            self._pps_error = "gpiozero not installed"
+        except Exception as exc:
+            self._logger.warning(
+                "gpiozero PPS setup failed on BCM %d: %s — trying RPi.GPIO",
+                self._pps_pin,
+                exc,
+            )
+            self._pps_error = f"gpiozero: {exc}"
+            self._pps_device = None
+
+        # Legacy fallback for systems where gpiozero is unavailable but the
+        # old RPi.GPIO module still works (e.g. Pi 4 on Bullseye).
         try:
             import RPi.GPIO as GPIO  # type: ignore[import]
 
@@ -441,27 +612,39 @@ class GPSManager:
             GPIO.add_event_detect(
                 self._pps_pin,
                 GPIO.RISING,
-                callback=self._pps_pulse_callback,
+                callback=self._pps_pulse_callback_legacy,
             )
             self._pps_gpio_active = True
+            self._pps_backend = "rpi.gpio"
+            self._pps_error = None
             self._logger.info(
-                "PPS blinkenlite armed on GPIO BCM %d", self._pps_pin
+                "PPS blinkenlite armed on GPIO BCM %d via RPi.GPIO",
+                self._pps_pin,
             )
         except ImportError:
-            self._logger.debug(
-                "RPi.GPIO not available — PPS blinkenlite disabled"
+            self._logger.warning(
+                "Neither gpiozero nor RPi.GPIO available — PPS LED disabled. "
+                "Install with: pip install gpiozero lgpio"
             )
+            self._pps_error = self._pps_error or "no GPIO library available"
         except Exception as exc:
-            self._logger.debug(
-                "PPS GPIO setup failed on BCM %d: %s", self._pps_pin, exc
+            self._logger.warning(
+                "RPi.GPIO PPS setup failed on BCM %d: %s",
+                self._pps_pin,
+                exc,
             )
+            self._pps_error = f"rpi.gpio: {exc}"
 
-    def _pps_pulse_callback(self, channel: int) -> None:
-        """Called by the RPi.GPIO interrupt thread on each PPS rising edge."""
+    def _pps_pulse_callback(self, *_args, **_kwargs) -> None:
+        """Called by the gpiozero callback thread on each PPS rising edge."""
         now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             self._fix["pps_last_pulse_at"] = now
             self._fix["pps_pulse_count"] = self._fix.get("pps_pulse_count", 0) + 1
+
+    def _pps_pulse_callback_legacy(self, channel: int) -> None:
+        """Called by the RPi.GPIO interrupt thread on each PPS rising edge."""
+        self._pps_pulse_callback()
 
     def _set_error_status(self, status: str) -> None:
         """Update the local fix dict and Redis with an error status.

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -2300,6 +2300,31 @@ def create_api_app():
             logger.error(f"Error getting GPS status: {e}", exc_info=True)
             return jsonify({'success': False, 'error': str(e)}), 500
 
+    @api_app.route('/api/hardware/gps/nmea', methods=['GET'])
+    def get_gps_nmea():
+        """Return the rolling NMEA sentence log + per-type counters."""
+        try:
+            limit = request.args.get('limit', default=50, type=int)
+            limit = max(1, min(limit, 200))
+            if _gps_manager is not None:
+                return jsonify(_gps_manager.get_nmea_log(limit=limit))
+            from app_core.hardware_settings import get_gps_settings
+            gps_settings = get_gps_settings()
+            return jsonify({
+                'running': False,
+                'serial_port': gps_settings.get('serial_port', '/dev/serial0'),
+                'baudrate': gps_settings.get('baudrate', 9600),
+                'total_sentences': 0,
+                'parse_errors': 0,
+                'counts_by_type': {},
+                'sentences': [],
+                'status': 'disabled' if not gps_settings.get('enabled') else 'not_started',
+                'timestamp': datetime.now(timezone.utc).isoformat(),
+            })
+        except Exception as e:
+            logger.error(f"Error getting GPS NMEA log: {e}", exc_info=True)
+            return jsonify({'success': False, 'error': str(e)}), 500
+
     @api_app.route('/api/hardware/gps/configure', methods=['POST'])
     def configure_gps():
         """Save GPS configuration and restart the GPS manager."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,6 +110,10 @@ luma.oled==3.14.0  # I2C SSD1306/SH1106 driver used by the Argon OLED
 
 # GPIO control for Raspberry Pi hardware
 gpiozero==2.0.1
+# lgpio: pin-factory backend used by gpiozero on Raspberry Pi 5 / Bookworm
+# (the legacy RPi.GPIO library no longer works on Pi 5 because /dev/mem is
+# locked down). Required for the GPS PPS pulse detector to function.
+lgpio>=0.2.2.0
 rpi-ws281x>=0.0.5  # NeoPixel/WS2812B addressable LED strip control (requires DMA/root on Pi)
 
 # Multi-Factor Authentication (MFA) support

--- a/templates/admin/hardware_settings.html
+++ b/templates/admin/hardware_settings.html
@@ -1277,16 +1277,29 @@ function buildSatTable(satsInView, activePrns) {
 function buildPpsHtml(d) {
     var age = d.pps_pulse_age_s;
     var pin = d.pps_gpio_pin !== undefined ? d.pps_gpio_pin : '?';
+    var backend = d.pps_backend || 'none';
+    var armed = !!d.pps_gpio_active;
+    var err   = d.pps_error;
     var active = age !== null && age < 2.5;
     var ever   = age !== null && age >= 2.5;
     var cls = active ? 'pps-active' : (ever ? 'pps-lost' : 'pps-inactive');
     var txt = active
         ? ('PPS \u00b7 ' + age.toFixed(1) + 's')
         : 'PPS';
-    var tip = active
-        ? ('PPS active on GPIO ' + pin + ' \u2014 last pulse ' + age.toFixed(1) + 's ago')
-        : (ever ? ('PPS lost on GPIO ' + pin + ' \u2014 last pulse ' + age.toFixed(1) + 's ago')
-               : ('No PPS signal detected on GPIO ' + pin));
+    var tip;
+    if (active) {
+        tip = 'PPS active on GPIO ' + pin + ' via ' + backend
+            + ' \u2014 last pulse ' + age.toFixed(1) + 's ago';
+    } else if (ever) {
+        tip = 'PPS lost on GPIO ' + pin + ' via ' + backend
+            + ' \u2014 last pulse ' + age.toFixed(1) + 's ago';
+    } else if (!armed && err) {
+        tip = 'PPS GPIO not armed on BCM ' + pin + ': ' + err;
+    } else if (!armed) {
+        tip = 'PPS monitoring disabled (BCM ' + pin + ')';
+    } else {
+        tip = 'No PPS signal detected on GPIO ' + pin + ' (' + backend + ')';
+    }
     return '<span class="pps-led ' + cls + '" title="' + tip + '">'
         + '<span class="pps-dot"></span>' + txt + '</span>';
 }

--- a/templates/diagnostics.html
+++ b/templates/diagnostics.html
@@ -47,6 +47,17 @@
     .progress-container {
         margin: 2rem 0;
     }
+
+    /* Render raw NMEA sentences and other monospace lines from the
+       diagnostics output (`$GPGGA,...`, `  ✓ $GPRMC,...`) in a fixed-width
+       font so the operator can scan for missing fields / bad checksums. */
+    .check-item.mono-line {
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 0.8125rem;
+        padding: 0.25rem 0.75rem;
+        white-space: pre;
+        overflow-x: auto;
+    }
 </style>
 {% endblock %}
 
@@ -373,7 +384,10 @@
     function addCheckItem(containerId, message, status) {
         const container = document.getElementById(containerId);
         const item = document.createElement('div');
-        item.className = 'check-item';
+        // Indented or dollar-prefixed lines are raw NMEA samples /
+        // command output — render them in monospace so they line up.
+        const isMono = /^\s*[✓✗]?\s*\$/.test(message) || /^\s{2,}/.test(message);
+        item.className = isMono ? 'check-item mono-line' : 'check-item';
 
         let icon = '';
         let statusClass = '';

--- a/tests/test_gps_manager.py
+++ b/tests/test_gps_manager.py
@@ -1,0 +1,111 @@
+"""Unit tests for the GPS manager NMEA logging and PMTK helpers.
+
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+These tests do not touch real hardware — they only exercise the parts of
+GPSManager that are pure data manipulation (sentence buffering, checksum
+computation, status payload shape).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_gps_module():
+    """Load gps_manager.py without going through the app_core package init,
+    which pulls in flask/sqlalchemy that aren't required for these tests."""
+    path = Path(__file__).resolve().parents[1] / "app_core" / "gps" / "gps_manager.py"
+    spec = importlib.util.spec_from_file_location("gps_manager_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gps_module():
+    return _load_gps_module()
+
+
+@pytest.fixture
+def manager(gps_module):
+    return gps_module.GPSManager(
+        config={"serial_port": "/dev/null", "baudrate": 9600, "pps_gpio_pin": 4},
+    )
+
+
+def test_pmtk_checksum_is_correct(gps_module):
+    """The PMTK314 enable-all-sentences command must carry checksum 2D.
+
+    A wrong checksum would cause the MTK3339 to silently ignore the command,
+    leaving the receiver in its default RMC+GGA-only mode and the sky view
+    permanently empty — which is the exact bug we're fixing.
+    """
+    cmd = gps_module.PMTK_SET_NMEA_OUTPUT
+    assert cmd.startswith("$PMTK314,0,1,1,1,1,5,")
+    assert "*2D" in cmd, f"Wrong PMTK checksum, got: {cmd!r}"
+    assert cmd.endswith("\r\n")
+
+
+def test_record_raw_sentence_classifies_by_type(manager):
+    manager._record_raw_sentence(
+        "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47"
+    )
+    manager._record_raw_sentence(
+        "$GPGSV,1,1,03,01,40,083,42,02,17,308,41,03,07,344,39*7B"
+    )
+    manager._record_raw_sentence(
+        "$GLGSV,1,1,02,65,28,124,32,66,18,068,28*64"
+    )
+    counts = dict(manager._nmea_counts)
+    assert counts["GGA"] == 1
+    assert counts["GSV"] == 2  # both GP and GL talker prefixes collapse to GSV
+    assert manager._nmea_total == 3
+    assert manager._nmea_parse_errors == 0
+
+
+def test_record_raw_sentence_tracks_parse_errors(manager):
+    manager._record_raw_sentence("$BOGUS,not,nmea", parse_ok=False)
+    assert manager._nmea_parse_errors == 1
+    log = list(manager._nmea_log)
+    assert log[-1]["ok"] is False
+
+
+def test_get_nmea_log_returns_recent_sentences(manager):
+    for i in range(5):
+        manager._record_raw_sentence(f"$GPRMC,{i},A,,,,,,,,,*00")
+    payload = manager.get_nmea_log(limit=3)
+    assert payload["total_sentences"] == 5
+    assert payload["counts_by_type"]["RMC"] == 5
+    assert len(payload["sentences"]) == 3
+    # Most recent sample should be the last one we appended
+    assert payload["sentences"][-1]["text"].startswith("$GPRMC,4,")
+
+
+def test_get_status_includes_nmea_summary(manager):
+    manager._record_raw_sentence("$GPGGA,,,,,,0,,,,,,,,*48")
+    status = manager.get_status()
+    # The new keys must be present so the diagnostics + UI can render them
+    for key in (
+        "nmea_counts",
+        "nmea_total",
+        "nmea_parse_errors",
+        "nmea_recent",
+        "pps_backend",
+        "pps_error",
+        "pps_gpio_active",
+    ):
+        assert key in status, f"missing key {key!r} in status payload"
+    assert status["nmea_counts"]["GGA"] == 1
+    assert status["pps_gpio_active"] is False
+
+
+def test_empty_fix_exposes_pps_metadata(manager):
+    fix = manager._empty_fix()
+    assert fix["pps_backend"] is None
+    assert fix["pps_error"] is None
+    assert fix["pps_gpio_active"] is False
+    assert fix["pps_pulse_count"] == 0

--- a/webapp/admin/network.py
+++ b/webapp/admin/network.py
@@ -386,6 +386,16 @@ def configure_gps():
     return jsonify(call_hardware_service('/api/hardware/gps/configure', method='POST', data=data))
 
 
+@network_bp.route('/api/hardware/gps/nmea')
+@require_permission('system.configure')
+def get_gps_nmea():
+    """Return raw NMEA sentence log via hardware-service."""
+    limit = request.args.get('limit', default=50, type=int)
+    return jsonify(call_hardware_service(
+        f'/api/hardware/gps/nmea?limit={limit}', method='GET'
+    ))
+
+
 def register_network_routes(app, logger):
     """Register network management routes with the Flask app."""
     app.register_blueprint(network_bp)

--- a/webapp/routes_diagnostics.py
+++ b/webapp/routes_diagnostics.py
@@ -430,6 +430,149 @@ def check_recent_logs() -> CheckResult:
 # Aggregation
 # --------------------------------------------------------------------------- #
 
+def check_gps_nmea() -> CheckResult:
+    """Inspect the GPS receiver via the hardware-service NMEA endpoint.
+
+    Reports running state, sentence counts by type, recent samples, and PPS
+    pulse activity so the operator can confirm the GPS HAT is wired
+    correctly without leaving the diagnostics page.
+    """
+    out = _empty_result()
+    try:
+        import requests
+
+        from app_core.config import HARDWARE_SERVICE_URL
+    except Exception as exc:  # pragma: no cover — defensive
+        out["warnings"].append(f"GPS check unavailable: {exc}")
+        return out
+
+    try:
+        nmea_resp = requests.get(
+            f"{HARDWARE_SERVICE_URL}/api/hardware/gps/nmea?limit=20",
+            timeout=5,
+        )
+        status_resp = requests.get(
+            f"{HARDWARE_SERVICE_URL}/api/hardware/gps/status",
+            timeout=5,
+        )
+    except Exception as exc:
+        out["warnings"].append(f"Could not reach hardware-service for GPS: {exc}")
+        return out
+
+    if nmea_resp.status_code != 200 or status_resp.status_code != 200:
+        out["warnings"].append(
+            f"Hardware-service returned HTTP {nmea_resp.status_code}/"
+            f"{status_resp.status_code} for GPS endpoints"
+        )
+        return out
+
+    try:
+        nmea = nmea_resp.json()
+        status = status_resp.json()
+    except Exception as exc:
+        out["warnings"].append(f"Invalid JSON from GPS endpoint: {exc}")
+        return out
+
+    gps_status = status.get("status") or "unknown"
+    if gps_status == "disabled":
+        out["info"].append("GPS receiver is disabled (Admin > Hardware Settings)")
+        return out
+
+    if not status.get("running"):
+        out["warnings"].append(
+            f"GPS reader not running (status='{gps_status}', "
+            f"port={status.get('serial_port')})"
+        )
+
+    counts = nmea.get("counts_by_type") or {}
+    total = nmea.get("total_sentences") or 0
+    parse_errors = nmea.get("parse_errors") or 0
+
+    if total == 0:
+        out["failed"].append(
+            f"No NMEA sentences received from {nmea.get('serial_port')} "
+            f"@ {nmea.get('baudrate')}bd"
+        )
+    else:
+        ordered = sorted(counts.items(), key=lambda kv: -kv[1])
+        summary = ", ".join(f"{t}={n}" for t, n in ordered[:8])
+        out["passed"].append(
+            f"GPS NMEA stream healthy: {total} sentences ({summary})"
+        )
+
+    # Specifically check for the sentences the live UI cares about. The
+    # MTK3339 default of "RMC + GGA only" is a known footgun — without
+    # GSV/GSA the sky view stays empty even with a 3D fix.
+    for required in ("GGA", "RMC"):
+        if counts.get(required, 0) == 0 and total > 0:
+            out["failed"].append(f"No {required} sentences seen — check antenna / fix")
+    for sky in ("GSV", "GSA"):
+        if counts.get(sky, 0) == 0 and total > 0:
+            out["warnings"].append(
+                f"No {sky} sentences seen — sky view will be empty. "
+                f"This is the Adafruit MTK3339 default; "
+                f"restart the GPS reader to send PMTK314."
+            )
+
+    if parse_errors:
+        out["warnings"].append(
+            f"{parse_errors} NMEA parse error(s) since startup "
+            f"({parse_errors * 100 // max(total, 1)}% of stream)"
+        )
+
+    has_fix = bool(status.get("has_fix"))
+    if has_fix:
+        sats = status.get("satellites") or 0
+        in_view = len(status.get("satellites_in_view") or [])
+        used = len(status.get("active_satellite_prns") or [])
+        out["info"].append(
+            f"3D fix: {sats} sats reported, {in_view} in view, {used} used in fix"
+        )
+    elif status.get("running"):
+        out["info"].append("GPS reader running — waiting for fix")
+
+    pps_backend = status.get("pps_backend")
+    pps_age = status.get("pps_pulse_age_s")
+    pps_count = status.get("pps_pulse_count") or 0
+    pps_pin = status.get("pps_gpio_pin")
+    pps_error = status.get("pps_error")
+    if not status.get("pps_gpio_active"):
+        if pps_error:
+            out["warnings"].append(
+                f"PPS GPIO not armed on BCM {pps_pin}: {pps_error}"
+            )
+        else:
+            out["info"].append(f"PPS monitoring disabled (pin BCM {pps_pin})")
+    elif pps_count == 0:
+        out["warnings"].append(
+            f"PPS armed via {pps_backend} on BCM {pps_pin} but no pulses seen "
+            f"— check antenna and PPS jumper"
+        )
+    elif pps_age is not None and pps_age < 2.5:
+        out["passed"].append(
+            f"PPS active via {pps_backend} on BCM {pps_pin} "
+            f"({pps_count} pulses, last {pps_age:.1f}s ago)"
+        )
+    else:
+        out["warnings"].append(
+            f"PPS lost via {pps_backend} on BCM {pps_pin} "
+            f"(last pulse {pps_age}s ago)"
+        )
+
+    # Surface the actual sentences so the operator can scan for talker IDs,
+    # checksum issues, missing fields, etc. without SSH'ing into the box.
+    samples = nmea.get("sentences") or []
+    if samples:
+        out["info"].append(f"Recent NMEA ({len(samples)}):")
+        for sample in samples[-10:]:
+            text = sample.get("text", "")
+            ok = sample.get("ok", True)
+            prefix = "✓" if ok else "✗"
+            out["info"].append(f"  {prefix} {text}")
+
+    return out
+
+
 CHECKS: List[Tuple[str, Callable[[], CheckResult]]] = [
     ("Services", check_services_running),
     ("Database", check_database_connection),
@@ -439,6 +582,7 @@ CHECKS: List[Tuple[str, Callable[[], CheckResult]]] = [
     ("Audio Service", check_audio_service_heartbeat),
     ("Audio Devices", check_audio_devices),
     ("NTP Sync", check_ntp_sync),
+    ("GPS / NMEA", check_gps_nmea),
     ("Recent Logs", check_recent_logs),
 ]
 


### PR DESCRIPTION
## Summary
Enhanced the GPS manager to log raw NMEA sentences for diagnostics, automatically configure MTK3339 receivers to emit all required sentence types, and improve PPS pulse monitoring with support for both gpiozero and legacy RPi.GPIO backends.

## Key Changes

### NMEA Sentence Logging & Diagnostics
- Added rolling buffer (`_nmea_log`) to store up to 50 raw NMEA sentences with timestamps, parse status, and sentence type
- Track per-sentence-type counters and parse error statistics
- New `get_nmea_log()` API endpoint returns recent sentences and aggregated counts for diagnostics
- `_record_raw_sentence()` logs all sentences regardless of parse success, allowing operators to inspect malformed data

### MTK3339 Receiver Configuration
- Implemented `_configure_mtk3339()` to send PMTK314 command on startup
- Enables RMC, GGA, GSA, GSV, and VTG sentence output (default Adafruit GPS HAT only emits RMC+GGA)
- Added `_nmea_checksum()` helper to compute XOR checksums for PMTK commands
- Fixes the "No satellite data yet" issue where sky view and active satellite lists remained empty despite valid 3D fix

### PPS Pulse Monitoring Improvements
- Migrated from RPi.GPIO-only to dual-backend support:
  - **Primary**: gpiozero (works on Pi 5 + Bookworm, auto-selects best pin factory)
  - **Fallback**: RPi.GPIO (for older Pi/OS combinations)
- Track PPS backend name, error messages, and armed status in fix data
- Separate callback signatures for gpiozero (`_pps_pulse_callback`) and RPi.GPIO (`_pps_pulse_callback_legacy`)
- Graceful degradation: GPS continues working if PPS setup fails; UI shows reason in tooltip

### Diagnostics & UI Enhancements
- New `check_gps_nmea()` diagnostic check validates NMEA stream health, sentence types, and PPS activity
- Hardware settings page now displays PPS backend name and error details
- Diagnostics page renders raw NMEA samples in monospace font for easy inspection of talker IDs, checksums, and missing fields
- Status payload includes `nmea_counts`, `nmea_total`, `nmea_parse_errors`, `nmea_recent`, `pps_backend`, `pps_error`, `pps_gpio_active`

### API Endpoints
- `GET /api/hardware/gps/nmea?limit=N` — returns rolling NMEA log with per-type counters
- Updated `GET /api/hardware/gps/status` to include PPS backend and error information

### Testing
- Added unit tests for PMTK checksum validation, sentence classification, parse error tracking, and status payload shape
- Tests load gps_manager.py directly without Flask/SQLAlchemy dependencies

## Implementation Details
- All NMEA logging is protected by the existing `_lock` to ensure thread safety
- Sentences longer than 200 characters are truncated in the log to keep JSON payloads small
- Parse errors are recorded with sentence type "UNKNOWN" so malformed data is still visible in diagnostics
- PPS setup failures are logged but don't block GPS reader startup
- PMTK command is sent immediately after serial port opens, before the reader loop starts

https://claude.ai/code/session_01VFy2Q4ifyCB6fBYosYq6ur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPS NMEA sentence logging API endpoint with configurable data limits
  * Enhanced GPS diagnostics with comprehensive checks for sentence types, signal health, and parse errors
  * Improved PPS signal monitoring with expanded backend support

* **Tests**
  * Added GPS manager unit tests for NMEA logging and signal processing

* **Chores**
  * Added GPIO library dependency for Raspberry Pi 5 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->