### PR TITLE
Add MDC1200 selective-calling packet detection to EAS alerts

### DIFF
--- a/app_core/audio/eas_monitor.py
+++ b/app_core/audio/eas_monitor.py
@@ -114,6 +114,8 @@ def _same_alert_to_dict(alert: Any) -> Dict[str, Any]:
         'purge_time': purge_time,
         'confidence': getattr(alert, 'confidence', 0.0),
         'timestamp': ts.isoformat() if hasattr(ts, 'isoformat') else str(ts),
+        'endec_mode': getattr(alert, 'endec_mode', 'UNKNOWN') or 'UNKNOWN',
+        'burst_timing_gaps_ms': list(getattr(alert, 'burst_timing_gaps_ms', [])),
     }
 
 
@@ -222,8 +224,22 @@ def _store_received_alert(
             if callsign:
                 duplicate_filters.append(ReceivedEASAlert.callsign == callsign)
 
-        duplicate_exists = db.session.query(ReceivedEASAlert.id).filter(*duplicate_filters).first()
-        if duplicate_exists:
+        duplicate_record = db.session.query(ReceivedEASAlert).filter(*duplicate_filters).first()
+        if duplicate_record:
+            # When burst 1 was stored before terminators arrived, its endec_mode is
+            # UNKNOWN.  Bursts 2 and 3 carry the correct fingerprint once the DLL has
+            # consumed burst 1's terminator bytes.  Promote the stored record here.
+            incoming_endec = full_alert_json.get('endec_mode') or 'UNKNOWN'
+            stored_endec = (duplicate_record.full_alert_data or {}).get('endec_mode') or 'UNKNOWN'
+            if incoming_endec != 'UNKNOWN' and stored_endec == 'UNKNOWN':
+                updated = dict(duplicate_record.full_alert_data or {})
+                updated['endec_mode'] = incoming_endec
+                updated['burst_timing_gaps_ms'] = full_alert_json.get('burst_timing_gaps_ms', [])
+                duplicate_record.full_alert_data = updated
+                try:
+                    db.session.commit()
+                except Exception:
+                    db.session.rollback()
             logger.info(
                 "Duplicate received alert suppressed within 10-minute window: %s",
                 raw_same_header or event_code,

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -2353,7 +2353,7 @@ class EASAudioGenerator:
         
         self.tts_engine = TTSEngine(config, logger, self.sample_rate)
         # Opt-out flag: set config key 'endec_fingerprint' to False to suppress
-        # the 3 × 0xAA trill appended after each SAME burst.  Defaults to True.
+        # the 3 × 0xBB terminator bytes appended after each SAME burst.  Defaults to True.
         self._fingerprint_enabled = bool(config.get('endec_fingerprint', True))
 
     def _terminator_samples(self, amplitude: float) -> List[int]:

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -483,16 +483,25 @@ def _goertzel(samples: Iterable[float], sample_rate: int, target_freq: float) ->
 
 def _correlate_and_decode_with_dll(
     samples: List[float], sample_rate: int
-) -> Tuple[List[str], float, List[Tuple[int, int]]]:
+) -> Tuple[List[str], float, List[Tuple[int, int]], List[Tuple[int, int]], bool]:
     """Decode SAME messages using SAMEDemodulatorCore (shared FSK/DLL engine).
 
-    Returns (decoded_messages, average_confidence, burst_sample_ranges).
+    Returns (decoded_messages, average_confidence, burst_sample_ranges,
+             terminator_runs, leading_null_detected).
     Bandpass filtering is handled by the caller before this function is called,
     so the core is instantiated with apply_bandpass=False.
     """
     core = SAMEDemodulatorCore(sample_rate, apply_bandpass=False)
     core.process_samples(np.asarray(samples, dtype=np.float32))
-    return core.messages, core.average_confidence, core.burst_sample_ranges
+    # Flush any open terminator run so the last burst's bytes are included.
+    core._flush_terminator_run()
+    return (
+        core.messages,
+        core.average_confidence,
+        core.burst_sample_ranges,
+        list(core._all_terminator_runs),
+        core._leading_null_detected,
+    )
 
 
 def _extract_bits(
@@ -1485,14 +1494,16 @@ def _decode_from_samples(
     correlation_raw_text: Optional[str] = None
     correlation_confidence: Optional[float] = None
     dll_burst_sample_ranges: List[Tuple[int, int]] = []
+    dll_terminator_runs: List[Tuple[int, int]] = []
+    dll_leading_null: bool = False
 
     # Enable correlation decoder to handle external files with timing variations
     USE_CORRELATION_DECODER = True
 
     if USE_CORRELATION_DECODER:
         try:
-            messages, confidence, dll_burst_sample_ranges = _correlate_and_decode_with_dll(
-                samples, sample_rate
+            messages, confidence, dll_burst_sample_ranges, dll_terminator_runs, dll_leading_null = (
+                _correlate_and_decode_with_dll(samples, sample_rate)
             )
 
             if messages:
@@ -1538,7 +1549,10 @@ def _decode_from_samples(
     # Compute inter-burst gap timing and fingerprint the ENDEC hardware type
     burst_timing_gaps_ms = _compute_burst_timing_gaps_ms(dll_burst_sample_ranges, sample_rate)
     endec_mode = _detect_endec_mode(
-        [h.header for h in (correlation_headers or [])], burst_timing_gaps_ms
+        [h.header for h in (correlation_headers or [])],
+        burst_timing_gaps_ms,
+        dll_terminator_runs or None,
+        dll_leading_null,
     )
 
     # Minimum DLL confidence above which the off-rate baud variants are not

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -31,7 +31,7 @@ from datetime import datetime, timedelta, timezone
 from array import array
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -326,6 +326,8 @@ class SAMEAudioDecodeResult:
     # True when 2-of-3 majority voting was applied across multiple bursts.
     # False when only a single burst was decoded (no voting possible).
     voting_applied: bool = False
+    # MDC1200 selective-calling packets decoded from the pre/post-alert audio.
+    mdc1200_packets: List[Any] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, object]:
         return {

--- a/app_utils/eas_demod.py
+++ b/app_utils/eas_demod.py
@@ -184,7 +184,7 @@ ENDEC_MODE_NWS_BMH = "NWS_BMH"         # NWS Broadcast Message Handler 2016+
 ENDEC_MODE_SAGE_3644 = "SAGE_DIGITAL_3644"
 ENDEC_MODE_SAGE_1822 = "SAGE_ANALOG_1822"
 ENDEC_MODE_TRILITHIC = "TRILITHIC"      # Trilithic EASyPLUS (~868 ms inter-burst gap)
-ENDEC_MODE_EAS_STATION = "EAS_STATION"  # KR8MER EAS Station (3 × 0xAA trill fingerprint)
+ENDEC_MODE_EAS_STATION = "EAS_STATION"  # KR8MER EAS Station (3 × 0xBB terminator fingerprint)
 
 # Inter-burst gap windows (ms) for mode fingerprinting
 _ENDEC_GAP_TRILITHIC = (820, 920)   # 868 ms nominal

--- a/app_utils/eas_detection.py
+++ b/app_utils/eas_detection.py
@@ -75,6 +75,9 @@ class EASDetectionResult:
     sample_rate: int = 0
     duration_seconds: float = 0.0
 
+    # MDC1200 selective-calling packets found in the audio (pre/post-alert chime)
+    mdc1200_packets: List[Any] = field(default_factory=list)
+
     # Raw detection details
     raw_same_result: Optional[SAMEAudioDecodeResult] = None
 
@@ -230,6 +233,41 @@ def detect_eas_from_file(
             result.eom_position = eom_segment.start_sample
 
         logger.info(f"SAME detection: {len(same_result.headers)} headers, confidence: {same_result.bit_confidence:.2%}")
+
+        # Step 1b: MDC1200 detection — scan the full audio for pre/post-alert
+        # MDC1200 selective-calling packets.  Uses the buffer or composite segment
+        # already in memory from the SAME decode to avoid re-reading the file.
+        try:
+            from app_utils.mdc1200 import decode_mdc1200_from_samples as _decode_mdc
+            mdc_audio: Optional[np.ndarray] = None
+            mdc_rate: int = same_result.sample_rate or 16000
+            for seg_key in ("buffer", "composite"):
+                seg = same_result.segments.get(seg_key)
+                if not (seg and getattr(seg, "wav_bytes", None)):
+                    continue
+                try:
+                    with wave.open(io.BytesIO(seg.wav_bytes), "rb") as wf:
+                        _sr = wf.getframerate()
+                        _sw = wf.getsampwidth()
+                        frames = wf.readframes(wf.getnframes())
+                    dtype = np.int16 if _sw == 2 else (np.int32 if _sw == 4 else None)
+                    if dtype is None:
+                        continue
+                    mdc_audio = np.frombuffer(frames, dtype=dtype).astype(np.float32) / float(2 ** (_sw * 8 - 1))
+                    mdc_rate = _sr
+                    break
+                except Exception:
+                    continue
+            if mdc_audio is not None:
+                pkt = _decode_mdc(mdc_audio, mdc_rate)
+                if pkt is not None:
+                    result.mdc1200_packets.append(pkt)
+                    logger.info(
+                        "MDC1200 packet decoded: unit_id=0x%04X op=0x%02X arg=0x%02X crc_ok=%s",
+                        pkt.unit_id, pkt.opcode, pkt.arg, pkt.crc_ok,
+                    )
+        except Exception as e:
+            logger.debug("MDC1200 detection skipped: %s", e)
 
     except Exception as e:
         logger.error(f"Error decoding SAME headers: {e}")

--- a/app_utils/mdc1200.py
+++ b/app_utils/mdc1200.py
@@ -938,6 +938,122 @@ def decode_double_packet(frame: Sequence[int]) -> MDC1200Packet:
     )
 
 
+def decode_mdc1200_from_samples(
+    samples,
+    sample_rate: int,
+) -> Optional["MDC1200Packet"]:
+    """Demodulate MDC1200 FFSK from PCM audio and return the decoded packet.
+
+    Runs a Goertzel FSK demodulator at 1200 baud (mark = 1200 Hz,
+    space = 1800 Hz) over the provided samples, searches for the MDC1200
+    preamble + sync word, and returns the decoded packet when found.
+
+    Both single-packet (26-byte) and double-packet (40-byte) frames are
+    tried; double-packet is attempted first when enough bits are available.
+
+    Args:
+        samples: Audio samples as a list of floats or a numpy array.
+            May be int16-range or normalised − 1.0..1.0.
+        sample_rate: Sample rate in Hz.
+
+    Returns:
+        Decoded :class:`MDC1200Packet` on success, ``None`` if no valid
+        MDC1200 frame is found in the audio.
+    """
+    try:
+        sample_list = [float(s) for s in samples]
+    except (TypeError, ValueError):
+        return None
+
+    if len(sample_list) < int(sample_rate / MDC1200_BAUD) * 4:
+        return None
+
+    # FSK demodulate: for each bit period, compare Goertzel power at the
+    # mark (1200 Hz) and space (1800 Hz) carriers.  A stronger mark power
+    # means the transmitted bit was 1; stronger space power means 0.
+    samples_per_bit = sample_rate / MDC1200_BAUD
+    coeff_mark = 2.0 * math.cos(2.0 * math.pi * MDC1200_MARK_FREQ / sample_rate)
+    coeff_space = 2.0 * math.cos(2.0 * math.pi * MDC1200_SPACE_FREQ / sample_rate)
+
+    raw_bits: List[int] = []
+    carry = 0.0
+    index = 0
+    while index < len(sample_list):
+        total = samples_per_bit + carry
+        chunk_len = int(total)
+        carry = total - chunk_len
+        end = index + chunk_len
+        if end > len(sample_list):
+            break
+        chunk = sample_list[index:end]
+
+        s1_m, s2_m = 0.0, 0.0
+        for x in chunk:
+            s = x + coeff_mark * s1_m - s2_m
+            s2_m, s1_m = s1_m, s
+        p_mark = s2_m ** 2 + s1_m ** 2 - coeff_mark * s1_m * s2_m
+        if p_mark < 0.0:
+            p_mark = 0.0
+
+        s1_s, s2_s = 0.0, 0.0
+        for x in chunk:
+            s = x + coeff_space * s1_s - s2_s
+            s2_s, s1_s = s1_s, s
+        p_space = s2_s ** 2 + s1_s ** 2 - coeff_space * s1_s * s2_s
+        if p_space < 0.0:
+            p_space = 0.0
+
+        raw_bits.append(1 if p_mark >= p_space else 0)
+        index = end
+
+    # Single packet = 26 bytes = 208 bits; double packet = 40 bytes = 320 bits.
+    _SINGLE_BITS = (len(MDC1200_PREAMBLE) + len(MDC1200_SYNC) + _FEC_K * 2 + len(MDC1200_POST_PREAMBLE)) * 8
+    _DOUBLE_BITS = (len(MDC1200_PREAMBLE) + len(MDC1200_SYNC) + _FEC_K * 2 + len(MDC1200_INTER_PACKET_PREAMBLE) + _FEC_K * 2) * 8
+
+    if len(raw_bits) < _SINGLE_BITS:
+        return None
+
+    sync_result = find_sync_in_bits(raw_bits)
+    if sync_result is None:
+        return None
+    bit_offset, polarity = sync_result
+
+    frame_bits = raw_bits[bit_offset:]
+    if polarity:
+        frame_bits = [b ^ 1 for b in frame_bits]
+
+    def _bits_to_bytes(blist: List[int], n: int) -> Optional[List[int]]:
+        if len(blist) < n * 8:
+            return None
+        result = []
+        for i in range(0, n * 8, 8):
+            byte_val = 0
+            for j in range(8):
+                byte_val = (byte_val << 1) | (blist[i + j] & 1)
+            result.append(byte_val)
+        return result
+
+    _SINGLE_BYTES = _SINGLE_BITS // 8
+    _DOUBLE_BYTES = _DOUBLE_BITS // 8
+
+    if len(frame_bits) >= _DOUBLE_BITS:
+        double_frame = _bits_to_bytes(frame_bits, _DOUBLE_BYTES)
+        if double_frame is not None:
+            try:
+                return decode_double_packet(double_frame)
+            except MDC1200DecodeError:
+                pass
+
+    single_frame = _bits_to_bytes(frame_bits, _SINGLE_BYTES)
+    if single_frame is not None:
+        try:
+            return decode_packet(single_frame)
+        except MDC1200DecodeError:
+            pass
+
+    return None
+
+
 def find_sync_in_bits(bits: Sequence[int]) -> Optional[Tuple[int, int]]:
     """Search a recovered FFSK bit stream for the MDC1200 preamble + sync.
 
@@ -1009,4 +1125,5 @@ __all__ = [
     "decode_packet",
     "decode_double_packet",
     "find_sync_in_bits",
+    "decode_mdc1200_from_samples",
 ]

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -12,6 +12,7 @@
         'SAGE_DIGITAL_3644': ('primary',   'SAGE Digital 3644'),
         'SAGE_ANALOG_1822':  ('primary',   'SAGE Analog 1822'),
         'TRILITHIC':         ('secondary', 'Trilithic EASyPLUS'),
+        'EAS_STATION':       ('success',   'KR8MER EAS Station'),
     } %}
     {% set info = endec_labels.get(mode, ('secondary', mode)) %}
     <span class="badge bg-{{ info[0] }}">{{ info[1] }}</span>

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -122,6 +122,27 @@
                         <dd class="col-sm-8">{{ '%.2f'|format(decode_result.duration_seconds) }} seconds @ {{ decode_result.sample_rate }} Hz</dd>
                         <dt class="col-sm-4">ENDEC hardware</dt>
                         <dd class="col-sm-8">{{ endec_badge(decode_result.endec_mode) }}</dd>
+                        {% if decode_result.mdc1200_packets %}
+                        <dt class="col-sm-4">MDC1200</dt>
+                        <dd class="col-sm-8">
+                            {% for pkt in decode_result.mdc1200_packets %}
+                            {% set op_names = {
+                                0x01: 'PTT-ID Pre',  0x00: 'PTT-ID Post',
+                                0x40: 'Emergency',   0x35: 'Request to Talk / Selective Call',
+                                0x11: 'Remote Monitor', 0x63: 'Call Alert'
+                            } %}
+                            <span class="badge bg-success me-1">
+                                Unit {{ '0x%04X'|format(pkt.unit_id) }}
+                                &nbsp;·&nbsp;
+                                {{ op_names.get(pkt.opcode, '0x%02X'|format(pkt.opcode)) }}
+                                {% if pkt.target_unit_id is not none %}
+                                    → {{ '0x%04X'|format(pkt.target_unit_id) }}
+                                {% endif %}
+                                {% if not pkt.crc_ok %}<span class="text-warning"> ⚠ CRC</span>{% endif %}
+                            </span>
+                            {% endfor %}
+                        </dd>
+                        {% endif %}
                     </dl>
 
                     {% if decode_result.raw_text %}
@@ -144,7 +165,9 @@
                                             'eom': 'End-of-Message (EOM)',
                                             'buffer': 'Buffer/Lead Audio',
                                             'composite': 'Complete Alert (Composite)',
-                                            'message': 'Message (Legacy)'
+                                            'message': 'Message (Legacy)',
+                                            'pre_chime': 'Pre-Alert Signal (MDC1200/chime)',
+                                            'post_chime': 'Post-Alert Signal (MDC1200/chime)'
                                         } %}
                                         <strong>{{ segment_labels.get(name, name|capitalize) }}</strong>
                                         · {{ '%.2f'|format(segment.duration_seconds) }}s

--- a/webapp/routes/alert_verification.py
+++ b/webapp/routes/alert_verification.py
@@ -788,6 +788,12 @@ def _detect_comprehensive_eas_segments(
         
         same_result.segments.update(ordered_segments)
 
+        # Lift MDC1200 packets from the detection result into the SAME result
+        # so the template and serialisation path see them without needing
+        # to thread a separate detection_result through every caller.
+        if getattr(detection_result, 'mdc1200_packets', None):
+            same_result.mdc1200_packets = list(detection_result.mdc1200_packets)
+
         return same_result, detection_result
 
     except Exception as e:


### PR DESCRIPTION
## Summary
This PR adds support for detecting and decoding MDC1200 selective-calling packets from audio preceding or following EAS alerts. MDC1200 is a 1200-baud FFSK protocol commonly used for unit identification and call signaling in emergency communications systems.

## Key Changes

- **New MDC1200 demodulator function** (`decode_mdc1200_from_samples`): Implements a Goertzel FSK demodulator that processes raw PCM audio samples at 1200 baud (mark=1200 Hz, space=1800 Hz), searches for the MDC1200 preamble and sync word, and decodes both single-packet (26-byte) and double-packet (40-byte) frames.

- **EAS detection integration**: Modified `detect_eas_from_file()` to scan the full audio buffer for MDC1200 packets after SAME header detection. Reuses the audio already loaded during SAME decoding to avoid redundant file I/O.

- **Result tracking**: Added `mdc1200_packets` field to both `EASDetectionResult` and `SAMEAudioDecodeResult` dataclasses to carry decoded packets through the detection pipeline.

- **UI enhancements**: Updated the alert verification template to display decoded MDC1200 packets with unit IDs, operation codes (PTT-ID, Emergency, Call Alert, etc.), target unit IDs, and CRC validation status. Added "EAS_STATION" ENDEC hardware badge for KR8MER EAS Station fingerprinting.

- **ENDEC fingerprinting improvements**: Enhanced `_detect_endec_mode()` to accept terminator run data and leading null detection flags, enabling more accurate hardware identification. Added logic to promote ENDEC mode from "UNKNOWN" to the correct value when burst 2/3 arrive with valid fingerprints after burst 1 was initially stored.

- **DLL decoder updates**: Modified `_correlate_and_decode_with_dll()` to return terminator run information and leading null detection state, enabling better ENDEC mode detection across multiple bursts.

## Implementation Details

- The Goertzel demodulator uses a sliding window approach with fractional sample tracking to handle arbitrary sample rates and maintain bit-level synchronization.
- MDC1200 detection gracefully handles missing or corrupted packets by returning `None` rather than raising exceptions.
- The implementation prioritizes double-packet decoding when sufficient bits are available, falling back to single-packet decoding.
- ENDEC mode detection now leverages terminator byte patterns to distinguish between different EAS hardware implementations (SAGE 3644/1822, Trilithic, KR8MER).

https://claude.ai/code/session_01U6S4ZcfsHux49vSymCjWdr