### PR TITLE
Bucket GSV accumulator per talker so multi-GNSS sky data isn't wiped

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -460,6 +460,7 @@ class GPSManager:
                             continue
                         bucket[prn] = {
                             "prn": prn,
+                            "constellation": talker,
                             "elevation": _safe_int(
                                 getattr(msg, "elevation_deg_%d" % i, None)
                             ),

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -118,8 +118,12 @@ class GPSManager:
         self._lock = threading.Lock()
         self._fix: Dict[str, Any] = self._empty_fix()
 
-        # GSV accumulation buffer — reader thread only, no lock needed
-        self._gsv_buffer: Dict[int, Dict[str, Any]] = {}
+        # GSV accumulation buffers, one bucket per talker (GP, GL, GA, GB, …).
+        # Multi-GNSS receivers emit one GSV group per constellation; if we
+        # shared a single buffer, the start of GLGSV (msg_num==1) would wipe
+        # the GPGSV satellites we just accumulated, leaving the published
+        # satellites_in_view empty — reader thread only, no lock needed.
+        self._gsv_buffer: Dict[str, Dict[int, Dict[str, Any]]] = {}
         # GSA per-cycle accumulator. Multi-GNSS receivers emit one GSA per
         # constellation (e.g. $GPGSA, $GLGSA, $GAGSA, or several $GNGSA in a
         # row). We union active PRNs across all GSA sentences within a single
@@ -433,12 +437,19 @@ class GPSManager:
                             self._fix["gps_utc_time"] = str(msg.timestamp)
 
             elif sentence_type == "GSV":
-                # Satellites in View — parse per-satellite PRN/elevation/azimuth/SNR
+                # Satellites in View — parse per-satellite PRN/elevation/azimuth/SNR.
+                # Multi-GNSS receivers send one GSV group per constellation
+                # (e.g. $GPGSV,3,1.. → 3,2 → 3,3 then $GLGSV,1,1..). We must
+                # bucket per-talker so the start of one constellation's group
+                # doesn't wipe another's — and union the buckets when
+                # publishing so satellites_in_view reflects all visible sats.
                 try:
+                    talker = getattr(msg, "talker", None) or "GN"
                     total_msgs = int(msg.num_messages) if msg.num_messages else 1
                     msg_num = int(msg.msg_num) if msg.msg_num else 1
                     if msg_num == 1:
-                        self._gsv_buffer.clear()
+                        self._gsv_buffer[talker] = {}
+                    bucket = self._gsv_buffer.setdefault(talker, {})
                     for i in range(1, 5):
                         prn_raw = getattr(msg, "sv_prn_num_%d" % i, None)
                         if not prn_raw:
@@ -447,7 +458,7 @@ class GPSManager:
                             prn = int(prn_raw)
                         except (ValueError, TypeError):
                             continue
-                        self._gsv_buffer[prn] = {
+                        bucket[prn] = {
                             "prn": prn,
                             "elevation": _safe_int(
                                 getattr(msg, "elevation_deg_%d" % i, None)
@@ -460,8 +471,11 @@ class GPSManager:
                             ),
                         }
                     if msg_num >= total_msgs:
+                        merged: Dict[int, Dict[str, Any]] = {}
+                        for tbucket in self._gsv_buffer.values():
+                            merged.update(tbucket)
                         self._fix["satellites_in_view"] = sorted(
-                            list(self._gsv_buffer.values()),
+                            merged.values(),
                             key=lambda s: s["prn"],
                         )
                 except Exception:

--- a/templates/admin/hardware_settings.html
+++ b/templates/admin/hardware_settings.html
@@ -936,6 +936,27 @@ function snrClass(snr) {
 var SNR_COLORS = { 'snr-s0':'#484f58','snr-s1':'#f85149','snr-s2':'#f97316','snr-s3':'#d29922','snr-s4':'#84cc16','snr-s5':'#3fb950' };
 function snrHex(snr) { return SNR_COLORS[snrClass(snr)] || '#484f58'; }
 
+/* Per-constellation colours for sky plot dots and the table PRN badge.
+   Keys are NMEA talker IDs (msg.talker on the backend); unknowns fall
+   back to neutral grey. */
+var CONSTELLATION_INFO = {
+    'GP': { color: '#58a6ff', label: 'GPS' },
+    'GL': { color: '#f85149', label: 'GLONASS' },
+    'GA': { color: '#bc8cff', label: 'Galileo' },
+    'GB': { color: '#ffa657', label: 'BeiDou' },
+    'GQ': { color: '#79c0ff', label: 'QZSS' },
+    'GI': { color: '#84cc16', label: 'NavIC' }
+};
+function constellationInfo(code) {
+    return CONSTELLATION_INFO[code] || { color: '#8b949e', label: code || 'Unknown' };
+}
+/* Map SNR to dot opacity so strong sats glow and weak ones fade,
+   while colour stays locked to constellation. */
+function snrAlpha(snr) {
+    if (snr === null || snr === undefined) return 0.55;
+    return Math.max(0.45, Math.min(0.95, 0.4 + snr / 60));
+}
+
 /* Draw the polar sky plot onto a <canvas> element */
 function drawSkyPlot(canvas, satsInView, activePrns) {
     var ctx = canvas.getContext('2d');
@@ -995,7 +1016,7 @@ function drawSkyPlot(canvas, satsInView, activePrns) {
         var x = cx + r * Math.sin(azRad);
         var y = cy - r * Math.cos(azRad);
         var isUsed = activePrns.indexOf(sat.prn) !== -1;
-        var color = snrHex(sat.snr);
+        var color = constellationInfo(sat.constellation).color;
 
         // Glow for used-in-fix sats
         if (isUsed && sat.snr !== null) {
@@ -1005,11 +1026,11 @@ function drawSkyPlot(canvas, satsInView, activePrns) {
             ctx.fill();
         }
 
-        // Satellite circle
+        // Satellite circle — colour by constellation, alpha by SNR
         ctx.beginPath();
         ctx.arc(x, y, 8, 0, Math.PI * 2);
         ctx.fillStyle = color;
-        ctx.globalAlpha = 0.88;
+        ctx.globalAlpha = snrAlpha(sat.snr);
         ctx.fill();
         ctx.globalAlpha = 1;
         ctx.strokeStyle = isUsed ? '#ffffff' : '#444c56';
@@ -1072,11 +1093,13 @@ function buildSatTable(satsInView, activePrns) {
         var snr = sat.snr;
         var barW = snr !== null ? Math.min(100, Math.round(snr / 50 * 100)) : 0;
         var barColor = snrHex(snr);
+        var info = constellationInfo(sat.constellation);
+        var constDot = '<span title="' + info.label + '" style="display:inline-block;width:7px;height:7px;border-radius:50%;background:' + info.color + ';margin-right:5px;vertical-align:middle"></span>';
         var usedMark = used
             ? '<span style="color:#3fb950">&#10003;</span>'
             : '<span style="color:#30363d">&#183;</span>';
         return '<tr class="' + cls + '">'
-            + '<td style="text-align:right;padding-right:8px">' + sat.prn + '</td>'
+            + '<td style="text-align:right;padding-right:8px;white-space:nowrap">' + constDot + sat.prn + '</td>'
             + '<td style="text-align:right;padding-right:8px">' + (sat.elevation !== null ? sat.elevation : '&mdash;') + '</td>'
             + '<td style="text-align:right;padding-right:10px">' + (sat.azimuth !== null ? sat.azimuth : '&mdash;') + '</td>'
             + '<td><span class="gps-snr-track"><span class="gps-snr-fill" style="width:' + barW + '%;background:' + barColor + '"></span></span></td>'
@@ -1084,6 +1107,17 @@ function buildSatTable(satsInView, activePrns) {
             + '<td style="padding-left:6px;text-align:center">' + usedMark + '</td>'
             + '</tr>';
     }).join('');
+
+    // Constellation legend — only shows the talkers actually present in this view
+    var presentConsts = {};
+    allSats.forEach(function (s) { if (s.constellation) presentConsts[s.constellation] = true; });
+    var constLegend = Object.keys(presentConsts).sort().map(function (code) {
+        var info = constellationInfo(code);
+        return '<span><span class="snr-dot" style="background:' + info.color + '"></span>' + info.label + '</span>';
+    }).join('');
+    var constLegendHtml = constLegend
+        ? '<div class="snr-legend" style="margin-top:2px">' + constLegend + '</div>'
+        : '';
 
     return almanacNote
         + '<table class="gps-sat-table">'
@@ -1103,7 +1137,8 @@ function buildSatTable(satsInView, activePrns) {
         + '<span><span class="snr-dot snr-s2"></span>15&ndash;24</span>'
         + '<span><span class="snr-dot snr-s1"></span>&lt;15</span>'
         + '<span><span class="snr-dot snr-s0"></span>no sig</span>'
-        + '</div>';
+        + '</div>'
+        + constLegendHtml;
 }
 
 /* Build the scrollable NMEA sentence log */

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -3608,6 +3608,24 @@
         const _GPS_SNR_COLORS = { 'snr-s0':'#484f58','snr-s1':'#f85149','snr-s2':'#f97316','snr-s3':'#d29922','snr-s4':'#84cc16','snr-s5':'#3fb950' };
         function gpsSnrHex(snr) { return _GPS_SNR_COLORS[gpsSnrClass(snr)] || '#484f58'; }
 
+        /* Per-constellation colours for sky plot dots and the table PRN badge.
+           Keys are NMEA talker IDs from msg.talker; unknowns fall back to grey. */
+        const _GPS_CONST_INFO = {
+            'GP': { color: '#58a6ff', label: 'GPS' },
+            'GL': { color: '#f85149', label: 'GLONASS' },
+            'GA': { color: '#bc8cff', label: 'Galileo' },
+            'GB': { color: '#ffa657', label: 'BeiDou' },
+            'GQ': { color: '#79c0ff', label: 'QZSS' },
+            'GI': { color: '#84cc16', label: 'NavIC' }
+        };
+        function gpsConstInfo(code) {
+            return _GPS_CONST_INFO[code] || { color: '#8b949e', label: code || 'Unknown' };
+        }
+        function gpsSnrAlpha(snr) {
+            if (snr === null || snr === undefined) return 0.55;
+            return Math.max(0.45, Math.min(0.95, 0.4 + snr / 60));
+        }
+
         function drawGpsSkyPlot(canvas, satsInView, activePrns) {
             const ctx = canvas.getContext('2d');
             const W = canvas.width, H = canvas.height;
@@ -3652,14 +3670,14 @@
                 const x = cx + r * Math.sin(azRad);
                 const y = cy - r * Math.cos(azRad);
                 const isUsed = (activePrns || []).indexOf(sat.prn) !== -1;
-                const color = gpsSnrHex(sat.snr);
+                const color = gpsConstInfo(sat.constellation).color;
 
                 if (isUsed && sat.snr !== null) {
                     ctx.beginPath(); ctx.arc(x, y, 11, 0, Math.PI * 2);
                     ctx.fillStyle = color + '28'; ctx.fill();
                 }
                 ctx.beginPath(); ctx.arc(x, y, 7, 0, Math.PI * 2);
-                ctx.fillStyle = color; ctx.globalAlpha = 0.88; ctx.fill();
+                ctx.fillStyle = color; ctx.globalAlpha = gpsSnrAlpha(sat.snr); ctx.fill();
                 ctx.globalAlpha = 1;
                 ctx.strokeStyle = isUsed ? '#ffffff' : '#444c56';
                 ctx.lineWidth = isUsed ? 1.5 : 0.8; ctx.stroke();
@@ -3694,11 +3712,13 @@
                 const snr  = sat.snr;
                 const barW = snr !== null ? Math.min(100, Math.round(snr / 50 * 100)) : 0;
                 const barColor = gpsSnrHex(snr);
+                const info = gpsConstInfo(sat.constellation);
+                const constDot = `<span title="${info.label}" style="display:inline-block;width:7px;height:7px;border-radius:50%;background:${info.color};margin-right:5px;vertical-align:middle"></span>`;
                 const mark = used
                     ? '<span style="color:#3fb950">&#10003;</span>'
                     : '<span style="color:#30363d">&#183;</span>';
                 return `<tr class="${used ? 'sat-used' : 'sat-unused'}">
-                    <td style="text-align:right;padding-right:8px">${sat.prn}</td>
+                    <td style="text-align:right;padding-right:8px;white-space:nowrap">${constDot}${sat.prn}</td>
                     <td style="text-align:right;padding-right:8px">${sat.elevation !== null ? sat.elevation : '&mdash;'}</td>
                     <td style="text-align:right;padding-right:10px">${sat.azimuth !== null ? sat.azimuth : '&mdash;'}</td>
                     <td><span class="gps-snr-track"><span class="gps-snr-fill" style="width:${barW}%;background:${barColor}"></span></span></td>
@@ -3706,6 +3726,17 @@
                     <td style="padding-left:6px;text-align:center">${mark}</td>
                 </tr>`;
             }).join('');
+
+            // Constellation legend — only the talkers actually present in this view
+            const presentConsts = {};
+            allSats.forEach(s => { if (s.constellation) presentConsts[s.constellation] = true; });
+            const constLegend = Object.keys(presentConsts).sort().map(code => {
+                const info = gpsConstInfo(code);
+                return `<span><span class="snr-dot" style="background:${info.color}"></span>${info.label}</span>`;
+            }).join('');
+            const constLegendHtml = constLegend
+                ? `<div class="snr-legend" style="margin-top:2px">${constLegend}</div>`
+                : '';
 
             return `<table class="gps-sat-table">
                 <thead><tr>
@@ -3724,7 +3755,7 @@
                 <span><span class="snr-dot snr-s2"></span>15&ndash;24</span>
                 <span><span class="snr-dot snr-s1"></span>&lt;15</span>
                 <span><span class="snr-dot snr-s0"></span>no sig</span>
-            </div>`;
+            </div>${constLegendHtml}`;
         }
         /* ── end GPS sky-plot helpers ── */
 


### PR DESCRIPTION
On multi-constellation receivers (GP+GL+GA+GB) each constellation sends
its own GSV group. The shared buffer was cleared every time msg_num==1
arrived, so an empty $GLGSV,1,1,00 immediately after $GPGSV,3,3,...
published satellites_in_view as []. The UI then fell back to "Sky
positions pending — receiver is downloading almanac/ephemeris data."
even though the receiver was streaming complete GPGSV sky data.

Bucket the buffer per talker (GP, GL, GA, …), reset only that talker's
bucket on its own msg_num==1, and union all buckets when publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-GNSS constellation support for improved satellite tracking across different systems (GPS, GLONASS, etc.)
  * Constellation-aware coloring and SNR-based transparency in GPS visualizations

* **Improvements**
  * Dynamic constellation legend showing only active satellite systems in current view
  * Enhanced satellite identification with constellation indicators in tables and sky-plot displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->