### PR TITLE
Enable memory diagnostics for EAS station service

### DIFF
--- a/systemd/eas-station-hardware.service
+++ b/systemd/eas-station-hardware.service
@@ -17,6 +17,13 @@ Environment="PATH=/opt/eas-station/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/
 Environment="PYTHONPATH=/opt/eas-station"
 # Pi 5 requires lgpio for GPIO access - prevents gpiozero auto-detection hangs
 Environment="GPIOZERO_PIN_FACTORY=lgpio"
+# Memory diagnostics — capture allocator tracebacks so SIGUSR1 produces
+# a useful top-N list. Tracemalloc has non-trivial overhead, so leave
+# it off once the leak is identified and a fix has shipped.
+# Dumps land in MEMDIAG_DUMP_DIR; we override the /tmp default because
+# PrivateTmp=true below would hide /tmp dumps from a normal shell.
+Environment="MEMDIAG_TRACEMALLOC=1"
+Environment="MEMDIAG_DUMP_DIR=/var/log/eas-station"
 EnvironmentFile=/opt/eas-station/.env
 
 # Logging to systemd journal


### PR DESCRIPTION
## Summary
Added memory diagnostics configuration to the EAS station systemd service to help identify and track memory leaks during development and debugging.

## Key Changes
- Enabled `MEMDIAG_TRACEMALLOC=1` to capture allocator tracebacks, allowing SIGUSR1 signals to produce useful memory allocation reports
- Configured `MEMDIAG_DUMP_DIR=/var/log/eas-station` to store memory diagnostic dumps outside of `/tmp`, ensuring they persist and remain accessible despite the service's `PrivateTmp=true` setting
- Added detailed comments explaining the purpose of memory diagnostics, the performance overhead of tracemalloc, and the rationale for the custom dump directory

## Implementation Details
The memory diagnostics feature is intentionally left as a development/debugging tool with the expectation that it will be disabled once any identified memory leaks are fixed and deployed, due to the non-trivial performance overhead of tracemalloc.

https://claude.ai/code/session_01NxCYX5afkzpJsjqfyYYf4C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced hardware service configuration to enable memory diagnostics capabilities, with diagnostic output directed to the system log directory for collection and analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2064)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->