### PR TITLE
Add GPS HAT diagnostic probe and admin UI panel

### DIFF
--- a/app_utils/gps_hat.py
+++ b/app_utils/gps_hat.py
@@ -1,0 +1,756 @@
+"""GPS HAT diagnostic probes.
+
+Inspects every prerequisite for a working GPS/RTC HAT setup on a
+Raspberry Pi running Pi OS — RTC chip vs overlay coherence, PPS device
+presence, gpsd / chrony / package state, ``/boot/firmware/config.txt``
+overlays, and the well-known failure modes we have seen in the field
+(RV-3028 PORF, baud-rate mismatch, ``hwclock`` missing on Bookworm,
+serial-port contention between gpsd and the EAS Station hardware
+service).
+
+This module is **read-only**. It runs as the unprivileged web service
+user and never invokes ``sudo``, ``apt``, or ``systemctl --change``.
+Any probe that needs root context (e.g. reading ``/etc/default/gpsd``
+which is world-readable, ``lsof`` of ``/dev/serial0`` which is not)
+is wrapped in a try/except and degrades to ``unknown`` on permission
+errors so the rest of the report still renders.
+
+The single public entry point is ``collect_gps_hat_diagnostics()``,
+which returns a JSON-serialisable dict that the admin UI consumes via
+``/api/admin/gps-hat/diagnostics`` (added in the API layer).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Knowledge base — what we expect on a healthy install. Keep flat and
+# documented so the UI can render the same constants without re-deriving.
+# ---------------------------------------------------------------------------
+
+# Boot config locations Pi OS uses; first existing path wins.
+_CONFIG_TXT_CANDIDATES: Tuple[str, ...] = (
+    "/boot/firmware/config.txt",  # Pi OS Bookworm and newer
+    "/boot/config.txt",           # Pi OS Bullseye and older
+)
+
+# Map of RTC kernel-driver names → human label, expected I²C address, and
+# the dtoverlay token that the user should have in config.txt.
+_RTC_CHIPS: Dict[str, Dict[str, str]] = {
+    "ds3231":  {"label": "DS3231",   "addr": "0x68", "overlay": "ds3231"},
+    "rv3028":  {"label": "RV-3028",  "addr": "0x52", "overlay": "rv3028"},
+    "ds1307":  {"label": "DS1307",   "addr": "0x68", "overlay": "ds1307"},
+    "pcf8523": {"label": "PCF8523",  "addr": "0x68", "overlay": "pcf8523"},
+    "pcf85063": {"label": "PCF85063", "addr": "0x51", "overlay": "pcf85063"},
+}
+
+# Packages we expect for the full GPS/PPS/chrony chain. Annotated so the UI
+# can decide which ones are required vs nice-to-have.
+_PACKAGES: Tuple[Tuple[str, str, bool], ...] = (
+    # (apt name, role, required-for-time-sync)
+    ("chrony",            "Time synchronization daemon",          True),
+    ("gpsd",              "GPS multiplexer",                      True),
+    ("gpsd-clients",      "cgps / gpspipe diagnostic tools",     False),
+    ("pps-tools",         "ppstest diagnostic command",          False),
+    ("util-linux-extra",  "hwclock command (Bookworm and newer)", True),
+    ("i2c-tools",         "i2cdetect for RTC verification",      False),
+)
+
+
+# ---------------------------------------------------------------------------
+# Tiny helpers
+# ---------------------------------------------------------------------------
+
+def _read(path: Path | str) -> Optional[str]:
+    try:
+        return Path(path).read_text().strip()
+    except Exception:
+        return None
+
+
+def _run(cmd: List[str], timeout: float = 3.0) -> Tuple[int, str, str]:
+    """Run a command, capturing stdout/stderr. Never raises."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.returncode, result.stdout or "", result.stderr or ""
+    except FileNotFoundError:
+        return 127, "", "command not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", "timeout"
+    except Exception as exc:
+        return -1, "", str(exc)
+
+
+def _which(cmd: str) -> Optional[str]:
+    return shutil.which(cmd)
+
+
+def _config_txt_path() -> Optional[str]:
+    for candidate in _CONFIG_TXT_CANDIDATES:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subsystem probes — each one returns a dict and never raises.
+# ---------------------------------------------------------------------------
+
+def _probe_rtc() -> Dict[str, Any]:
+    """Inspect /sys/class/rtc/rtc0 and detect chip + drift / PORF state."""
+    out: Dict[str, Any] = {
+        "device_present": False,
+        "kernel_name": None,
+        "detected_chip": None,
+        "chip_label": None,
+        "expected_addr": None,
+        "expected_overlay": None,
+        "is_battery_backed": False,
+        "porf_set": None,
+        "since_epoch": None,
+        "drift_seconds": None,
+        "drift_status": "unknown",
+    }
+    rtc_dir = Path("/sys/class/rtc/rtc0")
+    if not rtc_dir.exists():
+        return out
+    out["device_present"] = True
+
+    name = _read(rtc_dir / "name")
+    if name:
+        out["kernel_name"] = name
+        lowered = name.lower()
+        for chip_key, info in _RTC_CHIPS.items():
+            if chip_key in lowered:
+                out["detected_chip"] = chip_key
+                out["chip_label"] = info["label"]
+                out["expected_addr"] = info["addr"]
+                out["expected_overlay"] = f"i2c-rtc,{info['overlay']}"
+                out["is_battery_backed"] = True
+                break
+
+    # since_epoch is None / 0 / -EINVAL when the rv3028 driver refuses to
+    # return time because PORF is set. We treat any of those as "porf_set".
+    raw = _read(rtc_dir / "since_epoch")
+    try:
+        seconds = int(raw) if raw else 0
+    except ValueError:
+        seconds = 0
+
+    if seconds > 0:
+        out["since_epoch"] = seconds
+        out["porf_set"] = False
+        try:
+            drift = float(seconds) - datetime.now(timezone.utc).timestamp()
+            out["drift_seconds"] = round(drift, 3)
+            ad = abs(drift)
+            if ad < 2:
+                out["drift_status"] = "in_sync"
+            elif ad < 60:
+                out["drift_status"] = "minor"
+            elif ad < 3600:
+                out["drift_status"] = "moderate"
+            else:
+                out["drift_status"] = "severe"
+        except Exception:
+            out["drift_status"] = "unknown"
+    else:
+        # An rv3028 with PORF set has since_epoch of 0 / EINVAL; treat as PORF
+        # if we know the chip is one that latches that flag, otherwise just
+        # report "unreadable" without making a claim.
+        if out["detected_chip"] in ("rv3028", "ds3231"):
+            out["porf_set"] = True
+            out["drift_status"] = "unreadable"
+        else:
+            out["drift_status"] = "unreadable"
+
+    return out
+
+
+def _probe_i2c(expected_addr: Optional[str]) -> Dict[str, Any]:
+    """Run i2cdetect (if available) and parse seen addresses on bus 1."""
+    out: Dict[str, Any] = {
+        "tool_present": _which("i2cdetect") is not None,
+        "bus_scanned": False,
+        "addresses": [],
+        "rtc_address_match": None,
+    }
+    if not out["tool_present"]:
+        return out
+    rc, stdout, _ = _run(["i2cdetect", "-y", "1"], timeout=4.0)
+    if rc != 0:
+        return out
+    out["bus_scanned"] = True
+    addrs: List[str] = []
+    # i2cdetect output: rows like "60: -- -- 62 -- -- 65 -- -- -- -- -- -- -- -- -- --"
+    for line in stdout.splitlines():
+        m = re.match(r"^([0-9a-f]{2}):\s+(.*)$", line.strip(), re.IGNORECASE)
+        if not m:
+            continue
+        row_base = int(m.group(1), 16)
+        for col, cell in enumerate(m.group(2).split()):
+            cell = cell.strip()
+            if cell and cell.lower() != "--" and cell.lower() != "uu":
+                try:
+                    addr = int(cell, 16)
+                except ValueError:
+                    continue
+                addrs.append(f"0x{addr:02x}")
+        # row_base is just for parser clarity; cell value is the absolute addr
+        _ = row_base
+    out["addresses"] = sorted(set(addrs))
+    if expected_addr:
+        out["rtc_address_match"] = expected_addr.lower() in (a.lower() for a in out["addresses"])
+    return out
+
+
+def _probe_pps() -> Dict[str, Any]:
+    """Find /sys/class/pps/ppsX devices and classify GPIO vs line-discipline."""
+    out: Dict[str, Any] = {
+        "devices": [],
+        "gpio_device": None,
+        "ldisc_devices": [],
+        "ppstest_available": _which("ppstest") is not None,
+    }
+    base = Path("/sys/class/pps")
+    if not base.exists():
+        return out
+    for entry in sorted(base.iterdir()):
+        if not entry.name.startswith("pps"):
+            continue
+        info: Dict[str, Any] = {"name": entry.name, "path": str(entry)}
+        # Resolve device link to discriminate gpio vs line-discipline
+        try:
+            target = os.fspath((entry / "device").resolve())
+        except Exception:
+            target = ""
+        info["device_target"] = target
+        # last-known assert sequence (proves pulses are arriving)
+        assert_raw = _read(entry / "assert")
+        if assert_raw and "#" in assert_raw:
+            ts_part, _, seq_part = assert_raw.partition("#")
+            try:
+                info["assert_sequence"] = int(seq_part)
+            except ValueError:
+                info["assert_sequence"] = None
+            info["assert_raw"] = assert_raw
+        else:
+            info["assert_sequence"] = None
+        if "/tty/" in target or Path(target).name.startswith("tty"):
+            info["kind"] = "line_discipline"
+            out["ldisc_devices"].append(info)
+        else:
+            info["kind"] = "gpio"
+            if out["gpio_device"] is None:
+                out["gpio_device"] = info
+        out["devices"].append(info)
+    return out
+
+
+def _probe_serial(expected_baud: int = 9600) -> Dict[str, Any]:
+    """Look at /dev/serial0 → resolved tty, and try lsof for current owner."""
+    out: Dict[str, Any] = {
+        "device": "/dev/serial0",
+        "exists": False,
+        "resolved": None,
+        "owner": "unknown",
+        "expected_baud": expected_baud,
+    }
+    dev = Path("/dev/serial0")
+    if dev.exists():
+        out["exists"] = True
+        try:
+            out["resolved"] = os.fspath(dev.resolve())
+        except Exception:
+            out["resolved"] = None
+    # lsof is privileged for /dev/tty* — best-effort; users running this
+    # behind a unit with CAP_SYS_PTRACE may see results, otherwise None.
+    if _which("lsof"):
+        rc, stdout, _ = _run(["lsof", "-Fcp", "/dev/serial0"], timeout=2.0)
+        if rc == 0 and stdout.strip():
+            owners: List[str] = []
+            pid: Optional[str] = None
+            for line in stdout.splitlines():
+                if line.startswith("p"):
+                    pid = line[1:]
+                elif line.startswith("c") and pid:
+                    owners.append(f"{line[1:]} (pid {pid})")
+                    pid = None
+            if owners:
+                out["owner"] = ", ".join(owners)
+            else:
+                out["owner"] = "free"
+        elif rc == 0:
+            out["owner"] = "free"
+    return out
+
+
+def _probe_packages() -> Dict[str, Any]:
+    """Use dpkg-query for each well-known package."""
+    out: Dict[str, Any] = {"items": [], "missing_required": []}
+    have_dpkg = _which("dpkg-query") is not None
+    out["dpkg_available"] = have_dpkg
+    for name, role, required in _PACKAGES:
+        item = {"name": name, "role": role, "required": required, "installed": False, "version": None}
+        if have_dpkg:
+            rc, stdout, _ = _run(
+                ["dpkg-query", "-W", "-f=${Status}|${Version}", name], timeout=2.0
+            )
+            if rc == 0 and "install ok installed" in stdout:
+                item["installed"] = True
+                _, _, ver = stdout.partition("|")
+                item["version"] = ver.strip() or None
+        out["items"].append(item)
+        if required and not item["installed"]:
+            out["missing_required"].append(name)
+    return out
+
+
+def _probe_services() -> Dict[str, Any]:
+    """Query systemctl is-active / is-enabled for the relevant units."""
+    out: Dict[str, Any] = {"items": []}
+    units = ("chrony.service", "gpsd.service", "gpsd.socket")
+    for unit in units:
+        active = "unknown"
+        enabled = "unknown"
+        rc, stdout, _ = _run(["systemctl", "is-active", unit], timeout=2.0)
+        if rc in (0, 3):  # 0 active, 3 inactive — both authoritative
+            active = stdout.strip() or "unknown"
+        rc, stdout, _ = _run(["systemctl", "is-enabled", unit], timeout=2.0)
+        if rc in (0, 1):
+            enabled = stdout.strip() or "unknown"
+        out["items"].append({"unit": unit, "active": active, "enabled": enabled})
+    return out
+
+
+def _probe_gpsd_config() -> Dict[str, Any]:
+    """Parse /etc/default/gpsd."""
+    out: Dict[str, Any] = {
+        "path": "/etc/default/gpsd",
+        "exists": False,
+        "devices": None,
+        "options": None,
+        "has_n_flag": False,
+        "has_b_flag": False,
+        "baud_flag": None,
+    }
+    text = _read(out["path"])
+    if text is None:
+        return out
+    out["exists"] = True
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        val = val.strip().strip('"').strip("'")
+        if key.strip() == "DEVICES":
+            out["devices"] = val
+        elif key.strip() == "GPSD_OPTIONS":
+            out["options"] = val
+            tokens = val.split()
+            out["has_n_flag"] = "-n" in tokens
+            out["has_b_flag"] = "-b" in tokens
+            for i, tok in enumerate(tokens):
+                if tok == "-s" and i + 1 < len(tokens):
+                    try:
+                        out["baud_flag"] = int(tokens[i + 1])
+                    except ValueError:
+                        pass
+                elif tok.startswith("-s") and len(tok) > 2:
+                    try:
+                        out["baud_flag"] = int(tok[2:])
+                    except ValueError:
+                        pass
+    return out
+
+
+def _probe_chrony_config() -> Dict[str, Any]:
+    """Parse /etc/chrony/chrony.conf for rtcsync, PPS / SHM refclock, pool."""
+    out: Dict[str, Any] = {
+        "path": "/etc/chrony/chrony.conf",
+        "exists": False,
+        "rtcsync_enabled": False,
+        "has_pps_refclock": False,
+        "has_shm_refclock": False,
+        "pool_lines": [],
+    }
+    text = _read(out["path"])
+    if text is None:
+        return out
+    out["exists"] = True
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "rtcsync" or line.startswith("rtcsync "):
+            out["rtcsync_enabled"] = True
+        elif line.startswith("refclock"):
+            tokens = line.split()
+            if len(tokens) >= 2:
+                if tokens[1].upper() == "PPS":
+                    out["has_pps_refclock"] = True
+                elif tokens[1].upper() == "SHM":
+                    out["has_shm_refclock"] = True
+        elif line.startswith("pool ") or line.startswith("server "):
+            out["pool_lines"].append(line)
+    return out
+
+
+def _probe_chrony_runtime() -> Dict[str, Any]:
+    """Ask chronyc for the currently selected source, if chronyd is up."""
+    out: Dict[str, Any] = {
+        "tool_present": _which("chronyc") is not None,
+        "tracking_ok": False,
+        "selected_source": None,
+        "leap_status": None,
+        "last_offset_seconds": None,
+    }
+    if not out["tool_present"]:
+        return out
+    rc, stdout, _ = _run(["chronyc", "-c", "tracking"], timeout=2.0)
+    if rc != 0:
+        return out
+    out["tracking_ok"] = True
+    parts = [p.strip() for p in stdout.strip().split(",")]
+    # Format: ref_id_hex,ref_id_name,stratum,ref_time,system_time_offset, ...
+    if len(parts) >= 2:
+        out["selected_source"] = parts[1] or None
+    if len(parts) >= 5:
+        try:
+            out["last_offset_seconds"] = float(parts[4])
+        except ValueError:
+            pass
+    if len(parts) >= 14:
+        out["leap_status"] = parts[13] or None
+    return out
+
+
+def _probe_config_txt(rtc_overlay: Optional[str], expected_pps_pin: int) -> Dict[str, Any]:
+    """Parse the active /boot/firmware/config.txt for the relevant overlay lines."""
+    out: Dict[str, Any] = {
+        "path": _config_txt_path(),
+        "exists": False,
+        "i2c_arm_on": False,
+        "i2c_rtc_overlay_line": None,
+        "i2c_rtc_overlay_match": None,
+        "pps_gpio_overlay_line": None,
+        "pps_gpio_pin_in_config": None,
+        "pps_pin_match": None,
+    }
+    if not out["path"]:
+        return out
+    text = _read(out["path"])
+    if text is None:
+        return out
+    out["exists"] = True
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("dtparam=") and "i2c_arm=on" in line:
+            out["i2c_arm_on"] = True
+        if line.startswith("dtoverlay=i2c-rtc"):
+            out["i2c_rtc_overlay_line"] = line
+            if rtc_overlay:
+                out["i2c_rtc_overlay_match"] = rtc_overlay in line
+        if line.startswith("dtoverlay=pps-gpio"):
+            out["pps_gpio_overlay_line"] = line
+            m = re.search(r"gpiopin=(\d+)", line)
+            if m:
+                pin = int(m.group(1))
+                out["pps_gpio_pin_in_config"] = pin
+                out["pps_pin_match"] = pin == expected_pps_pin
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Action recommender — turn raw probe data into a checklist with shell
+# commands the user can copy-paste.
+# ---------------------------------------------------------------------------
+
+def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
+    actions: List[Dict[str, Any]] = []
+    rtc = report["rtc"]
+    pkg = report["packages"]
+    gpsd_cfg = report["gpsd_config"]
+    chrony_cfg = report["chrony_config"]
+    chrony_run = report["chrony_runtime"]
+    config_txt = report["config_txt"]
+    pps = report["pps"]
+    serial = report["serial"]
+    expected_baud = serial.get("expected_baud", 9600)
+
+    # 1. Missing packages
+    missing = [item for item in pkg["items"] if item["required"] and not item["installed"]]
+    if missing:
+        names = " ".join(item["name"] for item in missing)
+        actions.append({
+            "id": "install_packages",
+            "severity": "error",
+            "label": f"Install missing packages: {names}",
+            "reason": "Required packages are not installed; the time-sync chain cannot run without them.",
+            "command": f"sudo apt update && sudo apt install -y {names}",
+        })
+
+    # 2. RTC chip vs overlay mismatch
+    if rtc["detected_chip"] and rtc["expected_overlay"]:
+        actual_line = config_txt.get("i2c_rtc_overlay_line")
+        if not actual_line:
+            actions.append({
+                "id": "config_rtc_overlay",
+                "severity": "warning",
+                "label": f"Add {rtc['expected_overlay']} overlay to {config_txt['path']}",
+                "reason": f"Detected {rtc['chip_label']} RTC but no i2c-rtc overlay line is in config.txt.",
+                "command": f"echo 'dtoverlay={rtc['expected_overlay']}' | sudo tee -a {config_txt['path']}",
+                "requires_reboot": True,
+            })
+        elif config_txt.get("i2c_rtc_overlay_match") is False:
+            actions.append({
+                "id": "fix_rtc_overlay",
+                "severity": "warning",
+                "label": f"Replace RTC overlay with {rtc['expected_overlay']}",
+                "reason": f"Overlay in config.txt does not match the {rtc['chip_label']} chip detected on the bus.",
+                "command": (
+                    f"sudo sed -i 's|^dtoverlay=i2c-rtc.*|dtoverlay={rtc['expected_overlay']}|' "
+                    f"{config_txt['path']}"
+                ),
+                "requires_reboot": True,
+            })
+
+    # 3. RV-3028 / DS3231 PORF — needs hwclock -w after system clock is sane
+    if rtc.get("porf_set"):
+        actions.append({
+            "id": "seed_rtc",
+            "severity": "warning",
+            "label": "Seed RTC from system clock (clears PORF)",
+            "reason": (
+                f"{rtc.get('chip_label') or 'RTC'} reports power-on-reset flag set. "
+                "After the system clock is synchronized, write it back to the RTC to clear the flag."
+            ),
+            "command": "timedatectl && sudo hwclock -w && sudo hwclock -r",
+            "preconditions": ["System clock must be synchronized (chrony or NTP)."],
+        })
+
+    # 4. PPS overlay missing or wrong pin
+    if config_txt.get("pps_gpio_overlay_line") is None:
+        actions.append({
+            "id": "config_pps_overlay",
+            "severity": "info",
+            "label": "Add pps-gpio overlay to config.txt",
+            "reason": "PPS time discipline requires the pps-gpio kernel overlay.",
+            "command": f"echo 'dtoverlay=pps-gpio,gpiopin=18' | sudo tee -a {config_txt['path']}",
+            "requires_reboot": True,
+        })
+    elif config_txt.get("pps_pin_match") is False:
+        actions.append({
+            "id": "fix_pps_pin",
+            "severity": "warning",
+            "label": "PPS GPIO pin in config.txt does not match EAS Station settings",
+            "reason": (
+                f"config.txt has gpiopin={config_txt.get('pps_gpio_pin_in_config')}, "
+                "but EAS Station expects 18 (Uputronics) or 4 (Adafruit)."
+            ),
+            "command": "Edit the dtoverlay=pps-gpio line in config.txt to match your HAT.",
+        })
+
+    # 5. gpsd config — needs DEVICES + -n + correct baud
+    gpsd_installed = any(p["name"] == "gpsd" and p["installed"] for p in pkg["items"])
+    if gpsd_installed:
+        if not gpsd_cfg.get("exists"):
+            actions.append({
+                "id": "write_gpsd_default",
+                "severity": "warning",
+                "label": "Write /etc/default/gpsd",
+                "reason": "gpsd is installed but /etc/default/gpsd is missing.",
+                "command": (
+                    "sudo tee /etc/default/gpsd <<'EOF'\n"
+                    'DEVICES="/dev/serial0 /dev/pps0"\n'
+                    f'GPSD_OPTIONS="-n -b -s {expected_baud}"\n'
+                    'START_DAEMON="true"\n'
+                    'USBAUTO="false"\n'
+                    "EOF"
+                ),
+            })
+        else:
+            issues = []
+            if not gpsd_cfg.get("has_n_flag"):
+                issues.append("missing -n (gpsd will idle until clients connect)")
+            if gpsd_cfg.get("baud_flag") and gpsd_cfg["baud_flag"] != expected_baud:
+                issues.append(f"baud is {gpsd_cfg['baud_flag']} but the HAT runs at {expected_baud}")
+            if not gpsd_cfg.get("baud_flag"):
+                issues.append(f"no -s flag (will auto-detect; force -s {expected_baud})")
+            if issues:
+                actions.append({
+                    "id": "fix_gpsd_options",
+                    "severity": "warning",
+                    "label": "Fix GPSD_OPTIONS in /etc/default/gpsd",
+                    "reason": "; ".join(issues),
+                    "command": (
+                        f"sudo sed -i 's|^GPSD_OPTIONS=.*|GPSD_OPTIONS=\"-n -b -s {expected_baud}\"|' "
+                        "/etc/default/gpsd && sudo systemctl restart gpsd"
+                    ),
+                })
+
+    # 6. chrony refclock + rtcsync
+    if chrony_cfg.get("exists"):
+        if not chrony_cfg.get("rtcsync_enabled"):
+            actions.append({
+                "id": "enable_rtcsync",
+                "severity": "info",
+                "label": "Enable rtcsync in chrony.conf",
+                "reason": "Without rtcsync, the kernel will not periodically copy disciplined system time back to the RTC.",
+                "command": "echo 'rtcsync' | sudo tee -a /etc/chrony/chrony.conf && sudo systemctl restart chrony",
+            })
+        if pps.get("gpio_device") and not chrony_cfg.get("has_pps_refclock"):
+            actions.append({
+                "id": "add_pps_refclock",
+                "severity": "info",
+                "label": "Add PPS refclock to chrony.conf",
+                "reason": "PPS device is present but chrony is not configured to use it.",
+                "command": (
+                    "sudo tee -a /etc/chrony/chrony.conf <<'EOF'\n"
+                    "refclock SHM 0 refid GPS precision 1e-1 offset 0.0 delay 0.2 noselect\n"
+                    "refclock PPS /dev/pps0 lock GPS refid PPS\n"
+                    "EOF\n"
+                    "sudo systemctl restart chrony"
+                ),
+            })
+
+    # 7. chrony tracking — call it out if it's not running
+    if not chrony_run.get("tracking_ok"):
+        actions.append({
+            "id": "start_chrony",
+            "severity": "warning",
+            "label": "Start the chrony service",
+            "reason": "chronyc is not responding — system clock is not being disciplined.",
+            "command": "sudo systemctl enable --now chrony",
+        })
+
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def collect_gps_hat_diagnostics(
+    expected_pps_pin: int = 18,
+    expected_baud: int = 9600,
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, Any]:
+    """Top-level probe. Returns a JSON-serialisable diagnostic report.
+
+    Args:
+        expected_pps_pin: BCM pin EAS Station has configured for PPS
+            (passed in by the caller from settings).
+        expected_baud: Baud rate EAS Station has configured for the GPS
+            serial port (passed in by the caller from settings).
+        logger: Optional logger; defaults to module logger.
+    """
+    log = logger or _logger
+    report: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "expected_pps_pin": expected_pps_pin,
+        "expected_baud": expected_baud,
+    }
+
+    try:
+        report["rtc"] = _probe_rtc()
+    except Exception as exc:
+        log.debug("rtc probe failed: %s", exc)
+        report["rtc"] = {"error": str(exc)}
+
+    try:
+        report["i2c"] = _probe_i2c(
+            (report.get("rtc") or {}).get("expected_addr")
+        )
+    except Exception as exc:
+        log.debug("i2c probe failed: %s", exc)
+        report["i2c"] = {"error": str(exc)}
+
+    try:
+        report["pps"] = _probe_pps()
+    except Exception as exc:
+        log.debug("pps probe failed: %s", exc)
+        report["pps"] = {"error": str(exc)}
+
+    try:
+        report["serial"] = _probe_serial(expected_baud=expected_baud)
+    except Exception as exc:
+        log.debug("serial probe failed: %s", exc)
+        report["serial"] = {"error": str(exc)}
+
+    try:
+        report["packages"] = _probe_packages()
+    except Exception as exc:
+        log.debug("packages probe failed: %s", exc)
+        report["packages"] = {"error": str(exc), "items": [], "missing_required": []}
+
+    try:
+        report["services"] = _probe_services()
+    except Exception as exc:
+        log.debug("services probe failed: %s", exc)
+        report["services"] = {"error": str(exc), "items": []}
+
+    try:
+        report["gpsd_config"] = _probe_gpsd_config()
+    except Exception as exc:
+        log.debug("gpsd config probe failed: %s", exc)
+        report["gpsd_config"] = {"error": str(exc)}
+
+    try:
+        report["chrony_config"] = _probe_chrony_config()
+    except Exception as exc:
+        log.debug("chrony config probe failed: %s", exc)
+        report["chrony_config"] = {"error": str(exc)}
+
+    try:
+        report["chrony_runtime"] = _probe_chrony_runtime()
+    except Exception as exc:
+        log.debug("chrony runtime probe failed: %s", exc)
+        report["chrony_runtime"] = {"error": str(exc)}
+
+    try:
+        report["config_txt"] = _probe_config_txt(
+            (report.get("rtc") or {}).get("expected_overlay"),
+            expected_pps_pin,
+        )
+    except Exception as exc:
+        log.debug("config.txt probe failed: %s", exc)
+        report["config_txt"] = {"error": str(exc)}
+
+    try:
+        report["actions"] = _build_actions(report)
+    except Exception as exc:
+        log.debug("action builder failed: %s", exc)
+        report["actions"] = []
+
+    # Top-level summary the UI can render as a status badge.
+    actions = report["actions"]
+    if any(a["severity"] == "error" for a in actions):
+        report["status"] = "error"
+    elif any(a["severity"] == "warning" for a in actions):
+        report["status"] = "warning"
+    elif actions:
+        report["status"] = "info"
+    else:
+        report["status"] = "ok"
+    report["action_count"] = len(actions)
+    return report

