### PR TITLE
fix(gps-hat): kill spurious "unknown" rows + show stratum

### DIFF
--- a/app_utils/gps_hat.py
+++ b/app_utils/gps_hat.py
@@ -419,8 +419,12 @@ def _probe_chrony_runtime() -> Dict[str, Any]:
         "tool_present": _which("chronyc") is not None,
         "tracking_ok": False,
         "selected_source": None,
+        "stratum": None,
         "leap_status": None,
+        "system_time_offset_seconds": None,
         "last_offset_seconds": None,
+        "root_dispersion_seconds": None,
+        "sources": [],
     }
     if not out["tool_present"]:
         return out
@@ -429,16 +433,67 @@ def _probe_chrony_runtime() -> Dict[str, Any]:
         return out
     out["tracking_ok"] = True
     parts = [p.strip() for p in stdout.strip().split(",")]
-    # Format: ref_id_hex,ref_id_name,stratum,ref_time,system_time_offset, ...
+    # chronyc -c tracking format (chrony ≥4.x):
+    #   0:ref_id_hex 1:ref_id_name 2:stratum 3:ref_time
+    #   4:system_time_offset 5:last_offset 6:rms_offset 7:frequency
+    #   8:residual_freq 9:skew 10:root_delay 11:root_dispersion
+    #   12:update_interval 13:leap_status
     if len(parts) >= 2:
         out["selected_source"] = parts[1] or None
+    if len(parts) >= 3:
+        try:
+            out["stratum"] = int(parts[2])
+        except ValueError:
+            pass
     if len(parts) >= 5:
         try:
+            out["system_time_offset_seconds"] = float(parts[4])
+            # Keep last_offset_seconds for backwards compatibility — older
+            # callers expected this name. New callers should prefer the
+            # named field above.
             out["last_offset_seconds"] = float(parts[4])
+        except ValueError:
+            pass
+    if len(parts) >= 12:
+        try:
+            out["root_dispersion_seconds"] = float(parts[11])
         except ValueError:
             pass
     if len(parts) >= 14:
         out["leap_status"] = parts[13] or None
+
+    # Source table: useful for surfacing GPS / PPS Reach=0 (the classic
+    # port-contention symptom).
+    rc2, stdout2, _ = _run(["chronyc", "-c", "sources"], timeout=2.0)
+    if rc2 == 0 and stdout2.strip():
+        sources: List[Dict[str, Any]] = []
+        # CSV format (chrony ≥4.x):
+        #   M,S,Name,Stratum,Poll,Reach,LastRx,LastSample,...
+        for raw in stdout2.strip().splitlines():
+            cols = [c.strip() for c in raw.split(",")]
+            if len(cols) < 6:
+                continue
+            try:
+                reach_octal = int(cols[5])
+            except ValueError:
+                reach_octal = None
+            sources.append({
+                "mode": cols[0],
+                "state": cols[1],
+                "name": cols[2],
+                "stratum": int(cols[3]) if cols[3].isdigit() else None,
+                "reach": reach_octal,
+                "last_rx_seconds": int(cols[6]) if len(cols) > 6 and cols[6].lstrip("-").isdigit() else None,
+            })
+        out["sources"] = sources
+        # Convenient flag: any refclock (M="#") that's stuck at reach=0
+        # almost always means the source isn't actually getting samples
+        # — for this codebase that's the gpsd-can't-read-serial-port
+        # symptom, called out in the action recommender below.
+        out["refclocks_unreached"] = [
+            s["name"] for s in sources
+            if s.get("mode") == "#" and s.get("reach") == 0
+        ]
     return out
 
 
@@ -767,6 +822,47 @@ def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "button_label": "Enable + start",
             },
         })
