### PR TITLE
Add per-category and weekly/monthly FCC compliance report exports

### DIFF
--- a/app_core/eas_storage.py
+++ b/app_core/eas_storage.py
@@ -39,6 +39,7 @@ from app_core.models import (
     EASDecodedAudio,
     EASMessage,
     ManualEASActivation,
+    ReceivedEASAlert,
 )
 from app_utils import ALERT_SOURCE_UNKNOWN
 from app_utils.eas_decode import (
@@ -1693,6 +1694,472 @@ def generate_compliance_log_pdf(
     buffer.write(f"startxref\n{startxref}\n%%EOF".encode("latin-1"))
 
     return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# FCC compliance report builders (received / forwarded / ignored / initiated /
+# weekly / monthly).  Each builder returns a uniform ``ReportPayload`` dict
+# that the PDF and CSV exporters consume.
+# ---------------------------------------------------------------------------
+
+
+REPORT_DECISION_FILTERS: Dict[str, Tuple[str, ...]] = {
+    "received": (),  # all decisions
+    "forwarded": ("forwarded",),
+    "ignored": ("ignored",),
+}
+
+
+def _coerce_aware_utc(value: Any) -> Optional[datetime]:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def resolve_report_window(
+    *,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    days: Optional[int] = None,
+) -> Tuple[datetime, datetime]:
+    """Resolve a report window from explicit bounds or a relative day count."""
+    end_dt = _coerce_aware_utc(end) or utc_now()
+    if start is not None:
+        start_dt = _coerce_aware_utc(start) or end_dt - timedelta(days=30)
+    else:
+        window_days = _normalize_window_days(days if days is not None else 30)
+        start_dt = end_dt - timedelta(days=window_days)
+    if start_dt > end_dt:
+        start_dt, end_dt = end_dt, start_dt
+    return start_dt, end_dt
+
+
+def _format_fips(values: Any) -> str:
+    if not values:
+        return ""
+    if isinstance(values, (list, tuple, set)):
+        return ", ".join(str(v) for v in values)
+    return str(values)
+
+
+def _short(text: Any, limit: int = 80) -> str:
+    if text is None:
+        return ""
+    s = str(text)
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "…"
+
+
+_DECISION_TITLES: Dict[str, str] = {
+    "received": "Received Alerts Report",
+    "forwarded": "Forwarded Alerts Report",
+    "ignored": "Ignored Alerts Report",
+}
+
+
+def build_received_alerts_report(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    decision: str = "received",
+) -> Dict[str, Any]:
+    """Build a per-category report covering received_eas_alerts rows.
+
+    ``decision`` selects ``received`` (all), ``forwarded`` or ``ignored``.
+    """
+    decision_key = decision if decision in REPORT_DECISION_FILTERS else "received"
+    filters = REPORT_DECISION_FILTERS[decision_key]
+
+    query = ReceivedEASAlert.query.filter(
+        ReceivedEASAlert.received_at >= window_start,
+        ReceivedEASAlert.received_at < window_end,
+    )
+    if filters:
+        query = query.filter(ReceivedEASAlert.forwarding_decision.in_(filters))
+    alerts = query.order_by(ReceivedEASAlert.received_at.desc()).all()
+
+    rows: List[List[Any]] = []
+    forwarded_count = 0
+    ignored_count = 0
+    error_count = 0
+    for alert in alerts:
+        decision_value = (alert.forwarding_decision or "").lower()
+        if decision_value == "forwarded":
+            forwarded_count += 1
+        elif decision_value == "ignored":
+            ignored_count += 1
+        elif decision_value == "error":
+            error_count += 1
+        rows.append([
+            format_local_datetime(alert.received_at, include_utc=True),
+            alert.event_code or "",
+            _short(alert.event_name, 40),
+            alert.originator_code or "",
+            alert.callsign or alert.source_name or "",
+            _format_fips(alert.matched_fips_codes or alert.fips_codes),
+            (alert.forwarding_decision or "").upper(),
+            _short(alert.forwarding_reason, 60),
+        ])
+
+    columns = [
+        {"label": "Received (local / UTC)", "weight": 2.4},
+        {"label": "Event", "weight": 0.7},
+        {"label": "Description", "weight": 2.0},
+        {"label": "Originator", "weight": 0.8},
+        {"label": "Callsign / Source", "weight": 1.4},
+        {"label": "FIPS", "weight": 1.5},
+        {"label": "Decision", "weight": 1.0},
+        {"label": "Reason", "weight": 2.4},
+    ]
+
+    title = _DECISION_TITLES[decision_key]
+    subtitle = (
+        f"Window: {format_local_datetime(window_start, include_utc=False)}"
+        f" to {format_local_datetime(window_end, include_utc=False)}"
+    )
+
+    summary_lines = [
+        f"Total entries:    {len(alerts)}",
+        f"Forwarded:        {forwarded_count}",
+        f"Ignored:          {ignored_count}",
+        f"Errors:           {error_count}",
+    ]
+
+    slug = f"{decision_key}-alerts"
+    return {
+        "slug": slug,
+        "title": title,
+        "subtitle": subtitle,
+        "columns": columns,
+        "rows": rows,
+        "summary_lines": summary_lines,
+        "window_start": window_start,
+        "window_end": window_end,
+        "row_count": len(alerts),
+    }
+
+
+def build_initiated_alerts_report(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+) -> Dict[str, Any]:
+    """Alerts initiated by this station: auto-relays plus manual activations."""
+
+    auto_query = (
+        EASMessage.query.options(joinedload(EASMessage.cap_alert))
+        .filter(EASMessage.created_at >= window_start)
+        .filter(EASMessage.created_at < window_end)
+        .order_by(EASMessage.created_at.desc())
+    )
+    manual_query = (
+        ManualEASActivation.query.filter(
+            ManualEASActivation.created_at >= window_start,
+            ManualEASActivation.created_at < window_end,
+        ).order_by(ManualEASActivation.created_at.desc())
+    )
+
+    rows: List[List[Any]] = []
+    auto_count = 0
+    manual_count = 0
+
+    for message in auto_query:
+        auto_count += 1
+        alert = message.cap_alert
+        rows.append([
+            format_local_datetime(message.created_at, include_utc=True),
+            "AUTO",
+            (alert.event if alert and alert.event else "") or "",
+            "",
+            _short(message.same_header, 50),
+            "relayed",
+            _short(alert.identifier if alert else "", 40),
+        ])
+
+    for activation in manual_query:
+        manual_count += 1
+        ts = activation.sent_at or activation.created_at
+        rows.append([
+            format_local_datetime(ts, include_utc=True),
+            "MANUAL",
+            activation.event_name or activation.event_code or "",
+            activation.event_code or "",
+            _short(activation.same_header, 50),
+            activation.status or "",
+            _short(activation.identifier, 40),
+        ])
+
+    rows.sort(key=lambda r: r[0], reverse=True)
+
+    columns = [
+        {"label": "Initiated (local / UTC)", "weight": 2.4},
+        {"label": "Source", "weight": 0.7},
+        {"label": "Event", "weight": 1.6},
+        {"label": "Code", "weight": 0.6},
+        {"label": "SAME Header", "weight": 3.0},
+        {"label": "Status", "weight": 1.0},
+        {"label": "Identifier", "weight": 1.8},
+    ]
+
+    subtitle = (
+        f"Window: {format_local_datetime(window_start, include_utc=False)}"
+        f" to {format_local_datetime(window_end, include_utc=False)}"
+    )
+    summary_lines = [
+        f"Total initiated:  {auto_count + manual_count}",
+        f"Automated relay:  {auto_count}",
+        f"Manual activation:{manual_count}",
+    ]
+
+    return {
+        "slug": "initiated-alerts",
+        "title": "Initiated Alerts Report",
+        "subtitle": subtitle,
+        "columns": columns,
+        "rows": rows,
+        "summary_lines": summary_lines,
+        "window_start": window_start,
+        "window_end": window_end,
+        "row_count": len(rows),
+    }
+
+
+def _bucket_received(window_start: datetime, window_end: datetime) -> List[ReceivedEASAlert]:
+    return (
+        ReceivedEASAlert.query.filter(
+            ReceivedEASAlert.received_at >= window_start,
+            ReceivedEASAlert.received_at < window_end,
+        )
+        .order_by(ReceivedEASAlert.received_at.asc())
+        .all()
+    )
+
+
+def _bucket_initiated(window_start: datetime, window_end: datetime) -> List[Tuple[datetime, str]]:
+    items: List[Tuple[datetime, str]] = []
+    for message in EASMessage.query.filter(
+        EASMessage.created_at >= window_start,
+        EASMessage.created_at < window_end,
+    ).all():
+        items.append((message.created_at, "auto"))
+    for activation in ManualEASActivation.query.filter(
+        ManualEASActivation.created_at >= window_start,
+        ManualEASActivation.created_at < window_end,
+    ).all():
+        ts = activation.sent_at or activation.created_at
+        items.append((ts, "manual"))
+    return items
+
+
+def _iso_week_start(dt: datetime) -> datetime:
+    aware = _coerce_aware_utc(dt) or dt
+    monday = aware - timedelta(days=aware.weekday())
+    return monday.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _month_start(dt: datetime) -> datetime:
+    aware = _coerce_aware_utc(dt) or dt
+    return aware.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _bucket_summary_report(
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    period: str,
+) -> Dict[str, Any]:
+    received_alerts = _bucket_received(window_start, window_end)
+    initiated_items = _bucket_initiated(window_start, window_end)
+
+    if period == "weekly":
+        bucket_fn = _iso_week_start
+        bucket_label = "Week starting"
+        title = "Weekly Compliance Summary"
+        slug = "weekly-summary"
+    else:
+        bucket_fn = _month_start
+        bucket_label = "Month"
+        title = "Monthly Compliance Summary"
+        slug = "monthly-summary"
+
+    buckets: Dict[datetime, Dict[str, int]] = defaultdict(
+        lambda: {
+            "received": 0,
+            "forwarded": 0,
+            "ignored": 0,
+            "errors": 0,
+            "tests": 0,
+            "auto_initiated": 0,
+            "manual_initiated": 0,
+        }
+    )
+
+    for alert in received_alerts:
+        ts = _coerce_aware_utc(alert.received_at)
+        if ts is None:
+            continue
+        key = bucket_fn(ts)
+        bucket = buckets[key]
+        bucket["received"] += 1
+        decision = (alert.forwarding_decision or "").lower()
+        if decision == "forwarded":
+            bucket["forwarded"] += 1
+        elif decision == "ignored":
+            bucket["ignored"] += 1
+        elif decision == "error":
+            bucket["errors"] += 1
+        if (alert.event_code or "").upper() in {"RWT", "RMT"} or _event_matches_test(alert.event_name):
+            bucket["tests"] += 1
+
+    for ts, source in initiated_items:
+        ts_aware = _coerce_aware_utc(ts)
+        if ts_aware is None:
+            continue
+        key = bucket_fn(ts_aware)
+        bucket = buckets[key]
+        if source == "auto":
+            bucket["auto_initiated"] += 1
+        else:
+            bucket["manual_initiated"] += 1
+
+    sorted_keys = sorted(buckets.keys(), reverse=True)
+
+    rows: List[List[Any]] = []
+    totals = {
+        "received": 0,
+        "forwarded": 0,
+        "ignored": 0,
+        "errors": 0,
+        "tests": 0,
+        "auto_initiated": 0,
+        "manual_initiated": 0,
+    }
+    for key in sorted_keys:
+        b = buckets[key]
+        for k, v in b.items():
+            totals[k] += v
+        if period == "weekly":
+            label = format_local_datetime(key, include_utc=False)
+        else:
+            local = key
+            label = local.strftime("%Y-%m")
+        forward_rate = (b["forwarded"] / b["received"] * 100.0) if b["received"] else None
+        rate_str = f"{forward_rate:.1f}%" if forward_rate is not None else "—"
+        rows.append([
+            label,
+            b["received"],
+            b["forwarded"],
+            b["ignored"],
+            b["errors"],
+            b["tests"],
+            b["auto_initiated"],
+            b["manual_initiated"],
+            rate_str,
+        ])
+
+    columns = [
+        {"label": bucket_label, "weight": 2.0},
+        {"label": "Received", "weight": 1.0},
+        {"label": "Forwarded", "weight": 1.0},
+        {"label": "Ignored", "weight": 1.0},
+        {"label": "Errors", "weight": 0.9},
+        {"label": "Tests (RWT/RMT)", "weight": 1.3},
+        {"label": "Auto Initiated", "weight": 1.2},
+        {"label": "Manual Initiated", "weight": 1.3},
+        {"label": "Forward Rate", "weight": 1.1},
+    ]
+
+    subtitle = (
+        f"Window: {format_local_datetime(window_start, include_utc=False)}"
+        f" to {format_local_datetime(window_end, include_utc=False)}"
+    )
+
+    forward_rate = (
+        (totals["forwarded"] / totals["received"] * 100.0) if totals["received"] else None
+    )
+    rate_str = f"{forward_rate:.1f}%" if forward_rate is not None else "N/A"
+    summary_lines = [
+        f"Buckets:           {len(sorted_keys)}",
+        f"Received:          {totals['received']}",
+        f"Forwarded:         {totals['forwarded']}",
+        f"Ignored:           {totals['ignored']}",
+        f"Errors:            {totals['errors']}",
+        f"Tests (RWT/RMT):   {totals['tests']}",
+        f"Auto initiated:    {totals['auto_initiated']}",
+        f"Manual initiated:  {totals['manual_initiated']}",
+        f"Overall forward rate: {rate_str}",
+    ]
+
+    return {
+        "slug": slug,
+        "title": title,
+        "subtitle": subtitle,
+        "columns": columns,
+        "rows": rows,
+        "summary_lines": summary_lines,
+        "window_start": window_start,
+        "window_end": window_end,
+        "row_count": len(rows),
+    }
+
+
+def build_weekly_summary_report(
+    *, window_start: datetime, window_end: datetime
+) -> Dict[str, Any]:
+    return _bucket_summary_report(
+        window_start=window_start, window_end=window_end, period="weekly"
+    )
+
+
+def build_monthly_summary_report(
+    *, window_start: datetime, window_end: datetime
+) -> Dict[str, Any]:
+    return _bucket_summary_report(
+        window_start=window_start, window_end=window_end, period="monthly"
+    )
+
+
+def generate_report_csv(report: Dict[str, Any]) -> str:
+    """Render a report payload as CSV (header row + data + summary block)."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([col.get("label", "") for col in report.get("columns", [])])
+    for row in report.get("rows", []):
+        writer.writerow(["" if cell is None else str(cell) for cell in row])
+    summary_lines = report.get("summary_lines") or []
+    if summary_lines:
+        writer.writerow([])
+        writer.writerow(["Summary"])
+        for line in summary_lines:
+            writer.writerow([line])
+    return output.getvalue()
+
+
+def generate_report_pdf(report: Dict[str, Any]) -> bytes:
+    """Render a report payload as a paginated landscape PDF."""
+    from app_utils.pdf_generator import generate_table_pdf
+
+    return generate_table_pdf(
+        report.get("title", "Compliance Report"),
+        report.get("columns", []),
+        report.get("rows", []),
+        subtitle=report.get("subtitle"),
+        summary_lines=report.get("summary_lines"),
+        landscape=True,
+    )
+
+
+REPORT_BUILDERS = {
+    "received": lambda **kw: build_received_alerts_report(decision="received", **kw),
+    "forwarded": lambda **kw: build_received_alerts_report(decision="forwarded", **kw),
+    "ignored": lambda **kw: build_received_alerts_report(decision="ignored", **kw),
+    "initiated": build_initiated_alerts_report,
+    "weekly": build_weekly_summary_report,
+    "monthly": build_monthly_summary_report,
+}
 
 
 def determine_alert_precedence(alert: CAPAlert) -> Optional[str]:

--- a/app_utils/pdf_generator.py
+++ b/app_utils/pdf_generator.py
@@ -308,4 +308,278 @@ def generate_pdf_document(
     return buffer.getvalue()
 
 
-__all__ = ["generate_pdf_document"]
+# ---------------------------------------------------------------------------
+# Table-oriented report PDFs (used for FCC compliance exports)
+# ---------------------------------------------------------------------------
+
+_PAGE_PORTRAIT: Tuple[int, int] = (612, 792)
+_PAGE_LANDSCAPE: Tuple[int, int] = (792, 612)
+
+
+def _approx_helvetica_width(text: str, font_size: int) -> float:
+    """Rough Helvetica advance width for monospace-style truncation."""
+    # Helvetica averages ~0.5em advance for most printable ASCII; this is a
+    # deliberately conservative approximation since the renderer has no real
+    # font metrics.
+    return len(text) * font_size * 0.52
+
+
+def _truncate_to_width(text: Any, max_width_pts: float, font_size: int) -> str:
+    s = "" if text is None else str(text)
+    s = s.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    if max_width_pts <= 0:
+        return ""
+    if _approx_helvetica_width(s, font_size) <= max_width_pts:
+        return s
+    # Binary-search a fitting prefix so wide characters do not blow past the
+    # column boundary even though we are guessing average widths.
+    ellipsis = "…"
+    lo, hi = 0, len(s)
+    best = 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        candidate = s[:mid] + ellipsis
+        if _approx_helvetica_width(candidate, font_size) <= max_width_pts:
+            best = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    if best == 0:
+        return ""
+    return s[:best] + ellipsis
+
+
+def _assemble_pdf(page_streams: List[bytes], page_size: Tuple[int, int]) -> bytes:
+    """Wrap pre-rendered content streams into a complete PDF document."""
+    page_w, page_h = page_size
+    objects: List[Tuple[int, bytes]] = []
+    font_obj_id = 3
+    page_objects: List[int] = []
+    next_obj_id = 4
+
+    for content_stream in page_streams:
+        content_obj_id = next_obj_id
+        next_obj_id += 1
+        stream_body = (
+            b"<< /Length "
+            + str(len(content_stream)).encode("ascii")
+            + b" >>\nstream\n"
+            + content_stream
+            + b"\nendstream"
+        )
+        objects.append((content_obj_id, stream_body))
+
+        page_obj_id = next_obj_id
+        next_obj_id += 1
+        page_objects.append(page_obj_id)
+        page_body = (
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {page_w} {page_h}] "
+            f"/Contents {content_obj_id} 0 R "
+            f"/Resources << /Font << /F1 {font_obj_id} 0 R /F2 {font_obj_id + 1} 0 R >> >> >>"
+        ).encode("latin-1")
+        objects.append((page_obj_id, page_body))
+
+    pages_body = (
+        "<< /Type /Pages /Count {count} /Kids [{kids}] >>".format(
+            count=len(page_objects),
+            kids=" ".join(f"{obj_id} 0 R" for obj_id in page_objects),
+        )
+    ).encode("latin-1")
+
+    catalog_body = b"<< /Type /Catalog /Pages 2 0 R >>"
+    font_body = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"
+    bold_body = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"
+
+    objects.insert(0, (1, catalog_body))
+    objects.insert(1, (2, pages_body))
+    objects.insert(2, (font_obj_id, font_body))
+    objects.insert(3, (font_obj_id + 1, bold_body))
+
+    buffer = io.BytesIO()
+    buffer.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    xref_positions = []
+    for obj_id, body in objects:
+        xref_positions.append(buffer.tell())
+        buffer.write(f"{obj_id} 0 obj\n".encode("latin-1"))
+        buffer.write(body)
+        buffer.write(b"\nendobj\n")
+    startxref = buffer.tell()
+    buffer.write(f"xref\n0 {len(objects) + 1}\n".encode("latin-1"))
+    buffer.write(b"0000000000 65535 f \n")
+    for offset in xref_positions:
+        buffer.write(f"{offset:010d} 00000 n \n".encode("latin-1"))
+    buffer.write(b"trailer\n")
+    buffer.write(f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n".encode("latin-1"))
+    buffer.write(f"startxref\n{startxref}\n%%EOF".encode("latin-1"))
+    return buffer.getvalue()
+
+
+def generate_table_pdf(
+    title: str,
+    columns: Sequence[Dict[str, Any]],
+    rows: Sequence[Sequence[Any]],
+    *,
+    subtitle: Optional[str] = None,
+    summary_lines: Optional[Sequence[str]] = None,
+    generated_at: Optional[datetime] = None,
+    footer_text: Optional[str] = None,
+    landscape: bool = True,
+    empty_message: str = "No matching records during this window.",
+) -> bytes:
+    """Render a paginated tabular PDF report.
+
+    ``columns`` entries accept ``label`` and an optional ``weight`` (relative
+    column width).  Rows are sequences of cell values; values are stringified
+    and truncated with an ellipsis when they exceed the allotted column width.
+    """
+
+    from app_core.eas_storage import utc_now
+
+    if generated_at is None:
+        generated_at = utc_now()
+
+    page_w, page_h = _PAGE_LANDSCAPE if landscape else _PAGE_PORTRAIT
+    margin_x = 36
+    margin_top = 56
+    margin_bottom = 44
+    body_font = 9
+    header_font = 9
+    title_font = 16
+    subtitle_font = 11
+    line_height = 13
+
+    weights = [float(c.get("weight", 1) or 1) for c in columns]
+    total_weight = sum(weights) or 1.0
+    available_w = page_w - 2 * margin_x
+    col_widths = [w / total_weight * available_w for w in weights]
+    col_x: List[float] = []
+    x_cursor = float(margin_x)
+    for w in col_widths:
+        col_x.append(x_cursor)
+        x_cursor += w
+
+    def emit_text(content: List[str], font_alias: str, size: int, x: float, y: float, value: str) -> None:
+        content.append(f"/{font_alias} {size} Tf")
+        content.append(
+            f"1 0 0 1 {x:.2f} {y:.2f} Tm ({_escape_pdf_text(value)}) Tj"
+        )
+
+    def render_doc_header(content: List[str], y: float) -> float:
+        emit_text(content, "F2", title_font, margin_x, y, title)
+        y -= title_font + 6
+        if subtitle:
+            emit_text(content, "F1", subtitle_font, margin_x, y, subtitle)
+            y -= subtitle_font + 4
+        from app_utils.time import format_local_datetime
+        gen_line = f"Generated: {format_local_datetime(generated_at, include_utc=True)}"
+        emit_text(content, "F1", body_font, margin_x, y, gen_line)
+        y -= body_font + 8
+        return y
+
+    def render_table_header(content: List[str], y: float) -> float:
+        for i, col in enumerate(columns):
+            label = _truncate_to_width(col.get("label", ""), col_widths[i] - 4, header_font)
+            emit_text(content, "F2", header_font, col_x[i] + 1, y, label)
+        y -= line_height - 1
+        # Underline as a thin rule using a stroked path inside the text scope.
+        # We close the BT/ET block, draw the rule, and reopen the text scope.
+        content.append("ET")
+        content.append(f"{margin_x} {y + 4:.2f} m {page_w - margin_x} {y + 4:.2f} l S")
+        content.append("BT")
+        return y
+
+    def render_footer(content: List[str], page_num: int, total_pages: Optional[int]) -> None:
+        footer = footer_text or "EAS Station — FCC Compliance Report"
+        emit_text(content, "F1", 8, margin_x, 24, footer)
+        if total_pages is not None:
+            label = f"Page {page_num} of {total_pages}"
+        else:
+            label = f"Page {page_num}"
+        emit_text(content, "F1", 8, page_w - margin_x - 70, 24, label)
+
+    # Two-pass render: pass 1 figures out page count, pass 2 stamps "of N".
+    row_list = list(rows)
+
+    def _layout(total_pages: Optional[int]) -> List[bytes]:
+        rendered: List[bytes] = []
+        idx = 0
+        page_num = 0
+        n_rows = len(row_list)
+        rendered_summary = False
+
+        while True:
+            page_num += 1
+            content: List[str] = ["BT"]
+            y = page_h - margin_top
+            if page_num == 1:
+                y = render_doc_header(content, y)
+            else:
+                emit_text(content, "F1", body_font, margin_x, y, f"{title} (continued)")
+                y -= body_font + 8
+            y = render_table_header(content, y)
+
+            if n_rows == 0 and page_num == 1:
+                emit_text(content, "F1", body_font, margin_x, y - 4, empty_message)
+                y -= line_height + 4
+            else:
+                while idx < n_rows and y >= margin_bottom + line_height:
+                    row = row_list[idx]
+                    for i, col in enumerate(columns):
+                        cell = row[i] if i < len(row) else ""
+                        text_val = _truncate_to_width(cell, col_widths[i] - 4, body_font)
+                        emit_text(content, "F1", body_font, col_x[i] + 1, y, text_val)
+                    y -= line_height
+                    idx += 1
+
+            done = idx >= n_rows
+            if done and summary_lines and not rendered_summary:
+                needed = (len(summary_lines) + 1) * line_height + 12
+                if y - margin_bottom < needed:
+                    # Defer summary to a fresh page.
+                    pass
+                else:
+                    y -= 6
+                    content.append("ET")
+                    content.append(
+                        f"{margin_x} {y:.2f} m {page_w - margin_x} {y:.2f} l S"
+                    )
+                    content.append("BT")
+                    y -= line_height
+                    emit_text(content, "F2", header_font, margin_x, y, "Summary")
+                    y -= line_height
+                    for line in summary_lines:
+                        emit_text(content, "F1", body_font, margin_x, y, str(line))
+                        y -= line_height
+                    rendered_summary = True
+
+            content.append("ET")
+            render_footer(content, page_num, total_pages)
+            stream = "\n".join(content).encode("latin-1", "ignore")
+            rendered.append(stream)
+
+            if done and (rendered_summary or not summary_lines):
+                break
+            # Overflow summary onto its own page.
+            if done and summary_lines and not rendered_summary:
+                page_num += 1
+                content = ["BT"]
+                y = page_h - margin_top
+                emit_text(content, "F2", title_font, margin_x, y, "Summary")
+                y -= title_font + 8
+                for line in summary_lines:
+                    emit_text(content, "F1", body_font, margin_x, y, str(line))
+                    y -= line_height
+                content.append("ET")
+                render_footer(content, page_num, total_pages)
+                rendered.append("\n".join(content).encode("latin-1", "ignore"))
+                rendered_summary = True
+                break
+
+        return rendered
+
+    first_pass = _layout(None)
+    page_streams = _layout(len(first_pass))
+    return _assemble_pdf(page_streams, (page_w, page_h))
+
+
+__all__ = ["generate_pdf_document", "generate_table_pdf"]

--- a/templates/eas/compliance.html
+++ b/templates/eas/compliance.html
@@ -13,13 +13,119 @@
         </div>
         <div class="btn-group" role="group">
             <a class="btn btn-outline-primary" href="{{ url_for('compliance_export_csv', days=window_days) }}">
-                <i class="fas fa-file-csv"></i> Download CSV
+                <i class="fas fa-file-csv"></i> Activity Log CSV
             </a>
             <a class="btn btn-outline-primary" href="{{ url_for('compliance_export_pdf', days=window_days) }}">
-                <i class="fas fa-file-pdf"></i> Download PDF
+                <i class="fas fa-file-pdf"></i> Activity Log PDF
             </a>
         </div>
     </div>
+
+    <div class="card mb-4 border-primary">
+        <div class="card-header bg-primary bg-opacity-10 d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+            <h5 class="card-title mb-0"><i class="fas fa-file-contract text-primary"></i> FCC Compliance Reports</h5>
+            <small class="text-muted">PDF (printable) and CSV per category, scoped to the selected window.</small>
+        </div>
+        <div class="card-body">
+            <form method="get" class="row g-2 align-items-end mb-3" id="fcc-report-form">
+                <div class="col-sm-3">
+                    <label class="form-label small mb-1" for="fcc-start">Start date</label>
+                    <input type="date" class="form-control form-control-sm" id="fcc-start" name="start"
+                        value="{{ (dashboard.window_start.strftime('%Y-%m-%d')) if dashboard.window_start else '' }}">
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small mb-1" for="fcc-end">End date</label>
+                    <input type="date" class="form-control form-control-sm" id="fcc-end" name="end"
+                        value="{{ (dashboard.window_end.strftime('%Y-%m-%d')) if dashboard.window_end else '' }}">
+                </div>
+                <div class="col-sm-3">
+                    <label class="form-label small mb-1" for="fcc-days">Or last N days</label>
+                    <input type="number" min="1" max="365" class="form-control form-control-sm" id="fcc-days" name="days"
+                        value="{{ window_days }}">
+                </div>
+                <div class="col-sm-3 text-end">
+                    <small class="text-muted d-block">Date range overrides "last N days".</small>
+                </div>
+            </form>
+
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th scope="col">Report</th>
+                            <th scope="col">Description</th>
+                            <th scope="col" class="text-end">Export</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set reports = [
+                            ('received',  'Received Alerts',  'All alerts decoded by audio monitors during the window.'),
+                            ('forwarded', 'Forwarded Alerts', 'Received alerts that were forwarded to broadcast.'),
+                            ('ignored',   'Ignored Alerts',   'Received alerts not forwarded (with reason).'),
+                            ('initiated', 'Initiated Alerts', 'Auto-relayed and manually-initiated broadcasts.'),
+                            ('weekly',    'Weekly Summary',   'Per-week rollup of received / forwarded / ignored / tests.'),
+                            ('monthly',   'Monthly Summary',  'Per-month rollup of received / forwarded / ignored / tests.'),
+                        ] %}
+                        {% for kind, label, desc in reports %}
+                            <tr>
+                                <td><strong>{{ label }}</strong></td>
+                                <td class="text-muted small">{{ desc }}</td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-primary report-link"
+                                       data-kind="{{ kind }}" data-fmt="pdf"
+                                       href="{{ url_for('compliance_report_export', report_kind=kind, fmt='pdf', days=window_days) }}">
+                                        <i class="fas fa-file-pdf"></i> PDF
+                                    </a>
+                                    <a class="btn btn-sm btn-outline-secondary report-link"
+                                       data-kind="{{ kind }}" data-fmt="csv"
+                                       href="{{ url_for('compliance_report_export', report_kind=kind, fmt='csv', days=window_days) }}">
+                                        <i class="fas fa-file-csv"></i> CSV
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        (function () {
+            var startInput = document.getElementById('fcc-start');
+            var endInput = document.getElementById('fcc-end');
+            var daysInput = document.getElementById('fcc-days');
+            var links = document.querySelectorAll('.report-link');
+
+            function buildQuery() {
+                var params = new URLSearchParams();
+                var start = (startInput && startInput.value) || '';
+                var end = (endInput && endInput.value) || '';
+                if (start && end) {
+                    params.set('start', start);
+                    params.set('end', end);
+                } else if (daysInput && daysInput.value) {
+                    params.set('days', daysInput.value);
+                }
+                return params.toString();
+            }
+
+            function rebuild() {
+                var qs = buildQuery();
+                links.forEach(function (link) {
+                    var kind = link.getAttribute('data-kind');
+                    var fmt = link.getAttribute('data-fmt');
+                    var base = '/admin/compliance/report/' + kind + '.' + fmt;
+                    link.href = qs ? base + '?' + qs : base;
+                });
+            }
+
+            [startInput, endInput, daysInput].forEach(function (el) {
+                if (el) { el.addEventListener('change', rebuild); el.addEventListener('input', rebuild); }
+            });
+            rebuild();
+        })();
+    </script>
 
     {% set relay = dashboard.received_vs_relayed or {} %}
     {% set weekly = dashboard.weekly_tests or {} %}

--- a/webapp/routes/eas_compliance.py
+++ b/webapp/routes/eas_compliance.py
@@ -21,16 +21,20 @@ from __future__ import annotations
 
 """Routes powering the EAS compliance dashboard and exports."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Flask, Response, current_app, render_template, request
 
 from app_core.auth.decorators import require_auth, require_role
 from app_core.eas_storage import (
+    REPORT_BUILDERS,
     collect_compliance_dashboard_data,
     collect_compliance_log_entries,
     generate_compliance_log_csv,
     generate_compliance_log_pdf,
+    generate_report_csv,
+    generate_report_pdf,
+    resolve_report_window,
 )
 from app_core.system_health import (
     collect_audio_path_status,
@@ -169,6 +173,69 @@ def register(app: Flask, logger) -> None:
             f"attachment; filename=eas_compliance_{window_days}d.pdf"
         )
         return response
+
+
+    def _resolve_report_window():
+        """Pick the report window from start/end query args, or fall back to days."""
+        start_raw = request.args.get("start", type=str)
+        end_raw = request.args.get("end", type=str)
+
+        def _parse(value):
+            if not value:
+                return None
+            try:
+                # Accept either YYYY-MM-DD or full ISO timestamps.
+                if len(value) == 10:
+                    parsed = datetime.strptime(value, "%Y-%m-%d")
+                else:
+                    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed
+
+        start_dt = _parse(start_raw)
+        end_dt = _parse(end_raw)
+        if start_dt or end_dt:
+            return resolve_report_window(start=start_dt, end=end_dt)
+        return resolve_report_window(days=_resolve_window_days())
+
+    def _make_response(report, fmt: str):
+        slug = report.get("slug", "report")
+        if fmt == "csv":
+            payload = generate_report_csv(report)
+            response = Response(payload, mimetype="text/csv")
+            filename = f"eas_{slug}.csv"
+        else:
+            payload = generate_report_pdf(report)
+            response = Response(payload, mimetype="application/pdf")
+            filename = f"eas_{slug}.pdf"
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    @app.route("/admin/compliance/report/<report_kind>.<fmt>")
+    @require_auth
+    @require_role("Admin", "Operator", "Analyst")
+    def compliance_report_export(report_kind: str, fmt: str):
+        if fmt not in {"pdf", "csv"}:
+            return Response("Unsupported format.", status=404, mimetype="text/plain")
+        builder = REPORT_BUILDERS.get(report_kind)
+        if builder is None:
+            return Response("Unknown report.", status=404, mimetype="text/plain")
+        try:
+            window_start, window_end = _resolve_report_window()
+            report = builder(window_start=window_start, window_end=window_end)
+            return _make_response(report, fmt)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            route_logger.error(
+                "Failed to generate %s report (%s): %s", report_kind, fmt, exc
+            )
+            return Response(
+                "Unable to generate report. See logs for details.",
+                status=500,
+                mimetype="text/plain",
+            )
 
 
 __all__ = ["register"]


### PR DESCRIPTION
The compliance dashboard previously offered only a single all-categories
activity log export, leaving operators without printable FCC-style
breakdowns. This adds six new exports — Received, Forwarded, Ignored,
Initiated, Weekly, Monthly — each available as PDF and CSV with an
optional date range or last-N-days window.

- pdf_generator.py: add generate_table_pdf() for paginated landscape
  tables with column truncation, summary block, and page numbers.
- eas_storage.py: add report builders pulling from ReceivedEASAlert,
  EASMessage and ManualEASActivation, plus generic CSV/PDF exporters.
- eas_compliance.py: new /admin/compliance/report/<kind>.<fmt> route
  honoring start/end or days query args.
- compliance.html: report selector card with date pickers that rewrites
  download links on the fly.

https://claude.ai/code/session_0135UHcQCYuAs1uBHYgSdzy7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive FCC compliance reporting with received, forwarded, ignored alerts, initiated activities, and weekly/monthly summaries.
  * Full report export support in CSV and PDF formats.
  * Date range customization for all compliance reports.
  * Redesigned report download interface with streamlined export controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->