### PR TITLE
fix(pdf): give bold font and content streams distinct object IDs

### DIFF
--- a/app_core/eas_storage.py
+++ b/app_core/eas_storage.py
@@ -1352,12 +1352,26 @@ def build_alert_delivery_trends(
 
 def collect_compliance_log_entries(
     window_days: int = 30,
+    *,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
 ) -> Tuple[List[Dict[str, Any]], datetime, datetime]:
-    """Return compliance activity entries for the requested window."""
+    """Return compliance activity entries for the requested window.
 
-    days = _normalize_window_days(window_days)
-    window_end = utc_now()
-    window_start = window_end - timedelta(days=days)
+    When ``window_start`` and ``window_end`` are both provided they take
+    precedence over ``window_days``; otherwise the window ends at "now" and
+    extends ``window_days`` into the past.
+    """
+
+    if window_start is not None and window_end is not None:
+        window_start = _coerce_aware_utc(window_start) or window_start
+        window_end = _coerce_aware_utc(window_end) or window_end
+        if window_start > window_end:
+            window_start, window_end = window_end, window_start
+    else:
+        days = _normalize_window_days(window_days)
+        window_end = utc_now()
+        window_start = window_end - timedelta(days=days)
 
     entries: List[Dict[str, Any]] = []
 
@@ -1444,10 +1458,23 @@ def collect_compliance_log_entries(
     return entries, window_start, window_end
 
 
-def collect_compliance_dashboard_data(window_days: int = 30) -> Dict[str, Any]:
-    """Aggregate compliance metrics for dashboard presentation."""
+def collect_compliance_dashboard_data(
+    window_days: int = 30,
+    *,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Aggregate compliance metrics for dashboard presentation.
 
-    entries, window_start, window_end = collect_compliance_log_entries(window_days)
+    Either supply ``window_days`` for a relative window, or pin the window by
+    providing both ``window_start`` and ``window_end`` (explicit bounds win).
+    """
+
+    entries, window_start, window_end = collect_compliance_log_entries(
+        window_days,
+        window_start=window_start,
+        window_end=window_end,
+    )
 
     received_total = sum(1 for entry in entries if entry["category"] == "received")
     auto_relay_total = sum(1 for entry in entries if entry["category"] == "relayed")
@@ -1502,8 +1529,11 @@ def collect_compliance_dashboard_data(window_days: int = 30) -> Dict[str, Any]:
 
     recent_activity = entries[:25]
 
+    span_seconds = max((window_end - window_start).total_seconds(), 0)
+    effective_window_days = max(1, int(round(span_seconds / 86400))) or 1
+
     return {
-        "window_days": _normalize_window_days(window_days),
+        "window_days": effective_window_days,
         "window_start": window_start,
         "window_end": window_end,
         "generated_at": utc_now(),

--- a/app_utils/pdf_generator.py
+++ b/app_utils/pdf_generator.py
@@ -354,8 +354,12 @@ def _assemble_pdf(page_streams: List[bytes], page_size: Tuple[int, int]) -> byte
     page_w, page_h = page_size
     objects: List[Tuple[int, bytes]] = []
     font_obj_id = 3
+    bold_font_obj_id = font_obj_id + 1
     page_objects: List[int] = []
-    next_obj_id = 4
+    # IDs 1..4 are reserved for catalog, pages tree, regular font, and bold
+    # font (inserted at the front below); content/page objects start at 5 to
+    # avoid colliding with the bold font's object number.
+    next_obj_id = bold_font_obj_id + 1
 
     for content_stream in page_streams:
         content_obj_id = next_obj_id
@@ -375,7 +379,7 @@ def _assemble_pdf(page_streams: List[bytes], page_size: Tuple[int, int]) -> byte
         page_body = (
             f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {page_w} {page_h}] "
             f"/Contents {content_obj_id} 0 R "
-            f"/Resources << /Font << /F1 {font_obj_id} 0 R /F2 {font_obj_id + 1} 0 R >> >> >>"
+            f"/Resources << /Font << /F1 {font_obj_id} 0 R /F2 {bold_font_obj_id} 0 R >> >> >>"
         ).encode("latin-1")
         objects.append((page_obj_id, page_body))
 
@@ -393,7 +397,7 @@ def _assemble_pdf(page_streams: List[bytes], page_size: Tuple[int, int]) -> byte
     objects.insert(0, (1, catalog_body))
     objects.insert(1, (2, pages_body))
     objects.insert(2, (font_obj_id, font_body))
-    objects.insert(3, (font_obj_id + 1, bold_body))
+    objects.insert(3, (bold_font_obj_id, bold_body))
 
     buffer = io.BytesIO()
     buffer.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")

--- a/templates/eas/compliance.html
+++ b/templates/eas/compliance.html
@@ -7,15 +7,26 @@
         <div>
             <h1 class="h3 mb-1">EAS Compliance Dashboard</h1>
             <p class="text-muted mb-0">
-                Monitoring window: last {{ window_days }} days · Generated
+                Monitoring window:
+                {% if dashboard.window_start and dashboard.window_end %}
+                    {{ format_local_datetime(dashboard.window_start, include_utc=False) }}
+                    &ndash;
+                    {{ format_local_datetime(dashboard.window_end, include_utc=False) }}
+                    ({{ window_days }} day{{ '' if window_days == 1 else 's' }})
+                {% else %}
+                    last {{ window_days }} days
+                {% endif %}
+                · Generated
                 {{ format_local_datetime(dashboard.generated_at, include_utc=True) if dashboard.generated_at else '—' }}
             </p>
         </div>
         <div class="btn-group" role="group">
-            <a class="btn btn-outline-primary" href="{{ url_for('compliance_export_csv', days=window_days) }}">
+            <a class="btn btn-outline-primary activity-log-link" data-fmt="csv"
+               href="{{ url_for('compliance_export_csv', days=window_days) }}">
                 <i class="fas fa-file-csv"></i> Activity Log CSV
             </a>
-            <a class="btn btn-outline-primary" href="{{ url_for('compliance_export_pdf', days=window_days) }}">
+            <a class="btn btn-outline-primary activity-log-link" data-fmt="pdf"
+               href="{{ url_for('compliance_export_pdf', days=window_days) }}">
                 <i class="fas fa-file-pdf"></i> Activity Log PDF
             </a>
         </div>
@@ -27,7 +38,8 @@
             <small class="text-muted">PDF (printable) and CSV per category, scoped to the selected window.</small>
         </div>
         <div class="card-body">
-            <form method="get" class="row g-2 align-items-end mb-3" id="fcc-report-form">
+            <form method="get" action="{{ url_for('compliance_dashboard') }}"
+                  class="row g-2 align-items-end mb-3" id="fcc-report-form">
                 <div class="col-sm-3">
                     <label class="form-label small mb-1" for="fcc-start">Start date</label>
                     <input type="date" class="form-control form-control-sm" id="fcc-start" name="start"
@@ -43,7 +55,10 @@
                     <input type="number" min="1" max="365" class="form-control form-control-sm" id="fcc-days" name="days"
                         value="{{ window_days }}">
                 </div>
-                <div class="col-sm-3 text-end">
+                <div class="col-sm-3 text-end d-flex flex-column align-items-end justify-content-end gap-1">
+                    <button type="submit" class="btn btn-sm btn-primary">
+                        <i class="fas fa-filter"></i> Apply
+                    </button>
                     <small class="text-muted d-block">Date range overrides "last N days".</small>
                 </div>
             </form>
@@ -95,7 +110,12 @@
             var startInput = document.getElementById('fcc-start');
             var endInput = document.getElementById('fcc-end');
             var daysInput = document.getElementById('fcc-days');
-            var links = document.querySelectorAll('.report-link');
+            var reportLinks = document.querySelectorAll('.report-link');
+            var activityLinks = document.querySelectorAll('.activity-log-link');
+            var activityBases = {
+                csv: {{ url_for('compliance_export_csv')|tojson }},
+                pdf: {{ url_for('compliance_export_pdf')|tojson }}
+            };
 
             function buildQuery() {
                 var params = new URLSearchParams();
@@ -112,10 +132,16 @@
 
             function rebuild() {
                 var qs = buildQuery();
-                links.forEach(function (link) {
+                reportLinks.forEach(function (link) {
                     var kind = link.getAttribute('data-kind');
                     var fmt = link.getAttribute('data-fmt');
                     var base = '/admin/compliance/report/' + kind + '.' + fmt;
+                    link.href = qs ? base + '?' + qs : base;
+                });
+                activityLinks.forEach(function (link) {
+                    var fmt = link.getAttribute('data-fmt');
+                    var base = activityBases[fmt];
+                    if (!base) { return; }
                     link.href = qs ? base + '?' + qs : base;
                 });
             }

--- a/webapp/routes/eas_compliance.py
+++ b/webapp/routes/eas_compliance.py
@@ -54,14 +54,45 @@ def register(app: Flask, logger) -> None:
             return 30
         return max(1, min(int(value), 365))
 
+    def _parse_query_date(value: str) -> "datetime | None":
+        if not value:
+            return None
+        try:
+            if len(value) == 10:
+                parsed = datetime.strptime(value, "%Y-%m-%d")
+            else:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def _resolve_dashboard_window():
+        """Return ``(start, end, days)``. Explicit start+end wins over days."""
+        start = _parse_query_date(request.args.get("start", type=str) or "")
+        end = _parse_query_date(request.args.get("end", type=str) or "")
+        if start and end:
+            window_start, window_end = resolve_report_window(start=start, end=end)
+            span = max((window_end - window_start).total_seconds(), 0)
+            days = max(1, int(round(span / 86400))) or 1
+            return window_start, window_end, days
+        days = _resolve_window_days()
+        window_start, window_end = resolve_report_window(days=days)
+        return window_start, window_end, days
+
     @app.route("/admin/compliance")
     @require_auth
     @require_role("Admin", "Operator", "Analyst")
     def compliance_dashboard():
-        window_days = _resolve_window_days()
+        window_start, window_end, window_days = _resolve_dashboard_window()
 
         try:
-            dashboard = collect_compliance_dashboard_data(window_days=window_days)
+            dashboard = collect_compliance_dashboard_data(
+                window_days=window_days,
+                window_start=window_start,
+                window_end=window_end,
+            )
             receiver_snapshot = collect_receiver_health_snapshot(route_logger)
             audio_status = collect_audio_path_status(route_logger)
         except Exception as exc:  # pragma: no cover - defensive fallback
@@ -69,8 +100,8 @@ def register(app: Flask, logger) -> None:
             now = utc_now()
             dashboard = {
                 "window_days": window_days,
-                "window_start": now - timedelta(days=window_days),
-                "window_end": now,
+                "window_start": window_start or (now - timedelta(days=window_days)),
+                "window_end": window_end or now,
                 "generated_at": now,
                 "received_vs_relayed": {
                     "received": 0,
@@ -119,6 +150,8 @@ def register(app: Flask, logger) -> None:
             audio_status=audio_status,
             timezone_name=timezone_name,
             window_days=window_days,
+            window_start=window_start,
+            window_end=window_end,
             format_local_datetime=format_local_datetime,
         )
 
@@ -126,10 +159,14 @@ def register(app: Flask, logger) -> None:
     @require_auth
     @require_role("Admin", "Operator", "Analyst")
     def compliance_export_csv():
-        window_days = _resolve_window_days()
+        window_start, window_end, window_days = _resolve_dashboard_window()
 
         try:
-            entries, _, _ = collect_compliance_log_entries(window_days=window_days)
+            entries, _, _ = collect_compliance_log_entries(
+                window_days=window_days,
+                window_start=window_start,
+                window_end=window_end,
+            )
             csv_payload = generate_compliance_log_csv(entries)
         except Exception as exc:  # pragma: no cover - defensive fallback
             route_logger.error("Failed to generate compliance CSV export: %s", exc)
@@ -149,11 +186,13 @@ def register(app: Flask, logger) -> None:
     @require_auth
     @require_role("Admin", "Operator", "Analyst")
     def compliance_export_pdf():
-        window_days = _resolve_window_days()
+        window_start, window_end, window_days = _resolve_dashboard_window()
 
         try:
             entries, window_start, window_end = collect_compliance_log_entries(
-                window_days=window_days
+                window_days=window_days,
+                window_start=window_start,
+                window_end=window_end,
             )
             pdf_payload = generate_compliance_log_pdf(
                 entries,
@@ -177,29 +216,8 @@ def register(app: Flask, logger) -> None:
 
     def _resolve_report_window():
         """Pick the report window from start/end query args, or fall back to days."""
-        start_raw = request.args.get("start", type=str)
-        end_raw = request.args.get("end", type=str)
-
-        def _parse(value):
-            if not value:
-                return None
-            try:
-                # Accept either YYYY-MM-DD or full ISO timestamps.
-                if len(value) == 10:
-                    parsed = datetime.strptime(value, "%Y-%m-%d")
-                else:
-                    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            except ValueError:
-                return None
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            return parsed
-
-        start_dt = _parse(start_raw)
-        end_dt = _parse(end_raw)
-        if start_dt or end_dt:
-            return resolve_report_window(start=start_dt, end=end_dt)
-        return resolve_report_window(days=_resolve_window_days())
+        window_start, window_end, _ = _resolve_dashboard_window()
+        return window_start, window_end
 
     def _make_response(report, fmt: str):
         slug = report.get("slug", "report")


### PR DESCRIPTION
generate_table_pdf produced PDFs whose page Contents reference resolved
to the bold font dictionary instead of the rendered content stream,
because _assemble_pdf seeded next_obj_id at 4 — the same ID it later
assigned to the bold font (font_obj_id + 1). The xref slot count then
no longer matched the declared object IDs, so strict readers refused
to open the file. Compliance report PDF downloads (Received, Forwarded,
Ignored, Initiated, Weekly, Monthly) all served broken documents.

Reserve IDs 1..4 for catalog/pages/regular font/bold font and start
content/page IDs at 5 so each object number is unique.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compliance dashboard now supports explicit start/end date selection for reports and activity logs, in addition to relative "last N days" filtering.
  * Added "Apply" button to submit date range selections.
  * Export links automatically update based on the selected monitoring window.

* **Refactor**
  * Optimized internal date range handling and PDF generation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->