--- a/templates/admin/hardware_settings.html
+++ b/templates/admin/hardware_settings.html
@@ -716,6 +716,37 @@
                         </div>
                     </div>
 
+                    <!-- ──────────────────────────────────────────────────
+                         GPS HAT diagnostic panel — read-only probe of every
+                         prerequisite (RTC chip, PPS device, packages, gpsd
+                         and chrony config). Populated from
+                         /admin/hardware/gps-hat/diagnostics.
+                         ────────────────────────────────────────────────── -->
+                    <div class="card mb-3" id="gps-hat-diag-card">
+                        <div class="card-body">
+                            <div class="d-flex align-items-center justify-content-between mb-2">
+                                <h5 class="card-title mb-0">
+                                    <i class="fas fa-stethoscope me-1"></i>
+                                    GPS HAT Setup Status
+                                    <span id="gps-hat-status-badge" class="badge bg-secondary ms-2">Checking…</span>
+                                </h5>
+                                <button type="button" class="btn btn-sm btn-outline-secondary" id="gps-hat-refresh-btn">
+                                    <i class="fas fa-rotate"></i> Recheck
+                                </button>
+                            </div>
+                            <p class="text-muted small mb-2" id="gps-hat-summary">
+                                Probes the operating system for every dependency the GPS HAT
+                                needs — kernel overlays, packages, services, and config files —
+                                and tells you exactly what to fix.
+                            </p>
+                            <div id="gps-hat-actions" class="mb-3"></div>
+                            <details>
+                                <summary class="text-muted small">Detected state</summary>
+                                <div id="gps-hat-detail" class="small mt-2"></div>
+                            </details>
+                        </div>
+                    </div>
+
                     <div class="card mb-3">
                         <div class="card-body">
                             <h5 class="card-title">Serial Connection</h5>