+
+    # 8. GPS/PPS refclocks configured but never reaching chrony. This is
+    #    the port-contention symptom: gpsd is configured for /dev/serial0
+    #    (which resolves to /dev/ttyAMAN on Pi 5) but EAS Station's
+    #    hardware service has the same port open. gpsd never gets NMEA,
+    #    SHM 0 stays empty, the `lock GPS` constraint on PPS never fires,
+    #    and chrony falls back to internet NTP at stratum ≥ 2. There is
+    #    no one-click fix yet — properly resolving it needs Tier 3
+    #    (gpsd-as-NMEA-source mode in gps_manager.py).
+    unreached = chrony_run.get("refclocks_unreached") or []
+    if unreached and serial.get("exists"):
+        # Only surface when chrony itself is otherwise healthy — if chrony
+        # isn't tracking yet there are bigger fish to fry.
+        if chrony_run.get("tracking_ok"):
+            current_stratum = chrony_run.get("stratum")
+            stratum_note = (
+                f" (currently stratum {current_stratum} via internet NTP)"
+                if current_stratum is not None else ""
+            )
+            actions.append({
+                "id": "refclocks_unreached",
+                "severity": "info",
+                "label": (
+                    "GPS / PPS refclocks aren't reaching chrony "
+                    + stratum_note
+                ),
+                "reason": (
+                    f"chrony has the {' / '.join(unreached)} refclock(s) configured "
+                    "but Reach=0 — no samples have ever arrived. The most common "
+                    "cause is gpsd not being able to open the GPS serial port "
+                    "because EAS Station's hardware service holds it. Until the "
+                    "gpsd-as-NMEA-source feature lands, the workaround is to "
+                    "uncheck 'Enable GPS Receiver' under Admin → Hardware "
+                    "Settings → GPS, save, and let gpsd own the port. You'll "
+                    "lose the live GPS card but gain stratum-1 PPS time."
+                ),
+                "command": (
+                    "# Check who owns the serial port:\n"
+                    "sudo lsof /dev/ttyAMA10 /dev/ttyAMA0 /dev/serial0 2>/dev/null"
+                ),
+            })
 
     return actions
 

