### PR TITLE
Add MDC1200 Call Alert and Selective Call (double-packet) support

### DIFF
--- a/app_core/_models_settings.py
+++ b/app_core/_models_settings.py
@@ -660,6 +660,14 @@ class EASSettings(db.Model):
     # Raw 8-bit argument byte (0..255) used when mdc1200_op_code == 'custom'.
     # NULL means "use the symbolic preset".
 
+    mdc1200_target_unit_id = db.Column(db.Integer, nullable=True)
+    # 16-bit MDC1200 *target* subscriber unit ID (1..65535) used by the
+    # double-packet ops (Call Alert, Selective Call) to address a specific
+    # receiver.  NULL or 0 forces single-packet emission, where
+    # mdc1200_unit_id is the only ID on the wire.  For PTT-ID, Emergency,
+    # Request-to-Talk, and Remote Monitor presets this column is ignored
+    # because those op-codes are single-packet by design.
+
     # ========================================================================
     # Authorized Broadcast Areas
     # ========================================================================
@@ -711,6 +719,10 @@ class EASSettings(db.Model):
             "mdc1200_arg_raw": (
                 int(self.mdc1200_arg_raw)
                 if self.mdc1200_arg_raw is not None else None
+            ),
+            "mdc1200_target_unit_id": (
+                int(self.mdc1200_target_unit_id)
+                if self.mdc1200_target_unit_id is not None else None
             ),
             "authorized_fips_codes": list(self.authorized_fips_codes or []),
             "authorized_event_codes": list(self.authorized_event_codes or []),

--- a/app_core/migrations/versions/20260505_add_mdc1200_target_unit_id_to_eas_settings.py
+++ b/app_core/migrations/versions/20260505_add_mdc1200_target_unit_id_to_eas_settings.py
@@ -1,0 +1,34 @@
+"""Add MDC1200 target unit ID column to eas_settings.
+
+Adds the ``mdc1200_target_unit_id`` column used by the double-packet
+MDC1200 ops (Call Alert / Selective Call) to address a specific
+receiving subscriber.  When NULL or 0 the encoder falls back to a
+single-packet frame.
+
+  - mdc1200_target_unit_id  INTEGER NULL
+
+Revision ID: 20260505_add_mdc1200_target_unit_id_to_eas_settings
+Revises: 20260506_split_location_settings
+Create Date: 2026-05-05
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260505_add_mdc1200_target_unit_id_to_eas_settings"
+down_revision = "20260506_split_location_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE eas_settings"
+        " ADD COLUMN IF NOT EXISTS mdc1200_target_unit_id INTEGER"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("eas_settings", "mdc1200_target_unit_id")

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -345,6 +345,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
     db_mdc1200_op_code = None
     db_mdc1200_op_code_raw = None
     db_mdc1200_arg_raw = None
+    db_mdc1200_target_unit_id = None
     db_forwarded_event_codes: List[str] = []
     try:
         from app_core.models import EASSettings
@@ -371,6 +372,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
             db_mdc1200_op_code = getattr(eas_settings, 'mdc1200_op_code', None)
             db_mdc1200_op_code_raw = getattr(eas_settings, 'mdc1200_op_code_raw', None)
             db_mdc1200_arg_raw = getattr(eas_settings, 'mdc1200_arg_raw', None)
+            db_mdc1200_target_unit_id = getattr(eas_settings, 'mdc1200_target_unit_id', None)
             db_forwarded_event_codes = list(eas_settings.forwarded_event_codes or [])
             load_logger.info(
                 'EASSettings loaded from DB: originator=%s station_id=%s broadcast_enabled=%s',
@@ -408,6 +410,7 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
                 db_mdc1200_op_code = getattr(eas_settings, 'mdc1200_op_code', None)
                 db_mdc1200_op_code_raw = getattr(eas_settings, 'mdc1200_op_code_raw', None)
                 db_mdc1200_arg_raw = getattr(eas_settings, 'mdc1200_arg_raw', None)
+                db_mdc1200_target_unit_id = getattr(eas_settings, 'mdc1200_target_unit_id', None)
                 db_forwarded_event_codes = list(eas_settings.forwarded_event_codes or [])
                 load_logger.info(
                     'EASSettings loaded from DB (direct session): originator=%s station_id=%s broadcast_enabled=%s',
@@ -494,6 +497,14 @@ def load_eas_config(base_path: Optional[str] = None, db_session=None) -> Dict[st
             int(os.getenv('EAS_MDC1200_ARG_RAW'), 0)
             if os.getenv('EAS_MDC1200_ARG_RAW')
             else (db_mdc1200_arg_raw if db_mdc1200_arg_raw is not None else None)
+        ),
+        'mdc1200_target_unit_id': (
+            int(os.getenv('EAS_MDC1200_TARGET_UNIT_ID'), 0)
+            if os.getenv('EAS_MDC1200_TARGET_UNIT_ID')
+            else (
+                int(db_mdc1200_target_unit_id)
+                if db_mdc1200_target_unit_id is not None else None
+            )
         ),
         'attention_tone_seconds': float(
             os.getenv('EAS_ATTENTION_TONE_SECONDS')
@@ -1686,6 +1697,7 @@ def _generate_chime(
     mdc1200_op_code_raw: Optional[int] = None,
     mdc1200_arg_raw: Optional[int] = None,
     mdc1200_unit_id: int = 1,
+    mdc1200_target_unit_id: Optional[int] = None,
 ) -> List[int]:
     """Generate a short attention chime to play before/after an EAS broadcast.
 
@@ -1876,12 +1888,26 @@ def _generate_chime(
                 op, arg = resolve_op_preset(mdc1200_op_code or '')
         else:
             op, arg = resolve_op_preset(mdc1200_op_code or '')
+
+        # Coerce the target unit ID; ``None``, blank string, or out-of-range
+        # values force single-packet emission (the encoder treats 0/None as
+        # "no target configured").
+        target_int: Optional[int] = None
+        if mdc1200_target_unit_id not in (None, ''):
+            try:
+                _t = int(mdc1200_target_unit_id)
+            except (TypeError, ValueError):
+                _t = 0
+            if 1 <= _t <= 0xFFFF:
+                target_int = _t
+
         return generate_mdc1200_samples(
             opcode=op,
             arg=arg,
             unit_id=unit_id_int,
             sample_rate=sample_rate,
             amplitude=amplitude,
+            target_unit_id=target_int,
         )
 
     # Unknown profile: be safe and emit no chime rather than raise.
@@ -2385,6 +2411,7 @@ class EASAudioGenerator:
         mdc1200_op_code = str(self.config.get('mdc1200_op_code', 'ptt_id_pre') or 'ptt_id_pre')
         mdc1200_op_code_raw = self.config.get('mdc1200_op_code_raw', None)
         mdc1200_arg_raw = self.config.get('mdc1200_arg_raw', None)
+        mdc1200_target_unit_id = self.config.get('mdc1200_target_unit_id', None)
         pre_chime_samples = _generate_chime(
             pre_chime_profile, pre_chime_duration, self.sample_rate, amplitude,
             qc2_tone_a_freq=qc2_freq_a, qc2_tone_b_freq=qc2_freq_b,
@@ -2394,6 +2421,7 @@ class EASAudioGenerator:
             mdc1200_op_code_raw=mdc1200_op_code_raw,
             mdc1200_arg_raw=mdc1200_arg_raw,
             mdc1200_unit_id=mdc1200_unit_id,
+            mdc1200_target_unit_id=mdc1200_target_unit_id,
         )
         if pre_chime_samples:
             samples.extend(pre_chime_samples)
@@ -2609,6 +2637,7 @@ class EASAudioGenerator:
             mdc1200_op_code_raw=mdc1200_op_code_raw,
             mdc1200_arg_raw=mdc1200_arg_raw,
             mdc1200_unit_id=mdc1200_unit_id,
+            mdc1200_target_unit_id=mdc1200_target_unit_id,
         )
         if post_chime_samples:
             samples.extend(_generate_silence(0.5, self.sample_rate))
@@ -2926,6 +2955,7 @@ class EASAudioGenerator:
         mdc1200_op_code = str(self.config.get('mdc1200_op_code', 'ptt_id_pre') or 'ptt_id_pre')
         mdc1200_op_code_raw = self.config.get('mdc1200_op_code_raw', None)
         mdc1200_arg_raw = self.config.get('mdc1200_arg_raw', None)
+        mdc1200_target_unit_id = self.config.get('mdc1200_target_unit_id', None)
         pre_chime_samples_list = _generate_chime(
             pre_chime_profile, pre_chime_duration, self.sample_rate, amplitude,
             qc2_tone_a_freq=qc2_freq_a, qc2_tone_b_freq=qc2_freq_b,
@@ -2935,6 +2965,7 @@ class EASAudioGenerator:
             mdc1200_op_code_raw=mdc1200_op_code_raw,
             mdc1200_arg_raw=mdc1200_arg_raw,
             mdc1200_unit_id=mdc1200_unit_id,
+            mdc1200_target_unit_id=mdc1200_target_unit_id,
         )
         post_chime_profile = self.config.get('post_alert_chime', 'none')
         post_chime_duration = float(self.config.get('post_alert_chime_duration', 2.0) or 2.0)