@@ -1463,5 +1494,212 @@ document.addEventListener('DOMContentLoaded', function() {
             });
     });
 });
+
+/* ── GPS HAT diagnostic panel ────────────────────────────────────────
+   Populates the "GPS HAT Setup Status" card by polling
+   /admin/hardware/gps-hat/diagnostics. Read-only — every action shown
+   to the user is just a copy-paste shell command for now. Tier 2 of
+   this work will add buttons that execute via a privileged helper.
+   ──────────────────────────────────────────────────────────────────── */
+(function () {
+    var BADGE_CLASS = {
+        ok:      'bg-success',
+        info:    'bg-info text-dark',
+        warning: 'bg-warning text-dark',
+        error:   'bg-danger',
+    };
+    var BADGE_TEXT = {
+        ok:      'All good',
+        info:    'Suggestions',
+        warning: 'Needs attention',
+        error:   'Action required',
+    };
+    var SEVERITY_CLASS = {
+        info:    'alert-info',
+        warning: 'alert-warning',
+        error:   'alert-danger',
+    };
+    var SEVERITY_ICON = {
+        info:    'fa-circle-info',
+        warning: 'fa-triangle-exclamation',
+        error:   'fa-circle-xmark',
+    };
+
+    function escapeHtml(s) {
+        if (s === null || s === undefined) return '';
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function renderActions(actions) {
+        if (!actions || !actions.length) {
+            return '<div class="alert alert-success py-2 mb-0 small">'
+                + '<i class="fas fa-check-circle me-1"></i> '
+                + 'Every prerequisite is in place. The GPS HAT, RTC, PPS, gpsd, and chrony all look healthy.'
+                + '</div>';
+        }
+        return actions.map(function (a) {
+            var sev = a.severity || 'info';
+            var alertCls = SEVERITY_CLASS[sev] || 'alert-secondary';
+            var icon = SEVERITY_ICON[sev] || 'fa-circle-info';
+            var preconditions = '';
+            if (a.preconditions && a.preconditions.length) {
+                preconditions = '<div class="small text-muted mt-1"><em>Before running: '
+                    + a.preconditions.map(escapeHtml).join('; ') + '</em></div>';
+            }
+            var rebootHint = a.requires_reboot
+                ? '<div class="small text-muted mt-1"><i class="fas fa-power-off me-1"></i>Requires reboot to take effect.</div>'
+                : '';
+            return '<div class="alert ' + alertCls + ' py-2 mb-2">'
+                +   '<div class="d-flex align-items-start">'
+                +     '<i class="fas ' + icon + ' me-2 mt-1"></i>'
+                +     '<div class="flex-grow-1">'
+                +       '<div class="fw-semibold">' + escapeHtml(a.label || a.id) + '</div>'
+                +       (a.reason ? '<div class="small">' + escapeHtml(a.reason) + '</div>' : '')
+                +       preconditions
+                +       (a.command
+                            ? '<pre class="mt-2 mb-0 small bg-dark text-light p-2 rounded" style="white-space:pre-wrap;"><code>'
+                                + escapeHtml(a.command) + '</code></pre>'
+                            : '')
+                +       rebootHint
+                +     '</div>'
+                +   '</div>'
+                + '</div>';
+        }).join('');
+    }
+
+    function renderDetail(report) {
+        var rtc = report.rtc || {};
+        var pps = report.pps || {};
+        var serial = report.serial || {};
+        var pkg  = report.packages || {};
+        var svc  = report.services || {};
+        var gcf  = report.gpsd_config || {};
+        var ccf  = report.chrony_config || {};
+        var crun = report.chrony_runtime || {};
+        var cfg  = report.config_txt || {};
+
+        function row(label, value, ok) {
+            var icon = ok === true
+                ? '<i class="fas fa-check-circle text-success me-1"></i>'
+                : ok === false
+                    ? '<i class="fas fa-circle-xmark text-danger me-1"></i>'
+                    : '<i class="fas fa-circle text-muted me-1" style="font-size:.5em;vertical-align:middle;"></i>';
+            return '<div>' + icon + '<strong>' + escapeHtml(label) + ':</strong> '
+                + (value === null || value === undefined ? '<em class="text-muted">unknown</em>' : escapeHtml(value))
+                + '</div>';
+        }
+        var rtcSummary = rtc.kernel_name
+            ? rtc.kernel_name + (rtc.chip_label ? ' (' + rtc.chip_label + ')' : '')
+            : (rtc.device_present ? 'present' : 'no /dev/rtc0');
+        var ppsSummary = pps.gpio_device
+            ? pps.gpio_device.name + ' seq=' + (pps.gpio_device.assert_sequence || 0)
+            : 'no pps-gpio device';
+        var serialSummary = serial.exists
+            ? (serial.resolved || serial.device) + ' — ' + serial.owner
+            : 'missing';
+        var pkgList = (pkg.items || []).map(function (i) {
+            return (i.installed ? '✅' : '❌') + ' ' + i.name + (i.version ? ' (' + i.version + ')' : '');
+        }).join('<br>') || '<em>dpkg-query unavailable</em>';
+        var svcList = (svc.items || []).map(function (i) {
+            return i.unit + ': ' + i.active + ' / ' + i.enabled;
+        }).join('<br>');
+        var gpsdSummary = gcf.exists
+            ? 'DEVICES=' + (gcf.devices || '?') + '; OPTIONS=' + (gcf.options || '?')
+            : '/etc/default/gpsd missing';
+        var chronySummary = ccf.exists
+            ? ('rtcsync=' + ccf.rtcsync_enabled
+                + '; PPS refclock=' + ccf.has_pps_refclock
+                + '; SHM refclock=' + ccf.has_shm_refclock
+                + '; sources=' + ((ccf.pool_lines || []).length))
+            : '/etc/chrony/chrony.conf missing';
+        var chronyRunSummary = crun.tracking_ok
+            ? ('source=' + (crun.selected_source || '?')
+                + '; offset=' + (crun.last_offset_seconds === null ? '?' : crun.last_offset_seconds + 's')
+                + '; leap=' + (crun.leap_status || '?'))
+            : 'chronyc unavailable';
+        var configSummary = cfg.exists
+            ? (cfg.path
+                + (cfg.i2c_rtc_overlay_line ? ' [' + cfg.i2c_rtc_overlay_line + ']' : '')
+                + (cfg.pps_gpio_overlay_line ? ' [' + cfg.pps_gpio_overlay_line + ']' : ''))
+            : 'config.txt not found';
+
+        return '<div class="row g-2">'
+            + '<div class="col-md-6">'
+            +   row('RTC',           rtcSummary,    rtc.device_present)
+            +   row('PPS',           ppsSummary,    !!pps.gpio_device)
+            +   row('Serial',        serialSummary, serial.exists)
+            +   row('config.txt',    configSummary, cfg.exists)
+            + '</div>'
+            + '<div class="col-md-6">'
+            +   row('Packages',      null,          (pkg.missing_required || []).length === 0)
+            +   '<div class="ms-3 small">' + pkgList + '</div>'
+            +   row('Services',      null,          null)
+            +   '<div class="ms-3 small">' + svcList + '</div>'
+            +   row('gpsd config',   gpsdSummary,   gcf.exists)
+            +   row('chrony config', chronySummary, ccf.exists)
+            +   row('chrony status', chronyRunSummary, crun.tracking_ok)
+            + '</div>'
+            + '</div>';
+    }
+
+    function refresh(button) {
+        var badge   = document.getElementById('gps-hat-status-badge');
+        var actions = document.getElementById('gps-hat-actions');
+        var detail  = document.getElementById('gps-hat-detail');
+        if (!badge || !actions || !detail) return;
+        badge.className = 'badge bg-secondary ms-2';
+        badge.textContent = 'Checking…';
+        if (button) {
+            button.disabled = true;
+            button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Checking';
+        }
+        fetch('/admin/hardware/gps-hat/diagnostics', {
+            credentials: 'same-origin',
+            headers: { 'Accept': 'application/json' },
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || !data.ok) {
+                    throw new Error((data && data.error) || 'unknown error');
+                }
+                var report = data.report;
+                var status = report.status || 'info';
+                badge.className = 'badge ms-2 ' + (BADGE_CLASS[status] || 'bg-secondary');
+                badge.textContent = BADGE_TEXT[status] || status;
+                actions.innerHTML = renderActions(report.actions || []);
+                detail.innerHTML = renderDetail(report);
+            })
+            .catch(function (err) {
+                badge.className = 'badge bg-danger ms-2';
+                badge.textContent = 'Probe failed';
+                actions.innerHTML = '<div class="alert alert-danger py-2 mb-0 small">'
+                    + '<i class="fas fa-circle-xmark me-1"></i> '
+                    + 'Diagnostic probe failed: ' + escapeHtml(String(err))
+                    + '</div>';
+                detail.innerHTML = '';
+            })
+            .finally(function () {
+                if (button) {
+                    button.disabled = false;
+                    button.innerHTML = '<i class="fas fa-rotate"></i> Recheck';
+                }
+            });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var card = document.getElementById('gps-hat-diag-card');
+        if (!card) return;
+        var btn = document.getElementById('gps-hat-refresh-btn');
+        if (btn) {
+            btn.addEventListener('click', function () { refresh(btn); });
+        }
+        refresh(null);
+    });
+})();
 </script>
 {% endblock %}

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -32,10 +32,12 @@ from werkzeug.exceptions import BadRequest
 from app_core.auth.roles import require_permission
 from app_core.extensions import db
 from app_core.hardware_settings import (
+    get_gps_settings,
     get_hardware_settings,
     update_hardware_settings,
     invalidate_hardware_settings_cache,
 )
