### PR TITLE
Fix: respect forwarded_event_codes allowlist for CAP-sourced alerts

### DIFF
--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -239,19 +239,37 @@ def auto_forward_cap_alert(
     fips_codes = _get_fips_from_cap_alert(cap_alert, raw_json)
     event_code = _resolve_event_code(cap_alert)
 
-    # Event code filtering: if forwarded_event_codes is configured, only forward
-    # events in that allowlist. An empty list means forward all event types.
+    # Event code filtering: forward only events the operator has selected.
+    # An empty allowlist means "forward all event types" — except RWT, which is
+    # always suppressed unless the operator explicitly opts in by adding 'RWT'
+    # to forwarded_event_codes.  This keeps the CAP path consistent with the
+    # OTA path (auto_forward_ota_alert) so test activations are not silently
+    # rebroadcast just because the allowlist is empty.
     forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
-    if forwarded_event_codes and event_code:
-        allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
-        if event_code.upper() not in allowed:
-            reason = (
-                f"Event '{event_code}' is not in the configured forwarding allowlist"
-            )
-            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
-            result['reason'] = reason
-            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-            return result
+    allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
+    event_code_upper = event_code.upper() if event_code else ''
+
+    if event_code_upper == 'RWT' and 'RWT' not in allowed:
+        reason = (
+            "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
+        )
+        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+        result['reason'] = reason
+        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+        return result
+
+    if allowed and event_code_upper not in allowed:
+        # An unresolved event code (event_code_upper == '') with a configured
+        # allowlist must also be rejected: we cannot prove the alert is on the
+        # allowlist, so refuse to forward rather than silently bypassing the
+        # operator's filter.
+        reason = (
+            f"Event '{event_code or 'UNKNOWN'}' is not in the configured forwarding allowlist"
+        )
+        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+        result['reason'] = reason
+        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+        return result
 
     # VTEC-aware action gating — only applies when VTEC was parsed at ingest
     vtec_action: Optional[str] = getattr(cap_alert, 'vtec_action', None)

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -2705,6 +2705,22 @@ class CAPPoller:
             # Auto-forward to air chain: generate SAME header with station
             # originator, build audio, activate GPIO, and play broadcast.
             # This is fully automatic with zero operator intervention.
+            #
+            # Reload the EAS config from the database before each forwarding
+            # decision so admin UI changes (broadcast_enabled, originator,
+            # forwarded_event_codes, etc.) take effect without a service
+            # restart.  Without this refresh, alerts the operator has just
+            # de-selected from the auto-forward allowlist would continue to
+            # be rebroadcast until the cap-poller process is restarted.
+            try:
+                self.eas_config = load_eas_config(db_session=self.db_session)
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to refresh EAS config before forwarding %s; "
+                    "using cached config: %s",
+                    new_alert.identifier, exc,
+                )
+
             try:
                 forward_result = auto_forward_cap_alert(
                     cap_alert=new_alert,


### PR DESCRIPTION
Two issues caused unselected alerts (e.g. RWT) to keep being relayed even
after the operator de-selected them in the Auto-Forward Event Filter:

1. auto_forward_cap_alert was asymmetric with auto_forward_ota_alert.  The
   OTA path always suppresses RWT unless the operator explicitly adds it to
   forwarded_event_codes; the CAP path only filtered when the allowlist was
   non-empty AND _resolve_event_code() returned a value, so CAP RWTs and
   any alert whose event name did not resolve to a registry code bypassed
   the filter entirely.  CAP now applies the same RWT block and rejects
   unresolved event codes when an allowlist is configured.

2. The CAP poller cached eas_config once at __init__ and never refreshed
   it.  Allowlist edits made via /admin/eas_settings persisted to the
   database but were not picked up by the running poller, so de-selected
   events kept forwarding until the service was restarted.  The poller
   now reloads load_eas_config() before each forwarding decision, matching
   the OTA paths in eas_processing.py and alert_forwarding.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CAP alert auto-forwarding with improved filtering logic and explicit event handling rules
  * Implemented dynamic configuration reloading before alert forwarding to ensure latest settings are applied

<!-- end of auto-generated comment: release notes by coderabbit.ai -->