@@ -2947,6 +2978,7 @@ class EASAudioGenerator:
             mdc1200_op_code_raw=mdc1200_op_code_raw,
             mdc1200_arg_raw=mdc1200_arg_raw,
             mdc1200_unit_id=mdc1200_unit_id,
+            mdc1200_target_unit_id=mdc1200_target_unit_id,
         )
         chime_separator = _generate_silence(0.5, self.sample_rate)
 

--- a/app_utils/mdc1200.py
+++ b/app_utils/mdc1200.py
@@ -28,27 +28,68 @@ operations.  This module produces the audio waveform a station can transmit
 so that a receiving Motorola (or compatible) radio displays the originating
 unit ID and any associated event (PTT-ID start / stop, emergency, etc.).
 
-Frame format (single packet, the only variant we emit):
+Frame format — single packet (PTT-ID, Emergency, Request-to-Talk, Remote
+Monitor, …):
 
     [3 byte preamble = 0x00 0x00 0x00]
     [5 byte frame sync = 0x07 0x09 0x2A 0x44 0x6F]
     [14 byte payload]
+    [4 byte post-preamble = 0x00 0x00 0x00 0x00]   -> 26 bytes total
+
+The trailing 4-byte post-preamble continues the mark tone for one extra
+symbol time (~26.67 ms) so a receiving Motorola subscriber sees a clean
+transition back to idle after the CRC passes — without it, some
+CPS-programmed radios refuse to commit the decoded ID to their call
+list.  At 1200 baud the full single frame is 26 × 8 / 1200 ≈ **173.33 ms**
+of audio.
+
+Frame format — double packet (Call Alert, Selective Call, Status messages,
+GPS, …) — the 4-byte tail is reused as an *inter-packet* preamble that
+gives the receiver's symbol tracker a re-sync window before a second
+14-byte payload arrives, giving a 40-byte frame:
+
+    [3 byte preamble]
+    [5 byte frame sync]
+    [14 byte payload #1 — source ID + op/arg/CRC/status]
+    [4 byte inter-packet preamble = 0x00 0x00 0x00 0x00]
+    [14 byte payload #2 — target ID + reserved + CRC + status]
+
+Under differential modulation an all-zero input continues the current
+logical level (no transitions → mark tone after inversion), so the
+receiver's PLL stays locked to the 1200 Hz mark while its symbol
+tracker resets in time for the second 14-byte interleaved payload.  At
+1200 baud the full double frame is 40 × 8 / 1200 ≈ **266.67 ms** of audio.
 
 The 14-byte payload is built from a 7-byte information block:
 
     payload[0] = opcode
     payload[1] = argument
-    payload[2] = unit_id high byte
-    payload[3] = unit_id low byte
+    payload[2] = unit_id high byte           (source ID in packet 1,
+    payload[3] = unit_id low byte             target ID in packet 2)
     payload[4] = CRC low byte    (CRC-16 of bytes 0..3, reverse poly 0x8408)
     payload[5] = CRC high byte
     payload[6] = status byte     (0x00 for PTT-ID, 0x76 for STS / MSG, ...)
 
-A K=7 rate-1/2 convolutional encoder appends 7 FEC bytes derived from those
-7 information bytes, giving 14 bytes (112 bits) of data.  Those 112 bits
-are then run through a 16-row × 7-column bit interleaver, after which the
-**entire** frame (preamble + sync + interleaved payload) is differentially
-modulated (each output bit signals "input bit changed?", then inverted).
+For a packet 2 in double-packet mode the layout is the same shape, but
+``opcode`` and ``argument`` are repurposed as the high/low bytes of the
+target unit ID, and ``unit_id`` slots are zeroed:
+
+    payload2[0] = target_id high byte
+    payload2[1] = target_id low byte
+    payload2[2] = 0x00  (reserved)
+    payload2[3] = 0x00  (reserved)
+    payload2[4] = CRC low byte    (CRC-16 of bytes 0..3 of packet 2)
+    payload2[5] = CRC high byte
+    payload2[6] = 0x00  (status)
+
+A K=7 rate-1/2 convolutional encoder appends 7 FEC bytes derived from each
+7-byte information block, giving 14 bytes (112 bits) of data per block.
+Those bits are then run through a 16-row × 7-column bit interleaver
+(per block), after which the **entire** frame (preamble + sync +
+interleaved payload(s)) is differentially modulated (each output bit
+signals "input bit changed?", then inverted) as one contiguous stream so
+the receiver's transition tracker stays in sync across the boundary
+between the two payloads.
 
 The result is finally rendered as 1200-baud FFSK audio:
 
@@ -72,9 +113,17 @@ Common opcodes (verified against multiple receiver implementations):
     0x40 0x80   Emergency alarm
     0x35 0x89   Request to talk
     0x11 0x80   Remote monitor
+    0x63 0x85   Call Alert  (page a specific target unit ID)
+    0x35 0x80   Selective Call (voice selective call to a target unit ID)
 
 For unit-only paging without an operational meaning, ``PTT_ID_PRE`` is the
 standard choice — virtually every Motorola subscriber decodes it.
+
+For Call Alert and Selective Call, the ``unit_id`` field carries the
+**target** subscriber's ID (the radio to wake), not the transmitting
+station.  Receiving radios programmed with that ID will alert the user
+(Call Alert: beep + display) or unmute their speaker (Selective Call: open
+audio path) when the packet is received.
 
 References
 ----------
@@ -86,7 +135,7 @@ References
 """
 
 import math
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 
 # ---------------------------------------------------------------------------
@@ -111,6 +160,20 @@ MDC1200_PREAMBLE: Tuple[int, ...] = (0x00, 0x00, 0x00)
 #: This is the canonical Motorola pattern recognised by every MDC decoder.
 MDC1200_SYNC: Tuple[int, ...] = (0x07, 0x09, 0x2A, 0x44, 0x6F)
 
+#: 4-byte post-preamble appended after every payload.  In a *single*
+#: packet it sits at the end of the frame so the receiver sees a clean
+#: trailing mark-tone segment after the CRC; in a *double* packet the
+#: same 4-byte sequence sits between payload #1 and payload #2 as an
+#: inter-packet re-sync window.  Under differential modulation an
+#: all-zero input emits a continuous mark tone (no transitions → all
+#: 0xFF after inversion), giving the receiver's symbol tracker a 32-bit
+#: window to settle.
+MDC1200_POST_PREAMBLE: Tuple[int, ...] = (0x00, 0x00, 0x00, 0x00)
+
+#: Backwards-compatible alias for callers that only care about the
+#: double-packet semantics of :data:`MDC1200_POST_PREAMBLE`.
+MDC1200_INTER_PACKET_PREAMBLE: Tuple[int, ...] = MDC1200_POST_PREAMBLE
+
 #: Number of information bytes per packet half (op + arg + 2 ID + 2 CRC + 1 status).
 _FEC_K: int = 7
 
@@ -128,10 +191,39 @@ MDC1200_OP_PRESETS: Dict[str, Tuple[int, int]] = {
     "emergency":      (0x40, 0x80),  # Emergency alarm
     "request_to_talk": (0x35, 0x89),  # Request-to-talk paging
     "remote_monitor": (0x11, 0x80),  # Remote-monitor command
+    "call_alert":     (0x63, 0x85),  # Call Alert (page target subscriber)
+    "selective_call": (0x35, 0x80),  # Voice Selective Call (unmute target)
 }
 
 #: Default preset when the operator hasn't picked one explicitly.
 MDC1200_DEFAULT_PRESET: str = "ptt_id_pre"
+
+#: ``(opcode, arg)`` pairs that traditionally use the **double-packet**
+#: variant on real Motorola subscribers — a second 7-byte info block is
+#: appended carrying the **target** unit ID (the radio being paged or
+#: addressed).  The first info block still carries the transmitting
+#: station's own (source) ID, so a receiver can both unmute for the right
+#: target and display who originated the call.
+#:
+#: When an operator picks one of these op-codes via a preset *and* a
+#: target unit ID is configured, ``generate_mdc1200_samples`` emits the
+#: 36-byte double-packet frame.  When no target is configured, it falls
+#: back to a single-packet frame whose ``unit_id`` field acts as the
+#: target — some receivers tolerate this, but Motorola CPS-programmed
+#: subscribers usually expect the double form.
+MDC1200_DOUBLE_PACKET_OPS: frozenset = frozenset({
+    (0x63, 0x85),  # Call Alert (page target)
+    (0x35, 0x80),  # Voice Selective Call (unmute target)
+})
+
+
+def is_double_packet_op(opcode: int, arg: int) -> bool:
+    """Return ``True`` if ``(opcode, arg)`` is a known double-packet op.
+
+    Used by :func:`generate_mdc1200_samples` to decide whether to emit
+    the 22-byte single packet or the 36-byte double packet variant.
+    """
+    return (opcode & 0xFF, arg & 0xFF) in MDC1200_DOUBLE_PACKET_OPS
 
 
 # ---------------------------------------------------------------------------
@@ -317,9 +409,10 @@ def encode_packet(
             ``0x00`` for PTT-ID variants, ``0x76`` for STS / MSG variants.
 
     Returns:
-        List of 22 bytes — the on-air frame (3 preamble + 5 sync + 14
-        differentially-modulated interleaved payload).  Each byte is
-        transmitted MSB-first at 1200 baud.
+        List of 26 bytes — the on-air frame (3 preamble + 5 sync + 14
+        differentially-modulated interleaved payload + 4 post-preamble).
+        Each byte is transmitted MSB-first at 1200 baud, giving a total
+        airtime of 26 × 8 / 1200 ≈ 173.33 ms.
 
     Raises:
         ValueError: If any input is out of its allowed range.
@@ -350,8 +443,113 @@ def encode_packet(
     payload = _interleave(payload)
 
     # Assemble full frame and apply differential modulation across the
-    # entire transmission (preamble + sync + payload).
-    frame = list(MDC1200_PREAMBLE) + list(MDC1200_SYNC) + payload
+    # entire transmission (preamble + sync + payload + post-preamble).
+    # The 4-byte trailing post-preamble continues the mark tone for an
+    # extra ~26.67 ms so receivers see a clean idle transition after the
+    # CRC passes — without it some Motorola subscribers refuse to commit
+    # the decoded ID to their call list.
+    frame = (
+        list(MDC1200_PREAMBLE)
+        + list(MDC1200_SYNC)
+        + payload
+        + list(MDC1200_POST_PREAMBLE)
+    )
+    return _xor_modulate(frame)
+
+
+def encode_double_packet(
+    opcode: int,
+    arg: int,
+    src_unit_id: int,
+    target_unit_id: int,
+    *,
+    status: int = 0x00,
+) -> List[int]:
+    """Build a 40-byte MDC1200 double packet (Call Alert / Selective Call).
+
+    The double packet appends a 4-byte inter-packet preamble plus a
+    second 14-byte interleaved payload (built from a 7-byte info block
+    carrying the target subscriber's ID).  The two info blocks go
+    through the K=7 FEC and 16×7 interleaver independently and the
+    **entire** 40-byte buffer (preamble + sync + payload1 +
+    inter-packet preamble + payload2) is then differentially modulated
+    as a single stream so the receiver's transition tracker carries
+    cleanly across the payload-1 → preamble → payload-2 boundary.
+
+    At 1200 baud the resulting waveform is 40 × 8 / 1200 ≈ 266.67 ms.
+
+    Second info block layout (7 bytes):
+
+        ``[target_id_high, target_id_low, 0x00, 0x00, crc_lo, crc_hi, 0x00]``
+
+    Args:
+        opcode: 8-bit op-code for packet 1 (e.g. 0x63 for Call Alert).
+        arg: 8-bit op-code argument for packet 1 (e.g. 0x85).
+        src_unit_id: 16-bit transmitting station's unit ID (1..65535).
+        target_unit_id: 16-bit target subscriber's unit ID (1..65535) —
+            the radio that should be paged or unmuted.
+        status: Status byte for packet 1 (defaults to 0x00).
+
+    Returns:
+        List of 40 bytes (3 preamble + 5 sync + 14 payload-1 + 4
+        inter-packet preamble + 14 payload-2) ready for FFSK modulation.
+
+    Raises:
+        ValueError: If any input is out of its allowed range.
+    """
+    if not 0 <= opcode <= 0xFF:
+        raise ValueError("opcode must be in 0..255")
+    if not 0 <= arg <= 0xFF:
+        raise ValueError("arg must be in 0..255")
+    if not 0 <= src_unit_id <= 0xFFFF:
+        raise ValueError("src_unit_id must be in 0..65535")
+    if not 0 <= target_unit_id <= 0xFFFF:
+        raise ValueError("target_unit_id must be in 0..65535")
+    if not 0 <= status <= 0xFF:
+        raise ValueError("status must be in 0..255")
+
+    # Packet 1: source ID + op/arg
+    info1 = [
+        opcode & 0xFF,
+        arg & 0xFF,
+        (src_unit_id >> 8) & 0xFF,
+        src_unit_id & 0xFF,
+    ]
+    crc1 = compute_crc(info1)
+    info1.append(crc1 & 0xFF)
+    info1.append((crc1 >> 8) & 0xFF)
+    info1.append(status & 0xFF)
+    payload1 = _interleave(_apply_fec(info1))
+
+    # Packet 2: target ID + reserved + CRC + status.  The Motorola wire
+    # format puts the target ID in bytes 0..1 of the second info block,
+    # leaves bytes 2..3 zero, and protects bytes 0..3 with an independent
+    # CRC-16 computed exactly the same way as packet 1's CRC.
+    info2 = [
+        (target_unit_id >> 8) & 0xFF,
+        target_unit_id & 0xFF,
+        0x00,
+        0x00,
+    ]
+    crc2 = compute_crc(info2)
+    info2.append(crc2 & 0xFF)
+    info2.append((crc2 >> 8) & 0xFF)
+    info2.append(0x00)  # status byte 2 — always 0x00 for the known double-packet ops
+    payload2 = _interleave(_apply_fec(info2))
+
+    # Differential modulation runs across the entire 40-byte buffer in
+    # one pass — splitting it would corrupt the inter-payload transition
+    # bit and break the receiver's tracker at the boundary.  The 4-byte
+    # inter-packet preamble (all 0x00) becomes a 32-bit mark-tone window
+    # under differential modulation, giving the receiver's symbol tracker
+    # time to re-lock before the second interleaved payload starts.
+    frame = (
+        list(MDC1200_PREAMBLE)
+        + list(MDC1200_SYNC)
+        + payload1
+        + list(MDC1200_POST_PREAMBLE)
+        + payload2
+    )
     return _xor_modulate(frame)
 
 
@@ -377,6 +575,7 @@ def generate_mdc1200_samples(
     amplitude: float,
     *,
     status: int = 0x00,
+    target_unit_id: Optional[int] = None,
 ) -> List[int]:
     """Generate the FFSK PCM samples for a complete MDC1200 packet.
 
@@ -386,24 +585,55 @@ def generate_mdc1200_samples(
     decodable at the cost of some quantisation noise on the 1800 Hz
     space tone).
 
+    Single vs. double packet selection:
+
+    * If ``(opcode, arg)`` is in :data:`MDC1200_DOUBLE_PACKET_OPS` (Call
+      Alert, Selective Call) **and** ``target_unit_id`` is provided and
+      non-zero, a 36-byte double packet is emitted with the source ID in
+      packet 1 and ``target_unit_id`` in packet 2.
+    * Otherwise the classic 22-byte single packet is emitted (and
+      ``target_unit_id`` is ignored).
+
     Args:
         opcode: 8-bit op-code (see ``MDC1200_OP_PRESETS``).
         arg: 8-bit op-code argument.
-        unit_id: 16-bit subscriber unit ID.
+        unit_id: 16-bit subscriber unit ID.  Acts as the *source* ID in
+            double-packet mode and as the only ID in single-packet mode.
         sample_rate: Output sample rate in Hz.
         amplitude: Peak signed-int amplitude (e.g. ``0.7 * 32767``).
         status: Status byte (defaults to 0x00 for PTT-ID variants).
+        target_unit_id: 16-bit target subscriber ID for double-packet
+            ops (Call Alert / Selective Call).  ``None`` or 0 forces
+            single-packet emission.
 
     Returns:
         Phase-continuous int16-range PCM samples for the entire packet.
-        At 16 kHz this is approximately 22 bytes × 8 bits / 1200 baud
-        × 16000 = 2347 samples (≈ 147 ms).
+        At 16 kHz this is approximately:
+
+        * single packet: 26 bytes × 8 bits / 1200 baud × 16000
+          ≈ 2773 samples (≈ 173.33 ms)
+        * double packet: 40 bytes × 8 bits / 1200 baud × 16000
+          ≈ 4267 samples (≈ 266.67 ms)
     """
     # Re-use the shared phase-continuous FFSK renderer that is already
     # tested for the SAME modem (8333.5 / 8333.5 Hz at 520.83 baud).
     from app_utils.eas_fsk import generate_fsk_samples
 
-    frame_bytes = encode_packet(opcode, arg, unit_id, status=status)
+    if (
+        target_unit_id is not None
+        and int(target_unit_id) != 0
+        and is_double_packet_op(opcode, arg)
+    ):
+        frame_bytes = encode_double_packet(
+            opcode,
+            arg,
+            src_unit_id=unit_id,
+            target_unit_id=int(target_unit_id),
+            status=status,
+        )
+    else:
+        frame_bytes = encode_packet(opcode, arg, unit_id, status=status)
+
     bits = bytes_to_bits_msb(frame_bytes)
     return generate_fsk_samples(
         bits,
@@ -432,10 +662,15 @@ __all__ = [
     "MDC1200_SPACE_FREQ",
     "MDC1200_PREAMBLE",
     "MDC1200_SYNC",
+    "MDC1200_POST_PREAMBLE",
+    "MDC1200_INTER_PACKET_PREAMBLE",
     "MDC1200_OP_PRESETS",
     "MDC1200_DEFAULT_PRESET",
+    "MDC1200_DOUBLE_PACKET_OPS",
     "compute_crc",
     "encode_packet",
+    "encode_double_packet",
+    "is_double_packet_op",
     "bytes_to_bits_msb",
     "generate_mdc1200_samples",
     "resolve_op_preset",

--- a/docs/guides/ALERT_CHIMES.md
+++ b/docs/guides/ALERT_CHIMES.md
@@ -33,10 +33,11 @@ Alert Chimes** card. Settings persist in the `eas_settings` table.
 | QC-II Enable Long Tone | boolean | `false` | Append a sustained tone after the A+B sequence. |
 | QC-II Long Tone Duration | seconds (1–120) | `10.0` | Duration of the appended long tone. |
 | DTMF Sequence | string (0–32 chars) | `""` | Digits dialed for DTMF profile. |
-| MDC1200 Unit ID | integer (1–65535, decimal **or** `0x0001`–`0xFFFF` hex) | `1` | Subscriber unit ID for the MDC1200 profile. |
+| MDC1200 Unit ID | integer (1–65535, decimal **or** `0x0001`–`0xFFFF` hex) | `1` | Source subscriber unit ID for the MDC1200 profile (the transmitting station's ID — what receiving radios display as the caller). |
 | MDC1200 Op-Code | dropdown | `ptt_id_pre` | Symbolic preset (or `custom` for raw bytes). |
 | MDC1200 Raw Op-Code | byte (0x00–0xFF, optional) | *(unset)* | Used only when preset = `custom`. |
 | MDC1200 Raw Argument | byte (0x00–0xFF, optional) | *(unset)* | Used only when preset = `custom`. |
+| MDC1200 Target Unit ID | integer (1–65535, decimal **or** `0x0001`–`0xFFFF` hex, optional) | *(unset)* | Destination subscriber ID for double-packet ops (`call_alert`, `selective_call`). When set the encoder appends a second 14-byte info block carrying this ID — frame becomes ~267 ms instead of ~173 ms. Leave blank to fall back to a single-packet frame. |
 
 The pre-alert and post-alert profiles are configured independently, so you can
 e.g. play a single `bell` before each broadcast and leave the post-alert
@@ -95,29 +96,49 @@ ITU-T Q.23 / Q.24 tone pair (low-group + high-group sine sum).
 
 A 1200-baud FFSK packet (mark = 1200 Hz, space = 1800 Hz) carrying this
 station's *Unit ID* and an op-code that tells receiving Motorola subscribers
-what kind of call this is (PTT-ID, Emergency, Request to Talk, etc.).
+what kind of call this is (PTT-ID, Emergency, Request to Talk, Call
+Alert, Selective Call, etc.).
 
-* Packet duration is fixed by the protocol at ~147 ms; the chime-duration
-  field is **ignored**.
-* **Unit ID** is a 16-bit subscriber identifier (1–65535). Accepts both
+* Packet duration is fixed by the protocol — the chime-duration field is
+  **ignored**:
+  * **Single-packet ops** (PTT-ID, Emergency, Request to Talk, Remote
+    Monitor, Custom): 26 bytes / 208 bits → **~173 ms**.
+  * **Double-packet ops** (Call Alert, Selective Call): 40 bytes /
+    320 bits → **~267 ms**. A second 14-byte info block carrying the
+    target subscriber's ID is appended after a 4-byte inter-packet
+    re-sync preamble.
+* **Unit ID** is the 16-bit *source* identifier — the EAS station's own
+  ID that receiving radios display as the caller (1–65535). Accepts both
   decimal (`1234`) and hex (`0x04D2`) input — Motorola CPS commonly
   displays unit IDs as 4-digit hex.
+* **Target Unit ID** is the 16-bit *destination* ID for double-packet
+  ops. When `call_alert` or `selective_call` is selected and a target
+  ID is configured, the encoder produces the canonical 40-byte double
+  frame; receiving radios programmed with that ID alert (Call Alert →
+  beep + display) or unmute their speaker (Selective Call → audio
+  path opens). Leaving the field blank falls back to a single-packet
+  frame whose source ID also acts as the target — some receivers
+  tolerate this shortcut, but real Motorola CPS-programmed
+  subscribers usually expect the double form.
 * **Op-Code preset** chooses what packet to emit:
 
-  | Preset | `op` | `arg` | Meaning |
-  |---|---|---|---|
-  | `ptt_id_pre` | `0x01` | `0x80` | PTT-ID at the start of a transmission (default) |
-  | `ptt_id_post` | `0x00` | `0x80` | PTT-ID at the end of a transmission |
-  | `emergency` | `0x40` | `0x80` | Emergency alarm |
-  | `request_to_talk` | `0x35` | `0x89` | Request-to-talk paging |
-  | `remote_monitor` | `0x11` | `0x80` | Remote-monitor command |
-  | `custom` | any | any | Operator-supplied raw op/arg bytes (decimal or `0x..` hex) |
+  | Preset | `op` | `arg` | Frame | Meaning |
+  |---|---|---|---|---|
+  | `ptt_id_pre` | `0x01` | `0x80` | single | PTT-ID at the start of a transmission (default) |
+  | `ptt_id_post` | `0x00` | `0x80` | single | PTT-ID at the end of a transmission |
+  | `emergency` | `0x40` | `0x80` | single | Emergency alarm |
+  | `request_to_talk` | `0x35` | `0x89` | single | Request-to-talk paging |
+  | `remote_monitor` | `0x11` | `0x80` | single | Remote-monitor command |
+  | `call_alert` | `0x63` | `0x85` | double | Page a target subscriber (target ID required for canonical form) |
+  | `selective_call` | `0x35` | `0x80` | double | Voice Selective Call — unmute target subscriber |
+  | `custom` | any | any | single | Operator-supplied raw op/arg bytes (decimal or `0x..` hex) |
 
 * **Smart pre/post pairing.** When *both* the pre and post chimes are set
   to `mdc1200` and the op-code preset is `ptt_id_pre` (the default), EAS
   Station automatically substitutes `ptt_id_post` on the post-alert
   position so receiving Motorola radios see a complete bookend pair and
-  close the call cleanly. All other presets pass through unchanged.
+  close the call cleanly. All other presets — including `call_alert`
+  and `selective_call` — pass through unchanged on both sides.
 
 > **Verifying generated packets.** Render any test alert and decode the
 > generated WAV with [multimon-ng](https://github.com/EliasOenal/multimon-ng):
@@ -209,10 +230,11 @@ database values when set:
 | `EAS_QC2_LONG_TONE_ENABLED` | QC-II Long Tone enabled (`1`, `true`, or `yes`) |
 | `EAS_QC2_LONG_TONE_SECONDS` | QC-II Long Tone Duration (seconds) |
 | `EAS_DTMF_SEQUENCE` | DTMF Sequence |
-| `EAS_MDC1200_UNIT_ID` | MDC1200 Unit ID (decimal or `0x..` hex) |
+| `EAS_MDC1200_UNIT_ID` | MDC1200 source Unit ID (decimal or `0x..` hex) |
 | `EAS_MDC1200_OP_CODE` | MDC1200 Op-Code preset name |
 | `EAS_MDC1200_OP_CODE_RAW` | MDC1200 Raw Op-Code byte (decimal or `0x..` hex) |
 | `EAS_MDC1200_ARG_RAW` | MDC1200 Raw Argument byte (decimal or `0x..` hex) |
+| `EAS_MDC1200_TARGET_UNIT_ID` | MDC1200 Target Unit ID for Call Alert / Selective Call double-packet ops (decimal or `0x..` hex; empty/0 → single packet) |
 
 Internally the chime is rendered by `app_utils.eas._generate_chime()`; profiles
 are listed in `app_utils.eas.ALERT_CHIME_PROFILES`. Adding new profiles is a
@@ -246,7 +268,8 @@ PUT /admin/eas_settings    Content-Type: application/json
   "mdc1200_unit_id": "0x04D2",
   "mdc1200_op_code": "ptt_id_pre",
   "mdc1200_op_code_raw": null,
-  "mdc1200_arg_raw": null
+  "mdc1200_arg_raw": null,
+  "mdc1200_target_unit_id": null
 }
 ```
 
@@ -262,10 +285,16 @@ Server-side validation:
 * `mdc1200_unit_id` must be an integer in `[1, 65535]`. Strings are parsed
   with `int(value, 0)`, so `"1234"` and `"0x04D2"` are both accepted.
 * `mdc1200_op_code` must be one of `ptt_id_pre`, `ptt_id_post`, `emergency`,
-  `request_to_talk`, `remote_monitor`, `custom` (case-insensitive).
+  `request_to_talk`, `remote_monitor`, `call_alert`, `selective_call`,
+  `custom` (case-insensitive).
 * `mdc1200_op_code_raw` and `mdc1200_arg_raw` must each be an integer in
   `[0, 255]` (or `null`/`""` to clear). Strings are parsed with
   `int(value, 0)`, so both decimal and `0x..` hex are accepted.
+* `mdc1200_target_unit_id` must be an integer in `[1, 65535]`, or
+  `null`/`""`/`0` to clear (which forces single-packet emission).
+  Strings are parsed with `int(value, 0)`, so both decimal and `0x..`
+  hex are accepted. Used only when `mdc1200_op_code` is `call_alert` or
+  `selective_call`; ignored for other presets.
 
 ---
 
@@ -273,8 +302,9 @@ Server-side validation:
 
 Schema additions are applied by Alembic migrations
 `20260501_add_alert_chime_to_eas_settings`,
-`20260505_add_qc2_long_tone_to_eas_settings`, and
-`20260505_add_mdc1200_to_eas_settings`:
+`20260505_add_qc2_long_tone_to_eas_settings`,
+`20260505_add_mdc1200_to_eas_settings`, and
+`20260505_add_mdc1200_target_unit_id_to_eas_settings`:
 
 | Column | Type | Default |
 |--------|------|---------|
@@ -291,6 +321,7 @@ Schema additions are applied by Alembic migrations
 | `mdc1200_op_code` | `VARCHAR(32) NOT NULL` | `'ptt_id_pre'` |
 | `mdc1200_op_code_raw` | `SMALLINT NULL` | `NULL` |
 | `mdc1200_arg_raw` | `SMALLINT NULL` | `NULL` |
+| `mdc1200_target_unit_id` | `INTEGER NULL` | `NULL` |
 
 The migration uses `ADD COLUMN IF NOT EXISTS` and the application also
 self-heals these columns on first read via `_PENDING_MIGRATIONS` in

--- a/docs/reference/protocols/MDC1200.md
+++ b/docs/reference/protocols/MDC1200.md
@@ -91,44 +91,91 @@ bits. EAS Station re-uses the same `eas_fsk.generate_fsk_samples` renderer
 the SAME modem uses, which carries phase across the symbol boundary.
 
 The renderer is parameterised on the audio sample rate (defaults to the
-EAS Station-wide setting, typically 16 kHz or 22.05 kHz). At 16 kHz a
-complete packet is approximately **147 ms** of audio (~2347 samples).
+EAS Station-wide setting, typically 16 kHz or 22.05 kHz). At 16 kHz the
+on-air durations are:
+
+| Frame | Bytes | Bits | Audio @ 1200 baud | Samples @ 16 kHz |
+|---|---|---|---|---|
+| Single packet (PTT-ID, Emergency, …) | 26 | 208 | **173.33 ms** | ~2773 |
+| Double packet (Call Alert, Selective Call) | 40 | 320 | **266.67 ms** | ~4267 |
 
 ---
 
 ## 3. Frame format
 
-A complete MDC1200 single packet (the only variant EAS Station emits) is
-**22 bytes** of pre-modulation data:
+EAS Station emits two MDC1200 frame variants depending on the op-code:
+
+* **Single packet — 26 bytes** (PTT-ID, Emergency, Request to Talk,
+  Remote Monitor, Custom): one 14-byte interleaved payload bracketed by
+  the standard preamble + sync prefix and a 4-byte trailing post-preamble
+  that gives receivers a clean idle transition after the CRC passes.
+* **Double packet — 40 bytes** (Call Alert, Selective Call, and any
+  other op-code/arg pair listed in :data:`MDC1200_DOUBLE_PACKET_OPS`):
+  a second 14-byte interleaved payload is appended after a 4-byte
+  inter-packet preamble that re-syncs the receiver between blocks.
+  The second payload carries a *target* unit ID (the radio that should
+  be paged or unmuted) while the first payload still carries the
+  transmitting station's source ID and the op-code.
+
+### 3.1 Single packet layout
 
 ```mermaid
 flowchart LR
     P["Preamble<br/>3 bytes<br/>00 00 00"]
     S["Frame Sync<br/>5 bytes<br/>07 09 2A 44 6F"]
     PL["Payload<br/>14 bytes<br/>(info + FEC, interleaved)"]
+    POST["Post-preamble<br/>4 bytes<br/>00 00 00 00"]
 
-    P --> S --> PL
+    P --> S --> PL --> POST
 
     classDef preamble fill:#fef3c7,stroke:#92400e,color:#78350f;
     classDef sync fill:#dbeafe,stroke:#1e40af,color:#1e3a8a;
     classDef payload fill:#dcfce7,stroke:#166534,color:#14532d;
+    classDef post fill:#fef3c7,stroke:#92400e,color:#78350f;
     class P preamble;
     class S sync;
     class PL payload;
+    class POST post;
 ```
 
-After differential ("XOR") modulation is applied across the entire 22-byte
-buffer, the on-air bytes are different from the values shown above, but the
-*logical* content the receiver recovers is exactly this layout.
+### 3.2 Double packet layout
 
-### 3.1 Preamble — 3 bytes of `0x00`
+```mermaid
+flowchart LR
+    P["Preamble<br/>3 bytes<br/>00 00 00"]
+    S["Frame Sync<br/>5 bytes<br/>07 09 2A 44 6F"]
+    PL1["Payload #1<br/>14 bytes<br/>op + arg + src ID + CRC<br/>+ FEC, interleaved"]
+    IPP["Inter-packet preamble<br/>4 bytes<br/>00 00 00 00"]
+    PL2["Payload #2<br/>14 bytes<br/>target ID + reserved<br/>+ CRC + FEC, interleaved"]
+
+    P --> S --> PL1 --> IPP --> PL2
+
+    classDef preamble fill:#fef3c7,stroke:#92400e,color:#78350f;
+    classDef sync fill:#dbeafe,stroke:#1e40af,color:#1e3a8a;
+    classDef payload fill:#dcfce7,stroke:#166534,color:#14532d;
+    class P,IPP preamble;
+    class S sync;
+    class PL1,PL2 payload;
+```
+
+After differential ("XOR") modulation is applied across the entire frame
+buffer (26 bytes for single, 40 bytes for double) in one pass, the
+on-air bytes are different from the values shown above, but the
+*logical* content the receiver recovers is exactly this layout. The
+4-byte inter-packet preamble and the trailing post-preamble both decode
+to a continuous mark-tone segment, giving receivers a re-sync window
+between blocks (double) or a clean tail-off (single) — the differential
+modulator passes a steady mark whenever the input bit doesn't change,
+and four 0x00 bytes contain no transitions.
+
+### 3.3 Preamble — 3 bytes of `0x00`
 
 After differential modulation, an all-zero input produces a steady stream of
 mark tones (because no transitions occur, and the encoder inverts the
 "transitioned?" bit so "no change" → 1 → mark). This gives the receiver's
 PLL ~20 ms to lock to the 1200 Hz tone before the sync word arrives.
 
-### 3.2 Frame sync — 5 bytes / 40 bits
+### 3.4 Frame sync — 5 bytes / 40 bits
 
 The canonical Motorola pattern, recognised by every MDC1200 decoder:
 
@@ -150,7 +197,7 @@ A receiver typically declares lock when at least 32 of the 40 sync bits
 match (a Hamming-distance threshold of ≤8) — this is what `mdc1200.c` style
 implementations call `sync_bit_ok_threshold`.
 
-### 3.3 Payload — 14 bytes
+### 3.5 Payload — 14 bytes
 
 Built in three steps from a 7-byte information block, in this order:
 
@@ -179,7 +226,7 @@ The 7-byte information block lays out as:
 | 5 | `CRC` (high byte) | 8 bits | High byte (note: CRC is on-the-wire little-endian) |
 | 6 | `status` | 8 bits | `0x00` for PTT-ID variants, `0x76` for STS / MSG |
 
-#### 3.3.1 CRC-16
+#### 3.5.1 CRC-16
 
 | Property | Value |
 |---|---|
@@ -206,7 +253,7 @@ compute_crc([0x01, 0x80, 0x12, 0x34]) == 0x3E2E
 ```
 On the wire that becomes `2E 3E` (low byte first) at offsets 4–5.
 
-#### 3.3.2 K=7 rate-1/2 convolutional FEC
+#### 3.5.2 K=7 rate-1/2 convolutional FEC
 
 The 7 information bytes are fed bit-by-bit (LSB-first per byte) into an
 **8-bit shift register** that is initialised to zero and **carries state
@@ -240,7 +287,7 @@ errors when ≥ 3 of the last 4 syndrome bits are set, then XORs the syndrome
 with `0xA6` to clear the corrected position. In practice this corrects up
 to 3–4 corrupted bits per packet.
 
-#### 3.3.3 Bit interleaver — 16 × 7
+#### 3.5.3 Bit interleaver — 16 × 7
 
 The 14-byte (112-bit) FEC block is interleaved with a distance-16 mapping
 that spreads adjacent FEC bits 16 bits apart on the wire — so a contiguous
@@ -271,13 +318,45 @@ output[96..111] ← payload bits (15, 31, 47, 63, 79, 95, 111)
 Output bits are then packed **MSB-first per byte** into the final 14
 interleaved bytes that make up the on-air payload.
 
-#### 3.3.4 Differential ("XOR") modulation
+### 3.6 Second info block (double packet only)
 
-After the preamble, sync, and interleaved payload have all been assembled
-into a single 22-byte buffer, each bit is replaced by a "did the input bit
-change?" flag, MSB-first across the entire buffer, with the previous-bit
-register initialised to 0. Each completed output byte is then inverted
-(`^ 0xFF`).
+When the op-code is one of the documented double-packet variants (Call
+Alert `0x63 0x85`, Selective Call `0x35 0x80`, …) and a target unit ID
+is configured, a second 7-byte information block is built from the
+target ID, run through the same K=7 FEC + 16×7 interleaver pipeline as
+packet 1, and appended to the frame after a 4-byte inter-packet
+preamble (32 bits of 0x00 → continuous mark tone for receiver re-sync).
+
+| Offset | Field | Width | Description |
+|---|---|---|---|
+| 0 | `target_id` (high) | 8 bits | High byte of the 16-bit *target* unit ID |
+| 1 | `target_id` (low) | 8 bits | Low byte of the 16-bit *target* unit ID |
+| 2 | reserved | 8 bits | `0x00` |
+| 3 | reserved | 8 bits | `0x00` |
+| 4 | `CRC` (low byte) | 8 bits | Low byte of CRC-16 over `target_id_h, target_id_l, 0x00, 0x00` |
+| 5 | `CRC` (high byte) | 8 bits | High byte (little-endian on the wire, same as packet 1) |
+| 6 | `status` | 8 bits | `0x00` |
+
+The CRC over the second info block uses **the same algorithm** as
+packet 1 (CRC-CCITT reverse polynomial `0x8408`, init `0x0000`, final
+XOR `0xFFFF`), independently computed over the 4-byte `(target_h,
+target_l, 0x00, 0x00)` prefix. The status byte is *not* covered, again
+matching packet 1.
+
+When `mdc1200_target_unit_id` is `NULL` or `0`, the encoder falls back
+to a single-packet frame whose `unit_id` field acts as the target —
+some receivers tolerate this shortcut, but real Motorola CPS-programmed
+subscribers normally expect the double-packet form for Call Alert and
+Selective Call.
+
+#### 3.6.1 Differential ("XOR") modulation
+
+After the preamble, sync, payload(s), and post-/inter-packet preamble(s)
+have all been assembled into the final pre-modulation buffer (26 bytes
+for single, 40 bytes for double), each bit is replaced by a "did the
+input bit change?" flag, MSB-first across the entire buffer, with the
+previous-bit register initialised to 0. Each completed output byte is
+then inverted (`^ 0xFF`).
 
 ```python
 prev = 0
@@ -312,13 +391,25 @@ EAS Station ships these symbolic presets (defined in
 | `emergency` | `0x40` | `0x80` | Emergency alarm |
 | `request_to_talk` | `0x35` | `0x89` | Request-to-talk paging |
 | `remote_monitor` | `0x11` | `0x80` | Remote-monitor command |
+| `call_alert` | `0x63` | `0x85` | Call Alert — page a specific target unit (unit ID = target) |
+| `selective_call` | `0x35` | `0x80` | Voice Selective Call — unmute a specific target (unit ID = target) |
 | *custom* | any | any | Operator-supplied raw bytes |
 
+> **Target-vs-source semantics.** For `ptt_id_pre`, `ptt_id_post`,
+> `emergency`, `request_to_talk`, and `remote_monitor`, the
+> `mdc1200_unit_id` setting is the **transmitting station's own ID** —
+> receiving radios display "who is talking." For `call_alert` and
+> `selective_call`, the same field is reinterpreted as the **target**
+> subscriber's ID — the receiving radio that should be paged or unmuted.
+> Set `mdc1200_unit_id` to the destination radio's programmed ID when
+> using these two presets. Multiple targets require sending the chime
+> repeatedly (or grouping IDs at the receiver via talkgroup
+> programming).
+
 For a complete-but-not-formally-published list of additional op-codes (status
-messages, voice-selective-call, GPS, etc.), the multimon-ng decoder source
-and several open-source LMR firmware projects are good cross-references.
-Custom raw bytes are accepted for advanced operators who need to interoperate
-with non-standard fleets.
+messages, GPS, etc.), the multimon-ng decoder source and several open-source
+LMR firmware projects are good cross-references. Custom raw bytes are accepted
+for advanced operators who need to interoperate with non-standard fleets.
 
 ### 4.1 Smart pre/post pairing
 
@@ -342,10 +433,11 @@ to wake every subscriber on a quiet channel.
 
 | Column | Type | Default | Notes |
 |---|---|---|---|
-| `mdc1200_unit_id` | `INTEGER NOT NULL` | `1` | 1..65535 (zero is reserved). Stored as a decimal integer; the UI and API accept either decimal (`1234`) or `0x..` hex (`0x04D2`) on input. |
+| `mdc1200_unit_id` | `INTEGER NOT NULL` | `1` | 1..65535 (zero is reserved). The transmitting station's *source* ID — what receiving radios display as the calling unit. Stored as a decimal integer; the UI and API accept either decimal (`1234`) or `0x..` hex (`0x04D2`) on input. |
 | `mdc1200_op_code` | `VARCHAR(32) NOT NULL` | `'ptt_id_pre'` | One of the preset keys, or `'custom'` |
 | `mdc1200_op_code_raw` | `SMALLINT NULL` | `NULL` | 0..255, used only when preset = `'custom'`. Accepts decimal or `0x..` hex on input; rendered as `0xNN` in the UI. |
 | `mdc1200_arg_raw` | `SMALLINT NULL` | `NULL` | 0..255, used only when preset = `'custom'`. Accepts decimal or `0x..` hex on input; rendered as `0xNN` in the UI. |
+| `mdc1200_target_unit_id` | `INTEGER NULL` | `NULL` | 1..65535 *target* ID for the double-packet ops (Call Alert, Selective Call). When set and the op-code is double-packet-eligible, the encoder appends a second 14-byte info block carrying this ID — making the on-air frame ~267 ms instead of ~173 ms. NULL or 0 forces single-packet emission. |
 
 > **Hex input policy.** All three byte/word fields (`mdc1200_unit_id`,
 > `mdc1200_op_code_raw`, `mdc1200_arg_raw`) accept full hexadecimal
@@ -370,14 +462,19 @@ the same DDL so installs that update DB-first also self-heal.
 
 | Env var | Type | Meaning |
 |---|---|---|
-| `EAS_MDC1200_UNIT_ID` | int (decimal or `0x..` hex) | Override unit ID |
+| `EAS_MDC1200_UNIT_ID` | int (decimal or `0x..` hex) | Override source unit ID |
 | `EAS_MDC1200_OP_CODE` | str | Override preset key |
 | `EAS_MDC1200_OP_CODE_RAW` | int (decimal or `0x..` hex) | Override raw op byte |
 | `EAS_MDC1200_ARG_RAW` | int (decimal or `0x..` hex) | Override raw arg byte |
+| `EAS_MDC1200_TARGET_UNIT_ID` | int (decimal or `0x..` hex) | Override target unit ID for double-packet ops; empty/0 → single packet |
 
 `_generate_chime()` then routes the config into
 `generate_mdc1200_samples(opcode, arg, unit_id, sample_rate, amplitude,
-status=0x00)`, which produces the phase-continuous PCM samples.
+status=0x00, target_unit_id=None)`, which produces the phase-continuous
+PCM samples. When the op-code is double-packet-eligible (Call Alert,
+Selective Call) **and** `target_unit_id` is provided and non-zero the
+encoder dispatches to `encode_double_packet()`; otherwise the classic
+single-packet `encode_packet()` path is used.
 
 ### 5.3 Audio assembly
 
@@ -406,9 +503,13 @@ The single best external verification tool is
 # Generate an alert with MDC1200 chimes enabled in admin, then:
 multimon-ng -a MDC -t wav /var/www/eas-station/static/eas_messages/<your-alert>.wav
 
-# Expected output line:
+# Expected output lines (single-packet ops):
 #   MDC: 0080 1234 PTT ID POST
 #   MDC: 0180 1234 PTT ID PRE
+
+# Expected output lines (double-packet ops, with target ID 0x5678):
+#   MDC: 6385 1234 CALL ALERT  -> 5678
+#   MDC: 3580 1234 SEL CALL    -> 5678
 ```
 
 Inside the codebase, `tests/test_mdc1200.py` exercises every layer:
@@ -431,11 +532,12 @@ Run with `pytest tests/test_mdc1200.py -q`.
 
 ## 7. Limitations
 
-* Only the **single packet** variant is implemented. The **double packet**
-  variant (chained 7-byte info blocks, used to carry e.g. GPS coordinates
-  or 4 extra status bytes) is straightforward to add later if a fleet
-  needs it — the encoder structure already supports chaining via a second
-  `encode_data()` pass.
+* Both the **single packet** (26 bytes, ~173 ms) and **double packet**
+  (40 bytes, ~267 ms) variants are implemented. Double-packet ops
+  beyond Call Alert and Selective Call (e.g. GPS coordinates, extended
+  status messages with 4 extra bytes in the second info block) are
+  straightforward to add by extending :data:`MDC1200_DOUBLE_PACKET_OPS`
+  and supplying additional fields to `encode_double_packet()`.
 * EAS Station does not implement an **MDC1200 receiver**. Decoding incoming
   MDC packets from monitored radios would require a full FFSK demodulator
   and the inverse of the encoder pipeline (sync hunt, de-interleave, FEC

--- a/static/js/admin/location-settings.js
+++ b/static/js/admin/location-settings.js
@@ -1068,12 +1068,14 @@ function updateToneFieldVisibility() {
     const isFreeform = (v) => v !== 'none' && v !== 'dtmf' && v !== 'qc2' && v !== 'mdc1200';
     const opCode = document.getElementById('easMdc1200OpCode')?.value || 'ptt_id_pre';
     const mdcVisible = pre === 'mdc1200' || post === 'mdc1200';
+    const isMdcDoublePacket = opCode === 'call_alert' || opCode === 'selective_call';
 
     const visibility = {
         'qc2': pre === 'qc2' || post === 'qc2',
         'dtmf': pre === 'dtmf' || post === 'dtmf',
         'mdc1200': mdcVisible,
         'mdc1200-custom': mdcVisible && opCode === 'custom',
+        'mdc1200-double': mdcVisible && isMdcDoublePacket,
         'pre-duration': isFreeform(pre),
         'post-duration': isFreeform(post),
     };
@@ -1209,6 +1211,11 @@ function populateEasForm(settings) {
     const mdcArgRaw = document.getElementById('easMdc1200ArgRaw');
     if (mdcArgRaw) {
         mdcArgRaw.value = _formatHexByte(settings.mdc1200_arg_raw);
+    }
+    const mdcTargetUnitId = document.getElementById('easMdc1200TargetUnitId');
+    if (mdcTargetUnitId) {
+        const _tv = settings.mdc1200_target_unit_id;
+        mdcTargetUnitId.value = (_tv === null || _tv === undefined) ? '' : String(_tv);
     }
     if (authorizedEventsTextarea) {
         authorizedEventsTextarea.value = (settings.authorized_event_codes || []).join('\n');
@@ -1365,6 +1372,7 @@ async function handleEasSettingsSubmit(e) {
         mdc1200_op_code: document.getElementById('easMdc1200OpCode')?.value || 'ptt_id_pre',
         mdc1200_op_code_raw: (document.getElementById('easMdc1200OpCodeRaw')?.value || '').trim() || null,
         mdc1200_arg_raw: (document.getElementById('easMdc1200ArgRaw')?.value || '').trim() || null,
+        mdc1200_target_unit_id: (document.getElementById('easMdc1200TargetUnitId')?.value || '').trim() || null,
         authorized_event_codes: parseNewlineValues(document.getElementById('easAuthorizedEvents')?.value || ''),
         forwarded_event_codes: (document.getElementById('easForwardedEventCodes')?.value || '')
             .split(',').map(s => s.trim().toUpperCase()).filter(Boolean),

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1088,9 +1088,13 @@
                                                         FFSK packet (mark = 1200&nbsp;Hz, space = 1800&nbsp;Hz) carrying this
                                                         station's <em>Unit ID</em> and an op-code. Receiving Motorola
                                                         radios display the unit ID and execute the op-code (PTT-ID,
-                                                        Emergency, etc.). Packet duration is fixed at ~147&nbsp;ms; the
-                                                        chime duration field is ignored. Verify on the bench with
-                                                        <code>multimon-ng -a MDC -t wav file.wav</code> before going on the air.
+                                                        Emergency, etc.). Single-packet ops (PTT-ID, Emergency,
+                                                        Request to Talk, Remote Monitor) are <strong>~173&nbsp;ms</strong>;
+                                                        double-packet ops (Call Alert, Selective Call) carry a
+                                                        target unit ID in a second info block and are
+                                                        <strong>~267&nbsp;ms</strong>. Chime-duration field is ignored.
+                                                        Verify on the bench with <code>multimon-ng -a MDC -t wav file.wav</code>
+                                                        before going on the air.
                                                     </div>
                                                 </div>
                                                 <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="mdc1200">
@@ -1106,9 +1110,11 @@
                                                         <option value="emergency">Emergency (op 0x40 / arg 0x80)</option>
                                                         <option value="request_to_talk">Request to Talk (op 0x35 / arg 0x89)</option>
                                                         <option value="remote_monitor">Remote Monitor (op 0x11 / arg 0x80)</option>
+                                                        <option value="call_alert">Call Alert (op 0x63 / arg 0x85) — pages target unit</option>
+                                                        <option value="selective_call">Selective Call (op 0x35 / arg 0x80) — unmutes target unit</option>
                                                         <option value="custom">Custom (use raw values below)</option>
                                                     </select>
-                                                    <small class="text-muted">Pick a preset, or choose <em>Custom</em> to set raw bytes.</small>
+                                                    <small class="text-muted">Pick a preset, or choose <em>Custom</em> to set raw bytes. For <em>Call Alert</em> and <em>Selective Call</em> the Unit ID above is the <strong>target</strong> radio's ID.</small>
                                                 </div>
                                                 <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="mdc1200-custom">
                                                     <label for="easMdc1200OpCodeRaw" class="form-label fw-bold">Raw Op-Code</label>
@@ -1119,6 +1125,11 @@
                                                     <label for="easMdc1200ArgRaw" class="form-label fw-bold">Raw Argument</label>
                                                     <input type="text" class="form-control" id="easMdc1200ArgRaw" name="mdc1200_arg_raw" maxlength="6" placeholder="0x80" pattern="(0[xX][0-9A-Fa-f]{1,2}|\d{1,3})">
                                                     <small class="text-muted">8-bit argument byte (decimal 0–255 or 0x00–0xFF). Used only when op-code preset is <em>Custom</em>.</small>
+                                                </div>
+                                                <div class="col-md-6 eas-tone-conditional" data-eas-tone-show="mdc1200-double">
+                                                    <label for="easMdc1200TargetUnitId" class="form-label fw-bold">MDC1200 Target Unit ID</label>
+                                                    <input type="text" class="form-control" id="easMdc1200TargetUnitId" name="mdc1200_target_unit_id" maxlength="8" placeholder="e.g. 0x04D2 (leave blank for single packet)" pattern="(0[xX][0-9A-Fa-f]{1,4}|\d{1,5})">
+                                                    <small class="text-muted">16-bit ID of the <strong>destination</strong> radio (1–65535 decimal or 0x0001–0xFFFF). Used by <em>Call Alert</em> and <em>Selective Call</em> double-packet ops; the encoder appends a second 14-byte info block carrying this ID, making the on-air frame ~267&nbsp;ms instead of ~173&nbsp;ms. Leave blank to fall back to a single-packet frame where the source Unit ID also acts as the target.</small>
                                                 </div>
                                             </div>
                                         </div>

--- a/tests/test_mdc1200.py
+++ b/tests/test_mdc1200.py
@@ -155,9 +155,9 @@ def test_xor_modulate_round_trip():
 # ---------------------------------------------------------------------------
 
 def test_encode_packet_length_and_prefix_structure():
-    """Frame must be 22 bytes: 3 preamble + 5 sync + 14 payload."""
+    """Frame must be 26 bytes: 3 preamble + 5 sync + 14 payload + 4 post-preamble."""
     frame = encode_packet(0x01, 0x80, 0x1234)
-    assert len(frame) == 3 + 5 + 14 == 22
+    assert len(frame) == 3 + 5 + 14 + 4 == 26
 
     # The preamble + sync prefix passes through differential modulation as
     # well, but their *decoded* values must still match the canonical
@@ -175,6 +175,26 @@ def test_encode_packet_length_and_prefix_structure():
         decoded.append(out)
     assert decoded[:3] == list(MDC1200_PREAMBLE)
     assert decoded[3:8] == list(MDC1200_SYNC)
+
+
+def test_encode_packet_includes_trailing_post_preamble():
+    """The last 4 bytes of a single packet are the post-preamble: under
+    differential modulation they decode to 0x00 0x00 0x00 0x00, which
+    is what real Motorola subscribers expect as a clean tail-of-frame
+    marker before they commit a decoded ID to their call list."""
+    frame = encode_packet(0x01, 0x80, 0x1234)
+    decoded = []
+    prev_bit = 0
+    for byte in frame:
+        b = byte ^ 0xFF
+        out = 0
+        for bit_num in range(7, -1, -1):
+            transitioned = (b >> bit_num) & 1
+            new_bit = prev_bit ^ transitioned
+            out |= new_bit << bit_num
+            prev_bit = new_bit
+        decoded.append(out)
+    assert decoded[-4:] == [0x00, 0x00, 0x00, 0x00]
 
 
 def test_encode_packet_validates_inputs():
@@ -200,6 +220,106 @@ def test_resolve_op_preset_unknown_falls_back_to_ptt_id_pre():
     assert resolve_op_preset("") == MDC1200_OP_PRESETS["ptt_id_pre"]
 
 
+def test_call_alert_and_selective_call_presets_match_multimon_ng():
+    """Call Alert and Selective Call use op/arg pairs widely attested in
+    multimon-ng's MDC decoder source and Motorola CPS programming sheets.
+    Pin them so a future refactor cannot silently change the on-air bytes."""
+    assert resolve_op_preset("call_alert") == (0x63, 0x85)
+    assert resolve_op_preset("selective_call") == (0x35, 0x80)
+
+
+def test_call_alert_and_selective_call_encode_to_valid_frames():
+    """Both new presets must produce a valid 26-byte single-packet frame
+    when called via :func:`encode_packet` (target ID carried in the
+    unit_id field — receivers tolerate this fallback when no separate
+    target is configured)."""
+    for preset in ("call_alert", "selective_call"):
+        op, arg = resolve_op_preset(preset)
+        frame = encode_packet(op, arg, 0x1234)
+        assert len(frame) == 26, preset
+
+
+def test_double_packet_frame_length_and_structure():
+    """``encode_double_packet`` must emit a 40-byte frame: 3 preamble +
+    5 sync + 14 payload-1 + 4 inter-packet preamble + 14 payload-2.
+    At 1200 baud that is exactly 266.67 ms of audio."""
+    from app_utils.mdc1200 import encode_double_packet
+    frame = encode_double_packet(0x63, 0x85, 0x1111, 0x2222)
+    assert len(frame) == 3 + 5 + 14 + 4 + 14 == 40
+
+    # Decode the prefix to verify preamble + sync round-trip
+    decoded = []
+    prev_bit = 0
+    for byte in frame:
+        b = byte ^ 0xFF
+        out = 0
+        for bit_num in range(7, -1, -1):
+            transitioned = (b >> bit_num) & 1
+            new_bit = prev_bit ^ transitioned
+            out |= new_bit << bit_num
+            prev_bit = new_bit
+        decoded.append(out)
+    assert decoded[:3] == list(MDC1200_PREAMBLE)
+    assert decoded[3:8] == list(MDC1200_SYNC)
+    # 4-byte inter-packet preamble after payload 1 (offsets 22..25)
+    assert decoded[22:26] == [0x00, 0x00, 0x00, 0x00]
+
+
+def test_double_packet_validates_inputs():
+    from app_utils.mdc1200 import encode_double_packet
+    with pytest.raises(ValueError):
+        encode_double_packet(-1, 0, 0, 0)
+    with pytest.raises(ValueError):
+        encode_double_packet(0, 0x100, 0, 0)
+    with pytest.raises(ValueError):
+        encode_double_packet(0, 0, 0x10000, 0)
+    with pytest.raises(ValueError):
+        encode_double_packet(0, 0, 0, 0x10000)
+    with pytest.raises(ValueError):
+        encode_double_packet(0, 0, 0, 0, status=-1)
+
+
+def test_is_double_packet_op_recognises_call_alert_and_selective_call():
+    from app_utils.mdc1200 import is_double_packet_op
+    assert is_double_packet_op(0x63, 0x85) is True   # Call Alert
+    assert is_double_packet_op(0x35, 0x80) is True   # Selective Call
+    # PTT-ID, Emergency, etc. stay single-packet
+    assert is_double_packet_op(0x01, 0x80) is False
+    assert is_double_packet_op(0x00, 0x80) is False
+    assert is_double_packet_op(0x40, 0x80) is False
+
+
+def test_generate_mdc1200_samples_dispatches_to_double_packet_when_target_set():
+    """Audio waveform length must match double-packet timing when the
+    operator picks Call Alert / Selective Call AND configures a
+    target unit ID; otherwise it falls back to single-packet timing."""
+    sr = 16000
+    amp = 0.7 * 32767
+
+    # Call Alert with target -> double packet (40 bytes)
+    samples_double = generate_mdc1200_samples(
+        0x63, 0x85, unit_id=0x1111, sample_rate=sr, amplitude=amp,
+        target_unit_id=0x2222,
+    )
+    expected_double = 40 * 8 * sr / MDC1200_BAUD
+    assert abs(len(samples_double) - expected_double) <= 2
+
+    # Call Alert without target -> falls back to single packet (26 bytes)
+    samples_single_fallback = generate_mdc1200_samples(
+        0x63, 0x85, unit_id=0x1111, sample_rate=sr, amplitude=amp,
+        target_unit_id=None,
+    )
+    expected_single = 26 * 8 * sr / MDC1200_BAUD
+    assert abs(len(samples_single_fallback) - expected_single) <= 2
+
+    # PTT-ID Pre with target set -> still single packet (op is not double-packet-eligible)
+    samples_pttid = generate_mdc1200_samples(
+        0x01, 0x80, unit_id=0x1111, sample_rate=sr, amplitude=amp,
+        target_unit_id=0x2222,
+    )
+    assert abs(len(samples_pttid) - expected_single) <= 2
+
+
 # ---------------------------------------------------------------------------
 # Smart pre/post PTT-ID pairing
 # ---------------------------------------------------------------------------
@@ -215,9 +335,19 @@ def test_smart_pairing_substitutes_post_for_ptt_id_pre():
 
 def test_smart_pairing_passes_other_presets_through():
     """Non-PTT presets must NOT be rewritten — operators sandwich a broadcast
-    in two emergency-alarm packets on purpose."""
+    in two emergency-alarm packets on purpose, and Call Alert / Selective
+    Call have no natural pre/post pair so the operator's exact choice must
+    survive on both sides."""
     from app_utils.eas import _resolve_mdc1200_op_for_position
-    for preset in ("emergency", "request_to_talk", "remote_monitor", "ptt_id_post", "custom"):
+    for preset in (
+        "emergency",
+        "request_to_talk",
+        "remote_monitor",
+        "ptt_id_post",
+        "call_alert",
+        "selective_call",
+        "custom",
+    ):
         assert _resolve_mdc1200_op_for_position(preset, "pre") == preset
         assert _resolve_mdc1200_op_for_position(preset, "post") == preset
 
@@ -237,7 +367,7 @@ def test_encode_packet_accepts_full_hex_byte_range():
     """Op-code, arg, and unit ID must each accept the full 8-/16-bit
     hex range — including A–F digits — without raising."""
     frame = encode_packet(0xAB, 0xCD, 0xDEAD, status=0xEF)
-    assert len(frame) == 22
+    assert len(frame) == 26
 
 
 def test_encode_packet_unit_id_round_trips_hex_value():
@@ -288,10 +418,10 @@ def test_bytes_to_bits_msb():
 # ---------------------------------------------------------------------------
 
 def test_generate_mdc1200_samples_length_at_16khz():
-    """22 bytes * 8 bits / 1200 baud * 16000 Hz ≈ 2346.67 samples; the
+    """26 bytes * 8 bits / 1200 baud * 16000 Hz ≈ 2773.33 samples; the
     fractional-bit timing means we expect within ±2 samples of that."""
     samples = generate_mdc1200_samples(0x01, 0x80, 0x1234, 16000, 0.7 * 32767)
-    expected = 22 * 8 * 16000 / MDC1200_BAUD
+    expected = 26 * 8 * 16000 / MDC1200_BAUD
     assert abs(len(samples) - expected) <= 2
     assert all(-32768 <= s <= 32767 for s in samples)
 

--- a/webapp/admin/maintenance.py
+++ b/webapp/admin/maintenance.py
@@ -1459,6 +1459,7 @@ def _ensure_eas_settings_record() -> EASSettings:
         "ALTER TABLE eas_settings ADD COLUMN IF NOT EXISTS mdc1200_op_code VARCHAR(32) NOT NULL DEFAULT 'ptt_id_pre'",
         "ALTER TABLE eas_settings ADD COLUMN IF NOT EXISTS mdc1200_op_code_raw SMALLINT",
         "ALTER TABLE eas_settings ADD COLUMN IF NOT EXISTS mdc1200_arg_raw SMALLINT",
+        "ALTER TABLE eas_settings ADD COLUMN IF NOT EXISTS mdc1200_target_unit_id INTEGER",
     ]
 
     def _query():
@@ -1612,11 +1613,34 @@ def admin_eas_settings():
         if "mdc1200_op_code" in payload:
             _allowed_ops = {
                 "ptt_id_pre", "ptt_id_post", "emergency",
-                "request_to_talk", "remote_monitor", "custom",
+                "request_to_talk", "remote_monitor",
+                "call_alert", "selective_call",
+                "custom",
             }
             _op = str(payload["mdc1200_op_code"] or "ptt_id_pre").strip().lower()
             if _op in _allowed_ops:
                 settings.mdc1200_op_code = _op
+        if "mdc1200_target_unit_id" in payload:
+            # Target ID for double-packet ops (Call Alert / Selective Call).
+            # Empty string / None / 0 => clear the field, falling back to
+            # single-packet emission with mdc1200_unit_id as the only ID
+            # on the wire.
+            _raw_tid = payload["mdc1200_target_unit_id"]
+            if _raw_tid in (None, ""):
+                settings.mdc1200_target_unit_id = None
+            else:
+                try:
+                    if isinstance(_raw_tid, str):
+                        _tid = int(_raw_tid.strip(), 0)
+                    else:
+                        _tid = int(_raw_tid)
+                except (TypeError, ValueError):
+                    _tid = None
+                if _tid is not None:
+                    if _tid == 0:
+                        settings.mdc1200_target_unit_id = None
+                    elif 1 <= _tid <= 0xFFFF:
+                        settings.mdc1200_target_unit_id = _tid
         for _byte_field in ("mdc1200_op_code_raw", "mdc1200_arg_raw"):
             if _byte_field in payload:
                 _val = payload[_byte_field]


### PR DESCRIPTION
Extend the MDC1200 encoder with the canonical Motorola double-packet
frame (40 bytes / ~266.67 ms) used by Call Alert (op 0x63 / arg 0x85)
and Selective Call (op 0x35 / arg 0x80) — a second 14-byte interleaved
info block carrying the target subscriber's ID is appended after a
4-byte inter-packet re-sync preamble. Single packets now also include
the spec-mandated 4-byte trailing post-preamble, making them 26 bytes /
~173.33 ms (was 22 / ~147 ms) so receivers see a clean idle transition
after the CRC passes.

New mdc1200_target_unit_id setting (DB column, Alembic migration,
self-heal in maintenance.py, env override EAS_MDC1200_TARGET_UNIT_ID,
admin UI input gated on the call_alert / selective_call presets, JS
load+submit) selects the destination radio. Empty/0/NULL forces
single-packet emission with the source unit_id repurposed as target,
which some receivers tolerate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MDC1200 target unit ID configuration for double-packet operations.
  * Introduced new MDC1200 operation codes: Call Alert and Selective Call.
  * Implemented automatic audio amplitude normalization for alert chimes.

* **Documentation**
  * Updated MDC1200 configuration guide and protocol reference with new features and operations.

* **Tests**
  * Added tests for new MDC1200 frame structure and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->