+from app_utils.gps_hat import collect_gps_hat_diagnostics
 from app_utils.pi_pinout import ARGON_OLED_RESERVED_BCM
 
 logger = logging.getLogger(__name__)
@@ -62,6 +64,30 @@ def hardware_settings_page():
         logger.error(f"Failed to load hardware settings: {exc}")
         flash(f"Error loading hardware settings: {exc}", "error")
         return redirect(url_for('dashboard.admin'))
+
+
+@hardware_bp.route('/hardware/gps-hat/diagnostics', methods=['GET'])
+@require_permission('system.configure')
+def gps_hat_diagnostics():
+    """Read-only probe of every GPS HAT prerequisite — RTC chip vs overlay,
+    PPS device, gpsd / chrony / package state, ``/boot/firmware/config.txt``
+    overlays, and the well-known failure modes (RV-3028 PORF, baud
+    mismatch, ``hwclock`` missing on Bookworm, serial-port contention).
+
+    The response is consumed by the "GPS HAT" diagnostic panel in the
+    hardware settings UI. No state is modified.
+    """
+    try:
+        gps_settings = get_gps_settings() or {}
+        report = collect_gps_hat_diagnostics(
+            expected_pps_pin=int(gps_settings.get('pps_gpio_pin', 18) or 18),
+            expected_baud=int(gps_settings.get('baudrate', 9600) or 9600),
+            logger=logger,
+        )
+        return jsonify({"ok": True, "report": report})
+    except Exception as exc:
+        logger.exception("GPS HAT diagnostics probe failed")
+        return jsonify({"ok": False, "error": str(exc)}), 500
 
 
 @hardware_bp.route('/hardware/update', methods=['POST'])


