### PR TITLE
Fix .bg-light dark-on-dark contrast across all dark themes

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1034,3 +1034,48 @@ code {
 .timeline-item.success::before { background: var(--success-color); }
 .timeline-item.error::before { background: var(--danger-color); }
 .timeline-item.warning::before { background: var(--warning-color); }
+
+/* ----------------------------------------------------------------------------
+   Lightning theme readability — admin gradient banners
+   ----------------------------------------------------------------------------
+   The admin header/stat cards/modal header/count badge all paint a
+   primary→secondary gradient and put `color: white` on top. On the lightning
+   theme that gradient resolves to bright-yellow→cyan (very light) so white
+   text becomes nearly invisible. Force dark ink on every admin-themed gradient
+   surface for this theme. The yellow theme is similar (primary is
+   bright yellow). */
+[data-theme="lightning"] .admin-header,
+[data-theme="lightning"] .admin-header h1,
+[data-theme="lightning"] .admin-header h2,
+[data-theme="lightning"] .admin-header p,
+[data-theme="lightning"] .admin-header *,
+[data-theme="lightning"] .admin-page-header,
+[data-theme="lightning"] .admin-page-header h1,
+[data-theme="lightning"] .admin-page-header h2,
+[data-theme="lightning"] .admin-page-header p,
+[data-theme="lightning"] .admin-page-header *,
+[data-theme="lightning"] .stat-card,
+[data-theme="lightning"] .stat-card *,
+[data-theme="lightning"] .modal-header,
+[data-theme="lightning"] .modal-header *,
+[data-theme="lightning"] .admin-count-badge,
+[data-theme="yellow"] .admin-header,
+[data-theme="yellow"] .admin-header *,
+[data-theme="yellow"] .admin-page-header,
+[data-theme="yellow"] .admin-page-header *,
+[data-theme="yellow"] .stat-card,
+[data-theme="yellow"] .stat-card *,
+[data-theme="yellow"] .modal-header,
+[data-theme="yellow"] .modal-header *,
+[data-theme="yellow"] .admin-count-badge {
+    color: #0d1b2a !important;
+    text-shadow: none;
+}
+
+/* Restore the admin-page-header subtitle to a softer dark ink (was
+   rgba(white, 0.85) in the default rule). Pure black is too heavy for the
+   subtitle's smaller font size on the bright gradient. */
+[data-theme="lightning"] .admin-page-header p,
+[data-theme="yellow"] .admin-page-header p {
+    color: rgba(13, 27, 42, 0.78) !important;
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -907,22 +907,115 @@
     color: #0d1b2a;
 }
 
-/* Lightning Theme - .bg-light surfaces
-   --light-color resolves to pale yellow (#fff9c4) in this theme. Components
-   that declare their own text color (.metric-value, .metric-label, etc.)
-   beat the low-specificity `.bg-light * { color: inherit }` rule and render
-   cream-on-yellow, which is unreadable. Force dark text on any descendant
-   of a .bg-light region so those overrides lose. */
-[data-theme="lightning"] .bg-light,
-[data-theme="lightning"] .bg-light *,
-[data-theme="lightning"] .card-header.bg-light,
-[data-theme="lightning"] .card-header.bg-light * {
+/* ----------------------------------------------------------------------------
+   Bootstrap .bg-light surfaces - global readability
+   ----------------------------------------------------------------------------
+   Two structural problems make `.bg-light` containers unreadable on every
+   dark theme (lightning, aurora, nebula, midnight, charcoal, obsidian, slate,
+   coffee, dark):
+
+   1. `.card { background: linear-gradient(...) }` is a `background` shorthand
+      that paints an OPAQUE surface-color gradient into background-image.
+      Bootstrap's `.bg-light { background-color: ... !important }` cannot
+      override that, because !important on background-color does not clear an
+      image. Result: `<div class="card bg-light">` (or
+      `card-body bg-light` / `card-header bg-light` etc.) keeps the dark
+      gradient on every theme — visually identical to a non-bg-light card.
+
+   2. With the gradient suppressed, the bg-light surface is near-white, but
+      descendant text inherits `--text-color` which resolves to white / cream
+      / lavender on dark themes. White-on-white is unreadable.
+
+   Fix: clear the gradient, force the bg-light container to actually paint a
+   light surface, and pin dark ink on it (with !important so component-level
+   overrides like `.metric-value { color: var(--text-color) }` lose). */
+.card.bg-light,
+.card.card-body.bg-light,
+.card-body.bg-light,
+.card-footer.bg-light {
+    background-image: none !important;
+    background-color: var(--bs-light, #f8f9fa) !important;
+}
+
+.bg-light,
+.card.bg-light,
+.card-header.bg-light,
+.card-body.bg-light,
+.card-footer.bg-light {
     color: #0d1b2a !important;
     text-shadow: none;
 }
 
+/* Force dark ink on plain text descendants of a .bg-light surface, but
+   exclude self-coloring components (`.btn`, `.badge`, `.alert`, anything
+   with a `.bg-*` background utility) so their own theme-aware text colors
+   survive. Without these `:not()` exclusions the !important above would
+   bleach dark ink onto bg-primary buttons, colored badges, etc. */
+:is(.bg-light, .card.bg-light, .card-header.bg-light, .card-body.bg-light, .card-footer.bg-light) :not(.btn, .badge, .alert, [class*="bg-primary"], [class*="bg-success"], [class*="bg-info"], [class*="bg-warning"], [class*="bg-danger"], [class*="bg-secondary"], [class*="bg-dark"], .btn *, .badge *, .alert *) {
+    color: #0d1b2a !important;
+    text-shadow: none;
+}
+
+/* .text-muted inside a .bg-light region: its own rule sets
+   `color: var(--text-muted) !important`, which on dark themes resolves to a
+   light gray that is invisible against a near-white bg-light. Pin a darker
+   muted ink that still reads as "secondary" against the light surface. */
+.bg-light .text-muted,
+.card.bg-light .text-muted,
+.card-header.bg-light .text-muted,
+.card-body.bg-light .text-muted,
+.card-footer.bg-light .text-muted {
+    color: #495057 !important;
+}
+
+/* `<pre>` / `<code>` / `.code-block` inherit a global rule that paints them
+   with `background: color-mix(in srgb, var(--text-color) 5%, transparent)`.
+   On dark themes inside a `.bg-light` parent, that resolves to a 5% white
+   tint over a near-white surface (still light) — but the global text color
+   resolves to white, which we then override to #0d1b2a above. The pre block
+   itself though has been observed to render as dark-on-dark when its parent
+   is a `.card.bg-light` (see the original bug: collapsed JSON details in
+   templates/logs.html). Pin an explicit light surface and dark ink so any
+   descendant code/pre stays legible. */
+.bg-light pre,
+.bg-light code,
+.bg-light .code-block,
+.card.bg-light pre,
+.card.bg-light code,
+.card-body.bg-light pre,
+.card-body.bg-light code,
+.card-footer.bg-light pre,
+.card-footer.bg-light code,
+.card-header.bg-light pre,
+.card-header.bg-light code {
+    background: rgba(0, 0, 0, 0.06) !important;
+    color: #0d1b2a !important;
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+/* Bootstrap utility classes inside .bg-light: when an author writes
+   `<span class="text-success">` inside a bg-light region, the descendant
+   color override above (`color: #0d1b2a`) flattens that intent. Restore
+   theme-aware semantic colors (using the dark/text-emphasis variants so they
+   read well on a near-white background). */
+.bg-light .text-primary,
+.card.bg-light .text-primary { color: #0d6efd !important; }
+.bg-light .text-success,
+.card.bg-light .text-success { color: #198754 !important; }
+.bg-light .text-info,
+.card.bg-light .text-info { color: #087990 !important; }
+.bg-light .text-warning,
+.card.bg-light .text-warning { color: #997404 !important; }
+.bg-light .text-danger,
+.card.bg-light .text-danger { color: #dc3545 !important; }
+
+/* Lightning Theme - small additional tweak: keep the lightning-specific
+   muted ink that was tuned for its pale-yellow aesthetic when the theme
+   is active; otherwise the global #495057 above applies. */
 [data-theme="lightning"] .bg-light .text-muted,
-[data-theme="lightning"] .card-header.bg-light .text-muted {
+[data-theme="lightning"] .card-header.bg-light .text-muted,
+[data-theme="lightning"] .card-body.bg-light .text-muted,
+[data-theme="lightning"] .card-footer.bg-light .text-muted {
     color: #3a4d7a !important;
 }
 

--- a/templates/admin/tts.html
+++ b/templates/admin/tts.html
@@ -150,7 +150,7 @@
 
         <div id="previewResult" style="display: none;">
             <label class="form-label">Normalized Output <small class="text-muted">(what the TTS engine will receive)</small></label>
-            <textarea class="form-control font-monospace bg-light" id="previewOutput" rows="4" readonly></textarea>
+            <textarea class="form-control font-monospace" id="previewOutput" rows="4" readonly></textarea>
             <div id="previewAudioPlayer" style="display: none; margin-top: 0.75rem;">
                 <audio id="previewAudioElement" controls style="width: 100%;"></audio>
             </div>

--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -332,7 +332,7 @@
 
     .scope-coverage-na {
         background: var(--text-muted);
-        color: #fff;
+        color: var(--bg-color);
     }
 
     .county-wide-badge {
@@ -358,6 +358,19 @@
     .alert-actions {
         position: sticky;
         top: 20px;
+    }
+
+    /* "Current alert" star marker in the VTEC timeline. The theme's primary
+       color spans the full lightness range across themes, so pick the text
+       color per-theme: dark ink on themes whose primary resolves to a light
+       hue (lightning/yellow), white on the rest. */
+    .vtec-current-marker {
+        background: var(--primary-color);
+        color: #ffffff;
+    }
+    [data-theme="lightning"] .vtec-current-marker,
+    [data-theme="yellow"] .vtec-current-marker {
+        color: #0d1b2a;
     }
 </style>
 {% endblock %}
@@ -1322,7 +1335,7 @@
                                 <div class="d-flex align-items-start gap-2 mb-2">
                                     <div class="d-flex flex-column align-items-center" style="min-width:2rem;">
                                         {% if is_current %}
-                                        <div class="rounded-circle border border-primary d-flex align-items-center justify-content-center" style="width:1.5rem;height:1.5rem;background:var(--primary-color);color:#fff;font-size:.65rem;font-weight:700;">★</div>
+                                        <div class="rounded-circle border border-primary d-flex align-items-center justify-content-center vtec-current-marker" style="width:1.5rem;height:1.5rem;font-size:.65rem;font-weight:700;">★</div>
                                         {% else %}
                                         <div class="rounded-circle border d-flex align-items-center justify-content-center" style="width:1.5rem;height:1.5rem;background:var(--surface-color);font-size:.6rem;font-weight:700;color:var(--text-secondary);">{{ loop.index }}</div>
                                         {% endif %}

--- a/templates/site_navigation.html
+++ b/templates/site_navigation.html
@@ -257,7 +257,7 @@
 
     <!-- Configuration -->
     <div class="card mb-4">
-        <div class="card-header" style="background: var(--primary-color); color: white;">
+        <div class="card-header bg-primary">
             <h5 class="mb-0"><i class="fas fa-cog me-2"></i>Configuration</h5>
         </div>
         <div class="card-body">


### PR DESCRIPTION
The "Detailed Information" JSON pre-block in logs.html (and any
`<pre>`/`<code>` inside a `.bg-light` container) rendered dark text on
a dark navy background on the lightning theme — completely unreadable.

Two cascade bugs:

1. `.card { background: linear-gradient(...) }` is a `background`
   shorthand that paints an OPAQUE surface-color gradient into
   background-image. Bootstrap's `.bg-light { background-color ...
   !important }` cannot override that, because !important on
   background-color does not clear an image. Result:
   `<div class="card bg-light">` (or `card-body bg-light` /
   `card-header bg-light` / `card-footer bg-light`) keeps the dark
   gradient on every theme.

2. With the gradient suppressed, the bg-light surface is near-white,
   but descendant text still inherits `--text-color` which resolves to
   white / cream / lavender on dark themes — white-on-white.

The previous lightning-only descendant override (#0d1b2a !important on
`.bg-light *`) only papered over the symptom on one theme and didn't
clear the gradient image, so the underlying gradient still showed.

Fix:

- `.card.bg-light` / `.card-body.bg-light` / `.card-footer.bg-light`
  now clear `background-image` and pin Bootstrap's light bg-color, so
  the surface is actually light on every theme.
- Force dark ink on `.bg-light` and its descendants, with `:not(...)`
  exclusions for self-coloring components (`.btn`, `.badge`, `.alert`,
  any `.bg-*` background utility) so colored badges/buttons keep their
  own theme-aware text.
- `<pre>` / `<code>` / `.code-block` inside a `.bg-light` parent now
  get an explicit light surface tint + dark ink (their global rule
  paints a `--text-color` 5% tint that goes dark on dark themes).
- `.text-muted` inside `.bg-light` resolves to `#495057` globally
  (was invisible light gray on dark themes); lightning keeps its
  tuned `#3a4d7a` muted ink.
- Restore theme-aware `.text-primary` / `.text-success` / `.text-info`
  / `.text-warning` / `.text-danger` colors inside `.bg-light` so
  semantic text stays semantic.

Lightning/yellow theme — admin gradient banners:

The `.admin-header`, `.admin-page-header`, `.stat-card`, `.modal-header`,
and `.admin-count-badge` rules in admin.css all paint a primary →
secondary gradient with `color: white`. On lightning that gradient
resolves to bright-yellow → cyan, so white text becomes nearly
invisible. Force dark ink on these surfaces for the lightning + yellow
themes.

Misc inline-style fixes:

- `templates/site_navigation.html` Configuration card-header: replaced
  inline `style="background: var(--primary-color); color: white;"`
  with the themed `.bg-primary` utility (already has the lightning
  override).
- `templates/alert_detail.html` VTEC current-alert star marker:
  promoted the inline style to a `.vtec-current-marker` class with a
  per-theme color so the star reads on both light and dark primaries.
- `templates/alert_detail.html` `.scope-coverage-na`: switched from
  `color: #fff` (invisible on light --text-muted backgrounds) to
  `var(--bg-color)` for theme-aware contrast.
- `templates/admin/tts.html` preview textarea: dropped the
  `bg-light` class so it picks up the theme-aware form-control
  styling instead of fighting with it.

https://claude.ai/code/session_011wujC4TA71fppYhQVd3Xia