### PR TITLE
Support RV-3028-C7 RTC on newer Uputronics GPS boards

### DIFF
--- a/app_utils/system.py
+++ b/app_utils/system.py
@@ -2322,10 +2322,13 @@ def _to_bool(value: Any) -> Optional[bool]:
 def _collect_rtc_status(logger) -> Dict[str, Any]:
     """Inspect any battery-backed real-time clock exposed via ``/sys/class/rtc``.
 
-    Targets the DS3231 on the Uputronics Raspberry Pi GPS/RTC Expansion Board
-    (enabled on the Pi via ``dtoverlay=i2c-rtc,ds3231``), but works for any
-    Linux RTC. All reads come from sysfs — ``hwclock`` is never invoked, so
-    the function is safe to run without root and never blocks.
+    Targets the on-board RTC of the Uputronics Raspberry Pi GPS/RTC Expansion
+    Board — DS3231 at I²C ``0x68`` on older revisions (``dtoverlay=i2c-rtc,ds3231``)
+    and RV-3028-C7 at I²C ``0x52`` on current revisions
+    (``dtoverlay=i2c-rtc,rv3028``) — but works for any Linux RTC. All reads
+    come from sysfs — ``hwclock`` is never invoked, so the function is safe
+    to run without root, never blocks, and does not depend on the
+    ``util-linux-extra`` package being installed.
 
     Returns a best-effort dict that is always safe to serialise. When no RTC
     is present the dict will contain ``available=False`` so the health page
@@ -2345,11 +2348,19 @@ def _collect_rtc_status(logger) -> Dict[str, Any]:
         name = _safe_read_text(rtc_root / "name")
         if name:
             # The kernel reports e.g. "rtc-ds3231 1-0068" for the DS3231 driver
-            # bound on I²C bus 1 address 0x68. Normalise for downstream UI.
+            # bound on I²C bus 1 address 0x68, or "rtc-rv3028 1-0052" for the
+            # RV-3028-C7 used on current Uputronics boards. Normalise for
+            # downstream UI.
             result["name"] = name
             lowered = name.lower()
             result["is_ds3231"] = "ds3231" in lowered
-            result["is_battery_backed"] = result["is_ds3231"] or "ds1307" in lowered or "pcf85" in lowered
+            result["is_rv3028"] = "rv3028" in lowered
+            result["is_battery_backed"] = (
+                result["is_ds3231"]
+                or result["is_rv3028"]
+                or "ds1307" in lowered
+                or "pcf85" in lowered
+            )
 
         # Current RTC time. ``since_epoch`` is exported in seconds (UTC) and
         # is the most reliable source — the textual ``date``/``time`` files
@@ -2373,7 +2384,8 @@ def _collect_rtc_status(logger) -> Dict[str, Any]:
                 result["drift_status"] = "moderate"
             else:
                 # Large drift after a power cycle is the classic "RTC battery
-                # failed and the clock reset" symptom on the DS3231.
+                # failed and the clock reset" symptom on both the DS3231 and
+                # the RV-3028-C7.
                 result["drift_status"] = "severe"
         else:
             # An unreadable ``since_epoch`` typically means the OSF

--- a/docs/hardware/GPS_HAT_SETUP.md
+++ b/docs/hardware/GPS_HAT_SETUP.md
@@ -2,7 +2,7 @@
 
 EAS Station supports two NMEA-0183 GPS HATs out of the box:
 
-- **Uputronics Raspberry Pi GPS/RTC Expansion Board** *(recommended default)* — u-blox MAX-M8Q multi-GNSS receiver with PPS on **BCM 18**, battery-backed DS3231 RTC, and a low-profile stacking GPIO header.
+- **Uputronics Raspberry Pi GPS/RTC Expansion Board** *(recommended default)* — u-blox MAX-M8Q multi-GNSS receiver with PPS on **BCM 18**, battery-backed RTC (DS3231 on older revisions, RV-3028-C7 on current revisions), and a low-profile stacking GPIO header.
 - **Adafruit Ultimate GPS HAT (#2324)** *(legacy / alternative)* — MTK3339 GPS-only receiver with PPS on **BCM 4** and a tall non-stacking GPIO header.
 
 When enabled, the GPS module provides:
@@ -25,7 +25,7 @@ The Uputronics board solves two mechanical / electrical problems that the Adafru
 | OLED coexistence | Covers entire 40-pin header; PPS on BCM 4 (GPCLK0) crowds I²C OLED wiring | Stacking passthrough leaves I²C (BCM 2/3) free; PPS on BCM 18 |
 | GNSS constellations | GPS only (MTK3339, 22 channels) | GPS + GLONASS + Galileo + BeiDou concurrent (u-blox MAX-M8Q, 72 channels) |
 | Sensitivity / TTFF | −165 dBm tracking, ~34 s cold TTFF | −167 dBm tracking, ~26 s cold TTFF |
-| Battery-backed RTC | None (coin cell only seeds GPS warm-start) | DS3231-SN (±2 ppm, I²C `0x68`) — accurate time at boot before GPS lock or NTP |
+| Battery-backed RTC | None (coin cell only seeds GPS warm-start) | DS3231-SN at I²C `0x68` (older boards) or RV-3028-C7 at I²C `0x52` (current boards) — both ±2 ppm, accurate time at boot before GPS lock or NTP |
 | Antenna bias | 3.0 V fixed, no detect | 3.3 V with short-/open-circuit detection |
 | Configuration tooling | Proprietary PMTK commands | u-blox u-center over USB-serial bridge or UART |
 
@@ -41,7 +41,7 @@ Multi-GNSS in particular is something `app_core/gps/gps_manager.py` already hand
 | Interface | UART via `/dev/serial0` | UART via `/dev/serial0` |
 | Default baud rate | 9600 | 9600 |
 | PPS output | **GPIO BCM 18** | **GPIO BCM 4** |
-| Hardware RTC | DS3231 on I²C `0x68` (battery-backed) | none |
+| Hardware RTC | DS3231 (`0x68`) or RV-3028-C7 (`0x52`), battery-backed | none |
 | Fix indicator LED | 1 Hz blink with fix | 1 Hz blink no fix; 15 s pulse with fix |
 | Supported NMEA sentences | GGA, RMC, GSA, GSV (multi-GNSS) | GGA, RMC, GSV (GPS only) |
 | Update rate | 1 Hz default (configurable) | 1 Hz default (configurable) |
@@ -99,22 +99,54 @@ sudo usermod -aG dialout eas-station
 pip install pyserial pynmea2
 ```
 
-### 4. (Uputronics only) Enable the on-board DS3231 RTC
+### 4. (Uputronics only) Enable the on-board RTC
 
-The Uputronics board exposes a battery-backed DS3231 at I²C address `0x68`. Linux already has a kernel driver for it, so no application code is required to seed the system clock at boot — just enable the overlay:
+The Uputronics board exposes a battery-backed RTC on the I²C bus. Linux ships kernel drivers for both variants, so no application code is required to seed the system clock at boot — just enable the matching overlay.
 
-```ini
-# /boot/config.txt  (or /boot/firmware/config.txt on newer Pi OS)
-dtparam=i2c_arm=on
-dtoverlay=i2c-rtc,ds3231
-```
-
-After rebooting, verify:
+**Identify your RTC chip first** so you pick the right overlay:
 
 ```bash
-ls /dev/rtc*           # should list /dev/rtc0
-sudo hwclock -r        # should print the RTC time
+sudo apt install -y i2c-tools
+sudo i2cdetect -y 1
 ```
+
+- An entry at address `68` → **DS3231** (older Uputronics revisions)
+- An entry at address `52` → **RV-3028-C7** (current Uputronics revisions)
+
+Then add the matching line to `/boot/firmware/config.txt` (or `/boot/config.txt` on older Pi OS):
+
+```ini
+# Common to both
+dtparam=i2c_arm=on
+
+# Pick ONE of these to match your board:
+dtoverlay=i2c-rtc,ds3231       # DS3231 at 0x68
+# dtoverlay=i2c-rtc,rv3028      # RV-3028-C7 at 0x52
+```
+
+Reboot, then verify the kernel registered the RTC:
+
+```bash
+ls /dev/rtc*                   # should list /dev/rtc0
+cat /sys/class/rtc/rtc0/name   # e.g. "rtc-ds3231 1-0068" or "rtc-rv3028 1-0052"
+```
+
+#### `hwclock` on Raspberry Pi OS Bookworm and newer
+
+On Raspberry Pi OS / Debian 12 (Bookworm) and later, `hwclock` was split out of `util-linux` into a separate package and is **not installed by default** on Pi OS Lite images. If `sudo hwclock -r` reports `command not found`, install:
+
+```bash
+sudo apt install -y util-linux-extra
+```
+
+Then read and write the RTC:
+
+```bash
+sudo hwclock -r        # read RTC time
+sudo hwclock -w        # write current system time to RTC (do this once after NTP/GPS sync)
+```
+
+You do not strictly need `hwclock` for boot-time time-of-day — the kernel `i2c-rtc` overlay already seeds the system clock from the RTC at boot via `rtc-hctosys`. `hwclock -w` is only needed to **save** the current system time back to the RTC after NTP or GPS gets a fix (and after replacing the coin cell).
 
 This gives the Pi correct timestamps the moment the kernel mounts the I²C bus, well before `gpsd`/`chrony` come up. Combined with PPS, the system clock is then disciplined to sub-millisecond precision after fix.
 
@@ -265,12 +297,12 @@ redis-cli GET gps:status | python3 -m json.tool
 If you previously configured EAS Station for the Adafruit #2324 and are swapping in the Uputronics board:
 
 1. Power off the Pi and replace the HAT.
-2. Edit `/boot/config.txt` (or `/boot/firmware/config.txt`):
+2. Edit `/boot/firmware/config.txt` (or `/boot/config.txt` on older Pi OS):
    - Change `dtoverlay=pps-gpio,gpiopin=4` to `dtoverlay=pps-gpio,gpiopin=18`.
-   - Add `dtoverlay=i2c-rtc,ds3231` to enable the DS3231 RTC.
+   - Add the RTC overlay matching your board — run `sudo i2cdetect -y 1` to check: `dtoverlay=i2c-rtc,ds3231` if `0x68` is present, or `dtoverlay=i2c-rtc,rv3028` if `0x52` is present.
 3. Reboot. Verify `/dev/pps0` and `/dev/rtc0` both exist.
 4. In **Admin → Hardware Settings → GPS**, change the **PPS GPIO Pin** from `4` to `18` and **Save Settings**.
-5. (Optional) Run `sudo hwclock -w` once after a confirmed NTP/GPS sync to seed the DS3231 from system time.
+5. (Optional) On Pi OS Bookworm or newer, install `hwclock` if missing (`sudo apt install -y util-linux-extra`), then run `sudo hwclock -w` once after a confirmed NTP/GPS sync to seed the RTC from system time.
 
 No application data needs to be rebuilt; the GPS manager and chrony pick up the new pin/overlay on next start.
 
@@ -305,11 +337,34 @@ No application data needs to be rebuilt; the GPS manager and chrony pick up the 
 - PPS requires an active NMEA fix (the `lock GPS` directive). Run `cgps -s` to confirm gpsd has a fix before expecting PPS to be selected.
 - Check chrony sources: `chronyc sources -v`
 
-### DS3231 RTC not detected (Uputronics only)
+### RTC not detected (Uputronics only)
 
 - Confirm I²C is enabled: `sudo raspi-config` → **Interface Options → I2C → Yes**.
-- Confirm the device responds: `sudo i2cdetect -y 1` should show `68` on the bus.
-- Confirm the overlay is loaded: `dmesg | grep rtc`.
+- Confirm the device responds: `sudo i2cdetect -y 1`. You should see `68` (DS3231) **or** `52` (RV-3028-C7) on the bus, depending on board revision.
+- Confirm the overlay is loaded for the chip you actually have: `dmesg | grep rtc`. The expected lines are `rtc-ds3231 1-0068: registered as rtc0` or `rtc-rv3028 1-0052: registered as rtc0`. If they don't match, fix the `dtoverlay=i2c-rtc,...` line in `/boot/firmware/config.txt` and reboot.
+
+### `hwclock: command not found`
+
+On Raspberry Pi OS / Debian 12 (Bookworm) and newer, `hwclock` was moved to the `util-linux-extra` package, which is not preinstalled on Pi OS Lite. Install it:
+
+```bash
+sudo apt install -y util-linux-extra
+hwclock --version    # confirm it's now on PATH
+```
+
+Note that you generally do **not** need `hwclock` for the system clock to be correct at boot — the kernel `i2c-rtc` overlay already seeds time-of-day from the RTC via `rtc-hctosys` before userspace starts. `hwclock -w` is only required to push the *current* system time back to the RTC after NTP/GPS sync, or after replacing an exhausted coin cell.
+
+### Hardware Clock card shows "Drift vs system: Unknown" or large drift after a power cycle
+
+The driver could not read a sane epoch from the RTC. The two common causes are:
+
+1. **Backup coin cell is exhausted** — the chip lost time entirely (the RV-3028 / DS3231 sets its Power-On Reset / Oscillator Stop flag in this case). Replace the CR1225 (Uputronics) coin cell, then once the Pi has a confirmed NTP or GPS fix run:
+   ```bash
+   sudo apt install -y util-linux-extra   # only if hwclock is missing
+   sudo hwclock -w                        # write system time → RTC
+   sudo hwclock -r                        # confirm RTC reads back the same time
+   ```
+2. **Wrong overlay loaded** — e.g. `i2c-rtc,ds3231` selected but the board is actually an RV-3028. The kernel will still register *something* on rtc0 but reads come back as zero. Fix per the detection steps above.
 
 ---
 

--- a/docs/hardware/GPS_HAT_SETUP.md
+++ b/docs/hardware/GPS_HAT_SETUP.md
@@ -366,6 +366,36 @@ The driver could not read a sane epoch from the RTC. The two common causes are:
    ```
 2. **Wrong overlay loaded** — e.g. `i2c-rtc,ds3231` selected but the board is actually an RV-3028. The kernel will still register *something* on rtc0 but reads come back as zero. Fix per the detection steps above.
 
+### `hwclock -r` fails with `RTC_RD_TIME ... Invalid argument` (RV-3028 only)
+
+Symptom — typically seen on a brand-new board, after a long unpowered storage period, or after replacing the coin cell:
+
+```
+hwclock: ioctl(RTC_RD_TIME) to /dev/rtc0 to read the time failed: Invalid argument
+...synchronization failed
+```
+
+(The earlier `ioctl(4, RTC_UIE_ON, 0): Invalid argument` line in `-v` output is unrelated — the RV-3028 simply does not implement the update-interrupt; hwclock automatically falls back to polling.)
+
+This is **not** an I²C wiring or overlay problem. The Linux `rv3028` driver returns `-EINVAL` from `RTC_RD_TIME` whenever the chip's status register has the **PORF** (Power-On Reset Flag) bit set — its way of signalling "the time I have is unreliable, do not use it." PORF latches on whenever the RV-3028 has lost both VDD and the backup coin cell, and is only cleared by *writing* a new time.
+
+**Resolution:** write the RTC (this clears PORF in the same operation), do not read it first.
+
+```bash
+# 1. Confirm system time is actually correct
+timedatectl                 # look for "System clock synchronized: yes"
+chronyc tracking            # or check that the offset is small
+
+# 2. Write current system time to the RTC (clears PORF)
+sudo hwclock -w
+
+# 3. Reads should now succeed
+sudo hwclock -r
+cat /sys/class/rtc/rtc0/since_epoch
+```
+
+If PORF re-appears after the next power cycle, the backup coin cell is exhausted — replace it (CR1225 on the Uputronics board) and run `sudo hwclock -w` once more.
+
 ---
 
 ## Hardware Documentation

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -1973,6 +1973,8 @@
                                             {% endif %}
                                             {% if rtc.get('is_ds3231') %}
                                                 <span class="badge bg-info ms-1">DS3231</span>
+                                            {% elif rtc.get('is_rv3028') %}
+                                                <span class="badge bg-info ms-1">RV-3028</span>
                                             {% endif %}
                                             {% if rtc.get('is_battery_backed') %}
                                                 <span class="badge bg-success ms-1" title="Battery-backed"><i class="fas fa-battery-three-quarters me-1"></i>Battery-backed</span>
@@ -2017,7 +2019,9 @@
                                         <i class="fas fa-exclamation-triangle me-1 text-warning"></i>
                                         Large drift after a power cycle usually means the RTC backup battery is
                                         exhausted. Replace the coin cell, then run <code>sudo hwclock -w</code>
-                                        once after the system clock is synced.
+                                        once after the system clock is synced. On Pi OS Bookworm or newer,
+                                        <code>hwclock</code> ships in a separate package — install it with
+                                        <code>sudo apt install util-linux-extra</code> if the command is not found.
                                     </p>
                                     {% endif %}
                                 </div>
@@ -4035,13 +4039,18 @@
 
             const device = rtc.device || '/dev/rtc0';
             const nameSuffix = rtc.name ? `<span class="ms-1 text-muted small">(${escapeHtml(rtc.name)})</span>` : '';
-            const ds3231Badge = rtc.is_ds3231 ? '<span class="badge bg-info ms-1">DS3231</span>' : '';
+            let chipBadge = '';
+            if (rtc.is_ds3231) {
+                chipBadge = '<span class="badge bg-info ms-1">DS3231</span>';
+            } else if (rtc.is_rv3028) {
+                chipBadge = '<span class="badge bg-info ms-1">RV-3028</span>';
+            }
             const batteryBadge = rtc.is_battery_backed
                 ? '<span class="badge bg-success ms-1" title="Battery-backed"><i class="fas fa-battery-three-quarters me-1"></i>Battery-backed</span>'
                 : '';
             setHtml('rtc-h-device-row',
                 `<div class="metric-row"><span class="metric-label">Device:</span>
-                    <span class="metric-value"><code>${escapeHtml(device)}</code>${nameSuffix}${ds3231Badge}${batteryBadge}</span></div>`);
+                    <span class="metric-value"><code>${escapeHtml(device)}</code>${nameSuffix}${chipBadge}${batteryBadge}</span></div>`);
 
             setHtml('rtc-h-time-row', rtc.rtc_time_iso
                 ? `<div class="metric-row"><span class="metric-label">RTC UTC:</span>
@@ -4067,7 +4076,9 @@
                             <i class="fas fa-exclamation-triangle me-1 text-warning"></i>
                             Large drift after a power cycle usually means the RTC backup battery is
                             exhausted. Replace the coin cell, then run <code>sudo hwclock -w</code>
-                            once after the system clock is synced.
+                            once after the system clock is synced. On Pi OS Bookworm or newer,
+                            <code>hwclock</code> ships in a separate package — install it with
+                            <code>sudo apt install util-linux-extra</code> if the command is not found.
                        </p>`
                     : '');
         }


### PR DESCRIPTION
## Summary
Updated documentation and code to support both the DS3231 and RV-3028-C7 real-time clock chips found on different revisions of the Uputronics Raspberry Pi GPS/RTC Expansion Board. The RV-3028-C7 is used on current board revisions while older boards use the DS3231.

## Key Changes

**Documentation (`docs/hardware/GPS_HAT_SETUP.md`)**
- Updated hardware comparison table to clarify that Uputronics boards use either DS3231 (older) or RV-3028-C7 (current) at different I²C addresses
- Added RTC chip identification procedure using `i2cdetect` to help users determine which overlay to enable
- Expanded RTC setup instructions with separate overlay options for each chip variant
- Added troubleshooting section for RV-3028-specific issues (PORF flag handling, `hwclock` command availability on Bookworm)
- Clarified that `hwclock` is optional for boot-time synchronization but required to persist time changes to the RTC
- Updated migration guide for users switching from Adafruit to Uputronics boards

**Application Code (`app_utils/system.py`)**
- Enhanced `_collect_rtc_status()` to detect and report both DS3231 and RV-3028-C7 chips
- Added `is_rv3028` flag alongside existing `is_ds3231` flag for downstream UI differentiation
- Updated battery-backed detection logic to include RV-3028-C7
- Improved docstring to document support for both RTC variants

**UI Templates (`templates/system_health.html`)**
- Added RV-3028 badge display in Hardware Clock section (both static and dynamic rendering)
- Updated warning messages to mention both chip types and clarify `hwclock` availability on Pi OS Bookworm+
- Refactored chip badge logic to handle multiple variants cleanly

## Implementation Details

- Detection is automatic via kernel driver names reported in `/sys/class/rtc/rtc0/name`
- Users must manually select the correct overlay (`dtoverlay=i2c-rtc,ds3231` vs `dtoverlay=i2c-rtc,rv3028`) based on their board revision
- The RV-3028-C7 uses I²C address `0x52` while DS3231 uses `0x68`, allowing both to coexist on the same bus if needed
- Documentation includes workaround for RV-3028's PORF (Power-On Reset Flag) behavior which prevents reads until a write clears the flag

https://claude.ai/code/session_01TE5xrWRgjveFxBsXuP679p