### PR DESCRIPTION
## Summary
Adds a comprehensive, read-only diagnostic system for GPS/RTC HAT setup validation on Raspberry Pi. Includes a new `gps_hat.py` module that probes every prerequisite (RTC chip, PPS device, packages, services, kernel overlays, and config files), detects common failure modes, and recommends corrective actions. Integrates with the admin UI via a new diagnostic panel and API endpoint.

## Key Changes

- **New module: `app_utils/gps_hat.py`** (756 lines)
  - Comprehensive read-only diagnostic probes for GPS/RTC HAT prerequisites
  - Inspects RTC chip presence, I²C address, and drift/PORF state
  - Detects PPS devices (GPIO vs line-discipline) and validates pulse sequences
  - Validates package installation (chrony, gpsd, pps-tools, i2c-tools, util-linux-extra)
  - Parses `/etc/default/gpsd`, `/etc/chrony/chrony.conf`, and `/boot/firmware/config.txt`
  - Queries systemd service state and chrony runtime tracking
  - Builds actionable recommendations with shell commands for common issues
  - Handles permission errors gracefully (runs unprivileged, degrades to "unknown" on access denied)
  - Returns JSON-serializable diagnostic report with status badge and detailed state

- **Admin API endpoint: `/admin/hardware/gps-hat/diagnostics`**
  - GET-only endpoint requiring `system.configure` permission
  - Calls `collect_gps_hat_diagnostics()` with EAS Station's configured PPS pin and baud rate
  - Returns JSON with probe results, detected issues, and recommended actions

