### PR TITLE
Add QC-II two-tone paging decoder support

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -332,6 +332,8 @@ class SAMEAudioDecodeResult:
     alert_tones: List[Dict[str, Any]] = field(default_factory=list)
     # DTMF tones detected (serialised dicts from DTMFTone).
     dtmf_tones: List[Dict[str, Any]] = field(default_factory=list)
+    # QC-II two-tone paging sequences (serialised dicts from QC2Tone).
+    qc2_tones: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -353,6 +355,7 @@ class SAMEAudioDecodeResult:
             "voting_applied": self.voting_applied,
             "alert_tones": list(self.alert_tones),
             "dtmf_tones": list(self.dtmf_tones),
+            "qc2_tones": list(self.qc2_tones),
             "mdc1200_packets": [
                 {
                     "opcode": getattr(pkt, "opcode", 0),

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -353,6 +353,20 @@ class SAMEAudioDecodeResult:
             "voting_applied": self.voting_applied,
             "alert_tones": list(self.alert_tones),
             "dtmf_tones": list(self.dtmf_tones),
+            "mdc1200_packets": [
+                {
+                    "opcode": getattr(pkt, "opcode", 0),
+                    "arg": getattr(pkt, "arg", 0),
+                    "unit_id": getattr(pkt, "unit_id", 0),
+                    "status": getattr(pkt, "status", 0),
+                    "crc_ok": bool(getattr(pkt, "crc_ok", False)),
+                    "fec_ok": bool(getattr(pkt, "fec_ok", False)),
+                    "target_unit_id": getattr(pkt, "target_unit_id", None),
+                    "crc2_ok": getattr(pkt, "crc2_ok", None),
+                    "fec2_ok": getattr(pkt, "fec2_ok", None),
+                }
+                for pkt in self.mdc1200_packets
+            ],
         }
 
     @property

--- a/app_utils/eas_detection.py
+++ b/app_utils/eas_detection.py
@@ -81,6 +81,9 @@ class EASDetectionResult:
     # DTMF tones detected in the audio
     dtmf_tones: List[Any] = field(default_factory=list)
 
+    # QC-II (Motorola Quick Call II) two-tone paging sequences
+    qc2_tones: List[Any] = field(default_factory=list)
+
     # Raw detection details
     raw_same_result: Optional[SAMEAudioDecodeResult] = None
 
@@ -361,6 +364,20 @@ def detect_eas_from_file(
                     logger.info("DTMF detected: %s (%d tone(s))", digits, len(dtmf_results))
             except Exception as _dtmf_exc:
                 logger.debug("DTMF detection skipped: %s", _dtmf_exc)
+
+            # QC-II (Motorola Quick Call II) two-tone paging — reuse the buffer
+            try:
+                from app_utils.qc2 import detect_qc2 as _detect_qc2
+                qc2_results = _detect_qc2(tone_samples, tone_sample_rate)
+                result.qc2_tones = qc2_results
+                for q in qc2_results:
+                    logger.info(
+                        "QC-II detected: A=%.1f Hz (%.2fs) -> B=%.1f Hz (%.2fs)",
+                        q.tone_a_freq, q.tone_a_duration,
+                        q.tone_b_freq, q.tone_b_duration,
+                    )
+            except Exception as _qc2_exc:
+                logger.debug("QC-II detection skipped: %s", _qc2_exc)
 
             # Step 3: Extract narration if requested
             if detect_narration and tone_results:

--- a/app_utils/qc2.py
+++ b/app_utils/qc2.py
@@ -1,0 +1,249 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+from __future__ import annotations
+
+"""QC-II (Motorola Quick Call II) two-tone paging decoder.
+
+Quick Call II is a fixed-timing two-tone selective-calling protocol:
+    - 1.0 s of Tone A on a frequency from a fixed group
+    - immediately followed by 3-4 s of Tone B on a different frequency
+
+Per-tone frequencies live in ~280-3000 Hz across the standard groups
+(A, B, M, Z, etc.).  This decoder detects the temporal A->B pattern
+without requiring the exact frequency to match a known group, which
+lets it accept legacy and operator-customised tone tables.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+
+
+@dataclass
+class QC2Tone:
+    """A detected QC-II two-tone paging sequence."""
+
+    tone_a_freq: float
+    tone_b_freq: float
+    tone_a_duration: float
+    tone_b_duration: float
+    start_sample: int
+    end_sample: int
+    sample_rate: int
+    confidence: float
+
+    @property
+    def start_seconds(self) -> float:
+        return self.start_sample / self.sample_rate
+
+    @property
+    def duration_seconds(self) -> float:
+        return (self.end_sample - self.start_sample) / self.sample_rate
+
+    def to_dict(self):
+        return {
+            "tone_a_freq": self.tone_a_freq,
+            "tone_b_freq": self.tone_b_freq,
+            "tone_a_duration": self.tone_a_duration,
+            "tone_b_duration": self.tone_b_duration,
+            "start_sample": self.start_sample,
+            "end_sample": self.end_sample,
+            "sample_rate": self.sample_rate,
+            "duration_seconds": self.duration_seconds,
+            "start_seconds": self.start_seconds,
+            "confidence": self.confidence,
+        }
+
+
+# QC-II tones live in ~280-3000 Hz across all standard groupings.
+_QC2_FREQ_MIN = 280.0
+_QC2_FREQ_MAX = 3000.0
+
+# 853 + 960 Hz EBS attention is two simultaneous tones, but a noisy
+# capture can still leave one of them as the FFT peak.  Refuse runs
+# whose peak sits exactly on either EBS frequency to avoid mis-flagging
+# attention signals as QC-II.
+_EBS_FREQS: Tuple[float, ...] = (853.0, 960.0)
+_EBS_FREQ_TOL = 6.0  # Hz
+
+# Tone-A timing window (encoder emits 1.0 s; allow some slack).
+_TONE_A_MIN_SEC = 0.6
+_TONE_A_MAX_SEC = 1.5
+
+# Tone-B timing window (encoder emits 4.0 s; legacy systems use 3.0 s).
+_TONE_B_MIN_SEC = 2.5
+_TONE_B_MAX_SEC = 5.0
+
+# Two QC-II tones must be at least this many Hz apart -- otherwise the
+# A and B segments are really one continuous tone with FFT-bin jitter.
+_AB_FREQ_SEPARATION = 30.0
+
+
+def detect_qc2(
+    samples: np.ndarray,
+    sample_rate: int,
+    window_ms: float = 50.0,
+    hop_ms: float = 25.0,
+    stability_tol_hz: float = 8.0,
+    min_snr_db: float = 12.0,
+) -> List[QC2Tone]:
+    """Detect QC-II two-tone paging sequences in mono audio.
+
+    Args:
+        samples: Mono audio samples, float32 normalised to [-1, 1].
+        sample_rate: Sample rate in Hz.
+        window_ms: Analysis window length.  50 ms gives ~20 Hz FFT
+            resolution after zero-padding to 1024 bins -- fine enough
+            to distinguish adjacent QC-II group frequencies.
+        hop_ms: Hop between consecutive analysis windows.
+        stability_tol_hz: A run of windows is considered the same tone
+            while peak frequencies stay within this many Hz of each
+            other.
+        min_snr_db: Minimum peak-vs-band-mean SNR for a window to be
+            considered "tone present".
+
+    Returns:
+        List of :class:`QC2Tone` matches in chronological order.
+    """
+    if sample_rate <= 0 or len(samples) == 0:
+        return []
+
+    win = max(64, int(sample_rate * window_ms / 1000.0))
+    hop = max(16, int(sample_rate * hop_ms / 1000.0))
+    if win > len(samples):
+        return []
+
+    hann = np.hanning(win).astype(np.float32)
+    fft_size = int(2 ** math.ceil(math.log2(max(win, 1024))))
+    freqs = np.fft.rfftfreq(fft_size, d=1.0 / sample_rate)
+
+    band_idx = np.where((freqs >= _QC2_FREQ_MIN) & (freqs <= _QC2_FREQ_MAX))[0]
+    if band_idx.size == 0:
+        return []
+    bin_hz = sample_rate / fft_size
+    excl_bins = max(1, int(round(30.0 / bin_hz)))
+
+    peak_freqs: List[float] = []
+    peak_starts: List[int] = []
+    peak_snrs: List[float] = []
+
+    pos = 0
+    samples_f = samples.astype(np.float32, copy=False)
+    while pos + win <= len(samples_f):
+        block = samples_f[pos : pos + win] * hann
+        spec = np.abs(np.fft.rfft(block, fft_size))
+        band_spec = spec[band_idx]
+        peak_local = int(np.argmax(band_spec))
+        peak_global = int(band_idx[peak_local])
+        peak_power = float(spec[peak_global] ** 2)
+
+        # Noise floor: mean power across the band excluding +/- excl_bins
+        # around the peak so the peak doesn't pollute its own reference.
+        excl_mask = (band_idx < peak_global - excl_bins) | (band_idx > peak_global + excl_bins)
+        if excl_mask.any():
+            noise = float(np.mean(band_spec[excl_mask] ** 2)) + 1e-12
+        else:
+            noise = float(np.mean(band_spec ** 2)) + 1e-12
+        snr_db = 10.0 * math.log10(max(peak_power, 1e-12) / noise)
+
+        peak_freqs.append(float(freqs[peak_global]))
+        peak_starts.append(pos)
+        peak_snrs.append(snr_db)
+        pos += hop
+
+    if not peak_freqs:
+        return []
+
+    # Group consecutive high-SNR windows of stable frequency into runs.
+    runs: List[Tuple[int, int, float]] = []  # (start_idx, end_idx_exclusive, mean_freq)
+    i = 0
+    n = len(peak_freqs)
+    while i < n:
+        if peak_snrs[i] < min_snr_db:
+            i += 1
+            continue
+        f0 = peak_freqs[i]
+        if any(abs(f0 - ef) < _EBS_FREQ_TOL for ef in _EBS_FREQS):
+            i += 1
+            continue
+        j = i
+        while (
+            j < n
+            and peak_snrs[j] >= min_snr_db
+            and abs(peak_freqs[j] - f0) <= stability_tol_hz
+        ):
+            j += 1
+        if j > i:
+            runs.append((i, j, float(np.mean(peak_freqs[i:j]))))
+        i = max(j, i + 1)
+
+    if len(runs) < 2:
+        return []
+
+    detections: List[QC2Tone] = []
+    used = [False] * len(runs)
+    # Allow up to ~100 ms of dropout / silence between Tone A and Tone B.
+    max_gap_windows = max(1, int(0.10 * sample_rate / hop))
+
+    for a_idx in range(len(runs) - 1):
+        if used[a_idx]:
+            continue
+        a_start, a_end, a_freq = runs[a_idx]
+        a_dur = (peak_starts[a_end - 1] + win - peak_starts[a_start]) / sample_rate
+        if not (_TONE_A_MIN_SEC <= a_dur <= _TONE_A_MAX_SEC):
+            continue
+
+        b_idx = a_idx + 1
+        while b_idx < len(runs) and runs[b_idx][0] - a_end > max_gap_windows:
+            b_idx += 1
+        if b_idx >= len(runs) or used[b_idx]:
+            continue
+        b_start, b_end, b_freq = runs[b_idx]
+        b_dur = (peak_starts[b_end - 1] + win - peak_starts[b_start]) / sample_rate
+        if not (_TONE_B_MIN_SEC <= b_dur <= _TONE_B_MAX_SEC):
+            continue
+        if abs(a_freq - b_freq) < _AB_FREQ_SEPARATION:
+            continue
+
+        start_sample = peak_starts[a_start]
+        end_sample = min(len(samples_f), peak_starts[b_end - 1] + win)
+        snrs = peak_snrs[a_start:a_end] + peak_snrs[b_start:b_end]
+        mean_snr = float(np.mean(snrs)) if snrs else min_snr_db
+        confidence = max(0.0, min(1.0, (mean_snr - min_snr_db) / 18.0 + 0.5))
+
+        detections.append(QC2Tone(
+            tone_a_freq=a_freq,
+            tone_b_freq=b_freq,
+            tone_a_duration=a_dur,
+            tone_b_duration=b_dur,
+            start_sample=start_sample,
+            end_sample=end_sample,
+            sample_rate=sample_rate,
+            confidence=confidence,
+        ))
+        used[a_idx] = True
+        used[b_idx] = True
+
+    return detections
+
+
+__all__ = ["QC2Tone", "detect_qc2"]

--- a/templates/eas/alert_verification.html
+++ b/templates/eas/alert_verification.html
@@ -46,7 +46,7 @@
     <div class="card mb-4">
         <div class="card-header bg-transparent d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
             <h5 class="card-title mb-0"><i class="fas fa-wave-square text-primary"></i> SAME Audio Decoder</h5>
-            <span class="text-muted small">Decodes SAME, MDC1200, DTMF, and alert tones.</span>
+            <span class="text-muted small">Decodes SAME, MDC1200, DTMF, QC-II, and alert tones.</span>
         </div>
         <div class="card-body">
             <form method="post" enctype="multipart/form-data" class="row g-3 align-items-end">
@@ -197,6 +197,22 @@
                                 <span class="badge bg-secondary me-1">{{ tone.digit }} · {{ '%.2f'|format(tone.duration_seconds) }}s @ {{ '%.2f'|format(tone.start_seconds) }}s</span>
                             {% endfor %}
                         </div>
+                    </dd>
+                    {% endif %}
+
+                    {# QC-II two-tone paging #}
+                    {% if decode_result.qc2_tones %}
+                    <dt class="col-sm-4">QC-II</dt>
+                    <dd class="col-sm-8">
+                        {% for q in decode_result.qc2_tones %}
+                            <span class="badge bg-primary me-1">
+                                Tone&nbsp;A {{ '%.1f'|format(q.tone_a_freq) }} Hz ({{ '%.2f'|format(q.tone_a_duration) }}s)
+                                &nbsp;→&nbsp;
+                                Tone&nbsp;B {{ '%.1f'|format(q.tone_b_freq) }} Hz ({{ '%.2f'|format(q.tone_b_duration) }}s)
+                                &nbsp;@&nbsp;{{ '%.2f'|format(q.start_seconds) }}s
+                                · {{ '%.0f'|format(q.confidence * 100) }}%
+                            </span>
+                        {% endfor %}
                     </dd>
                     {% endif %}
                 </dl>

--- a/webapp/routes/alert_verification.py
+++ b/webapp/routes/alert_verification.py
@@ -408,6 +408,7 @@ def _deserialize_decode_result(data: Dict[str, object]) -> SAMEAudioDecodeResult
         endec_mode=str(data.get("endec_mode") or ENDEC_MODE_UNKNOWN),
         alert_tones=list(data.get("alert_tones") or []),
         dtmf_tones=list(data.get("dtmf_tones") or []),
+        qc2_tones=list(data.get("qc2_tones") or []),
         mdc1200_packets=mdc1200_packets,
     )
 
@@ -819,6 +820,10 @@ def _detect_comprehensive_eas_segments(
         # Lift DTMF tones as serialisable dicts.
         if getattr(detection_result, 'dtmf_tones', None):
             same_result.dtmf_tones = [t.to_dict() for t in detection_result.dtmf_tones]
+
+        # Lift QC-II tones as serialisable dicts.
+        if getattr(detection_result, 'qc2_tones', None):
+            same_result.qc2_tones = [t.to_dict() for t in detection_result.qc2_tones]
 
         return same_result, detection_result
 

--- a/webapp/routes/alert_verification.py
+++ b/webapp/routes/alert_verification.py
@@ -390,6 +390,10 @@ def _deserialize_decode_result(data: Dict[str, object]) -> SAMEAudioDecodeResult
             wav_bytes=wav_bytes,
         )
 
+    mdc1200_packets = [
+        SimpleNamespace(**pkt) for pkt in (data.get("mdc1200_packets") or [])
+    ]
+
     return SAMEAudioDecodeResult(
         raw_text=data.get("raw_text", ""),
         headers=headers,
@@ -404,6 +408,7 @@ def _deserialize_decode_result(data: Dict[str, object]) -> SAMEAudioDecodeResult
         endec_mode=str(data.get("endec_mode") or ENDEC_MODE_UNKNOWN),
         alert_tones=list(data.get("alert_tones") or []),
         dtmf_tones=list(data.get("dtmf_tones") or []),
+        mdc1200_packets=mdc1200_packets,
     )
 
 def _extract_audio_segment_wav(audio_path: str, start_sample: int, end_sample: int, sample_rate: int) -> bytes:


### PR DESCRIPTION
## Summary
This PR adds support for detecting and decoding QC-II (Motorola Quick Call II) two-tone selective-calling paging sequences in audio files. QC-II is a fixed-timing protocol consisting of a ~1 second Tone A followed by 3-4 seconds of Tone B on different frequencies.

## Key Changes

- **New QC-II decoder module** (`app_utils/qc2.py`):
  - Implements `detect_qc2()` function that analyzes audio using FFT-based spectral analysis
  - Detects temporal A→B tone patterns without requiring exact frequency matching
  - Supports legacy and operator-customized tone tables (280-3000 Hz range)
  - Returns `QC2Tone` dataclass with frequency, duration, timing, and confidence metrics
  - Includes EBS attention signal filtering (853/960 Hz) to avoid false positives

- **Integration into EAS detection pipeline** (`app_utils/eas_detection.py`):
  - Added QC-II detection to `detect_eas_from_file()` function
  - Reuses existing tone buffer for analysis
  - Logs detected QC-II sequences with frequency and duration details

- **Data model updates** (`app_utils/eas_decode.py`):
  - Added `qc2_tones` field to `SAMEAudioDecodeResult` dataclass
  - Serializes QC-II detections to dictionary format for storage/transmission
  - Improved MDC1200 packet serialization in `to_dict()` method

- **Web UI enhancements** (`templates/eas/alert_verification.html`):
  - Updated decoder description to mention QC-II support
  - Added QC-II results display showing tone frequencies, durations, timing, and confidence percentage

- **Route handler updates** (`webapp/routes/alert_verification.py`):
  - Added deserialization of QC-II tones from stored results
  - Properly handles MDC1200 packet deserialization as `SimpleNamespace` objects
  - Lifts QC-II tone objects to serializable dictionaries in decode results

## Implementation Details

The QC-II detector uses:
- Hann-windowed FFT analysis with configurable window/hop sizes
- SNR-based tone detection with configurable thresholds
- Frequency stability tracking to group consecutive windows into tone runs
- Temporal validation (Tone A: 0.6-1.5s, Tone B: 2.5-5.0s)
- Minimum 30 Hz separation between A and B tones
- Confidence scoring based on mean SNR relative to noise floor
- EBS signal filtering to prevent misidentification of attention signals

https://claude.ai/code/session_018DqG97x1yFi1Dwyf9G5Gap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * QC-II two-tone paging detection now integrated into audio analysis pipeline
  * Decode results display detected QC-II tones with paired frequencies, durations, start time, and confidence metrics
  * Enhanced audio decoding capabilities alongside SAME, DTMF, MDC1200, and alert tone detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->