--- a/templates/admin/hardware_settings.html
+++ b/templates/admin/hardware_settings.html
@@ -1638,13 +1638,37 @@ document.addEventListener('DOMContentLoaded', function() {
         var ppsSummary = pps.gpio_device
             ? pps.gpio_device.name + ' seq=' + (pps.gpio_device.assert_sequence || 0)
             : 'no pps-gpio device';
+        // Serial owner detection requires lsof + privileges the web service
+        // user doesn't have, so we suppress the "— unknown" suffix when the
+        // probe couldn't see it. Showing the resolved device path is enough
+        // for the operator to recognise.
         var serialSummary = serial.exists
-            ? (serial.resolved || serial.device) + ' — ' + serial.owner
+            ? (serial.resolved || serial.device)
+                + (serial.owner && serial.owner !== 'unknown'
+                    ? ' — ' + serial.owner
+                    : '')
             : 'missing';
-        var pkgList = (pkg.items || []).map(function (i) {
+        var pkgItems = pkg.items || [];
+        var pkgInstalled = pkgItems.filter(function (i) { return i.installed; }).length;
+        var pkgMissingRequired = (pkg.missing_required || []).length;
+        var pkgSummary = pkgItems.length === 0
+            ? 'dpkg-query unavailable'
+            : pkgMissingRequired === 0
+                ? pkgInstalled + ' / ' + pkgItems.length + ' installed'
+                : pkgMissingRequired + ' required missing';
+        var pkgList = pkgItems.map(function (i) {
             return (i.installed ? '✅' : '❌') + ' ' + i.name + (i.version ? ' (' + i.version + ')' : '');
         }).join('<br>') || '<em>dpkg-query unavailable</em>';
-        var svcList = (svc.items || []).map(function (i) {
+        var svcItems = svc.items || [];
+        var svcAllActive = svcItems.length > 0
+            && svcItems.every(function (i) { return i.active === 'active'; });
+        var svcSummary = svcItems.length === 0
+            ? 'systemctl unavailable'
+            : svcAllActive
+                ? 'all units active'
+                : svcItems.filter(function (i) { return i.active !== 'active'; }).length
+                    + ' / ' + svcItems.length + ' inactive';
+        var svcList = svcItems.map(function (i) {
             return i.unit + ': ' + i.active + ' / ' + i.enabled;
         }).join('<br>');
         var gpsdSummary = gcf.exists
@@ -1656,11 +1680,27 @@ document.addEventListener('DOMContentLoaded', function() {
                 + '; SHM refclock=' + ccf.has_shm_refclock
                 + '; sources=' + ((ccf.pool_lines || []).length))
             : '/etc/chrony/chrony.conf missing';
-        var chronyRunSummary = crun.tracking_ok
-            ? ('source=' + (crun.selected_source || '?')
-                + '; offset=' + (crun.last_offset_seconds === null ? '?' : crun.last_offset_seconds + 's')
-                + '; leap=' + (crun.leap_status || '?'))
-            : 'chronyc unavailable';
+        // Stratum is the headline number an operator wants to see — surface
+        // it prominently. Also flag any refclocks at Reach=0 so the user
+        // sees why they're not yet at stratum 1.
+        var chronyParts = [];
+        if (crun.tracking_ok) {
+            if (crun.stratum != null) chronyParts.push('stratum ' + crun.stratum);
+            if (crun.selected_source) chronyParts.push('source=' + crun.selected_source);
+            var offsetSrc = (crun.system_time_offset_seconds != null)
+                ? crun.system_time_offset_seconds
+                : crun.last_offset_seconds;
+            if (offsetSrc != null) {
+                chronyParts.push('offset=' + (Number(offsetSrc) * 1000).toFixed(3) + 'ms');
+            }
+            if (crun.leap_status) chronyParts.push('leap=' + crun.leap_status);
+            if ((crun.refclocks_unreached || []).length) {
+                chronyParts.push('refclocks unreached: ' + crun.refclocks_unreached.join(', '));
+            }
+        } else {
+            chronyParts.push('chronyc unavailable');
+        }
+        var chronyRunSummary = chronyParts.join('; ');
         var configSummary = cfg.exists
             ? (cfg.path
                 + (cfg.i2c_rtc_overlay_line ? ' [' + cfg.i2c_rtc_overlay_line + ']' : '')
@@ -1675,9 +1715,9 @@ document.addEventListener('DOMContentLoaded', function() {
             +   row('config.txt',    configSummary, cfg.exists)
             + '</div>'
             + '<div class="col-md-6">'
-            +   row('Packages',      null,          (pkg.missing_required || []).length === 0)
+            +   row('Packages',      pkgSummary,    pkgMissingRequired === 0 && pkgItems.length > 0)
             +   '<div class="ms-3 small">' + pkgList + '</div>'
-            +   row('Services',      null,          null)
+            +   row('Services',      svcSummary,    svcItems.length > 0 ? svcAllActive : null)
             +   '<div class="ms-3 small">' + svcList + '</div>'
             +   row('gpsd config',   gpsdSummary,   gcf.exists)
             +   row('chrony config', chronySummary, ccf.exists)


### PR DESCRIPTION
Three fixes in renderDetail() called out from the live install:

1. "Serial: /dev/ttyAMA10 — unknown" The owner suffix came from a privileged lsof(8) probe in the backend. The web service runs unprivileged as eas-station, so lsof of /dev/serial0 / /dev/ttyAMAN can never succeed there — the owner was perpetually "unknown". Suppress the suffix entirely when owner is missing or "unknown"; show just the resolved device path, which is actually informative.

2. "Packages: unknown" / "Services: unknown" I was passing null as the row value to keep the label clean while rendering the package/service list separately on the next line. The shared row() helper renders "unknown" for null values, so the labels read as if the probe failed even when every package and service was healthy. Replace with a computed inline summary: "6 / 6 installed" when all required packages are present "N required missing" otherwise "all units active" when every systemctl unit is active "N / M inactive" when any unit isn't active The detailed list still appears below as before.

3. chrony status row didn't show stratum. Added stratum extraction from `chronyc -c tracking` (CSV field [2]) plus a sources probe (`chronyc -c sources`) that builds a `refclocks_unreached` list — refclocks configured in chrony.conf with Reach=0 (the symptom of the gpsd port-contention issue). The chrony status row now reads "stratum 2; source=ntp3.torix.ca; offset=0.194ms; leap=Normal; refclocks unreached: GPS, PPS" when applicable.

Also surface the "GPS / PPS refclocks aren't reaching chrony" condition as an info-severity action card in the diagnostic panel, explaining that this is the gpsd-vs-EAS-Station port contention and that the resolution (uncheck Enable GPS Receiver, save) is in the GPS form above. No runner — the "real" fix is Tier 3 (gpsd-as-NMEA-source mode in gps_manager.py) which is still deferred.

The diagnostic backend also now includes:
  chrony_runtime.stratum                 (int or None)
  chrony_runtime.system_time_offset_seconds
  chrony_runtime.root_dispersion_seconds
  chrony_runtime.sources                 (parsed `chronyc -c sources`)
  chrony_runtime.refclocks_unreached     (refclocks at Reach=0)