- **Admin UI panel: "GPS HAT Setup Status"**
  - New card in hardware settings page with status badge (ok/info/warning/error)
  - Displays actionable recommendations with copy-paste shell commands
  - Shows detailed detected state (RTC, PPS, packages, services, configs) in collapsible section
  - "Recheck" button to refresh diagnostics without page reload
  - Graceful error handling for probe failures

## Notable Implementation Details

- **Knowledge base constants** kept flat and documented so UI can render without re-deriving
- **Subsystem probes** are isolated functions that never raise exceptions; failures degrade to partial results
- **Action recommender** (`_build_actions()`) turns raw probe data into prioritized, user-friendly recommendations
- **RTC PORF detection** specifically handles RV-3028 and DS3231 power-on-reset flag edge cases
- **Config file parsing** handles both Bookworm (`/boot/firmware/config.txt`) and Bullseye (`/boot/config.txt`) paths
- **Privilege-aware**: reads world-readable files directly; wraps privileged operations (lsof, /etc/default/gpsd) in try/except
- **UI rendering** includes HTML escaping, icon mapping, and collapsible details for advanced users

https://claude.ai/code/session_01TE5xrWRgjveFxBsXuP679p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPS HAT diagnostic reporting to admin hardware settings, enabling verification of GPS/RTC HAT setup status.
  * Provides automated recommendations for resolving detected configuration issues with suggested corrective commands and reboot guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2051)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->