### PR TITLE
Cut hardware-service CPU + RSS hot paths

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -221,6 +221,16 @@ class GPSManager:
         # Set by _handle_sentence (under _lock), cleared and acted on by _reader_loop
         self._pending_time_sync: Optional[datetime] = None
 
+        # Throttle for _publish_current_fix(): without this we serialize+
+        # SETEX the full fix dict on every NMEA sentence (≈10 Hz on a typical
+        # multi-constellation receiver). At ~3 KiB JSON per write that was
+        # the dominant CPU consumer in this process. Consumers (UI, trend
+        # sampler) only refresh at 1–5 s anyway, so 1 Hz is more than
+        # enough — but we still publish immediately on lifecycle events
+        # (start/stop/reconnect) by passing force=True.
+        self._last_publish_mono: float = 0.0
+        self._publish_min_interval_s: float = 1.0
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -795,10 +805,23 @@ class GPSManager:
         # Publish to Redis after releasing lock
         self._publish_current_fix()
 
-    def _publish_current_fix(self) -> None:
-        """Write the current fix dict to Redis."""
+    def _publish_current_fix(self, force: bool = False) -> None:
+        """Write the current fix dict to Redis.
+
+        Throttled to at most ``self._publish_min_interval_s`` (1 s by
+        default) — see ``_last_publish_mono`` in __init__ for rationale.
+        Pass ``force=True`` for lifecycle events (start, stop, reconnect)
+        where the UI should see the new state immediately.
+        """
         if not self._redis:
             return
+        if not force:
+            now_mono = time.monotonic()
+            if now_mono - self._last_publish_mono < self._publish_min_interval_s:
+                return
+            self._last_publish_mono = now_mono
+        else:
+            self._last_publish_mono = time.monotonic()
         try:
             with self._lock:
                 data = dict(self._fix)
@@ -845,7 +868,7 @@ class GPSManager:
             self._fix["status"] = "running"
             self._fix["running"] = True
             self._fix["source"] = "gpsd"
-        self._publish_current_fix()
+        self._publish_current_fix(force=True)
 
         buf = b""
         while self._running:
@@ -884,6 +907,19 @@ class GPSManager:
                 backoff = min(backoff * 2, 30.0)
                 continue
             buf += chunk
+            # Defensive cap: gpsd events are bounded (a few KiB at most),
+            # so anything past 1 MiB without a newline indicates the
+            # other end is misbehaving (or we're being fed garbage). Drop
+            # the buffer rather than letting it grow without bound — this
+            # is one of the few code paths in the hot loop that *could*
+            # leak Python heap if the peer never delimited messages.
+            if len(buf) > 1_048_576:
+                self._logger.warning(
+                    "gpsd: %d bytes buffered without newline; resetting",
+                    len(buf),
+                )
+                buf = b""
+                continue
             while b"\n" in buf:
                 line, _, buf = buf.partition(b"\n")
                 if not line.strip():
@@ -904,7 +940,7 @@ class GPSManager:
         with self._lock:
             self._fix["status"] = "stopped"
             self._fix["running"] = False
-        self._publish_current_fix()
+        self._publish_current_fix(force=True)
 
     def _record_recent_sentence(self, line: str) -> None:
         """Append a raw line to the rolling buffer the UI shows. Threadsafe."""

--- a/app_utils/memdiag.py
+++ b/app_utils/memdiag.py
@@ -178,8 +178,18 @@ def _write_tracemalloc_section(fh) -> None:
     current, peak = tracemalloc.get_traced_memory()
     fh.write(f"tracemalloc.current: {_format_bytes(current)}\n")
     fh.write(f"tracemalloc.peak   : {_format_bytes(peak)}\n\n")
+    # Flush before the (potentially expensive) statistics pass so the
+    # header survives even if statistics() runs out of memory or the
+    # service is OOM-killed mid-dump (the original bug that produced
+    # 367-byte stub dumps).
+    try:
+        fh.flush()
+    except Exception:
+        pass
 
     # 1) Top by file:line — best for spotting hot allocation sites.
+    #    Each entry is written + flushed individually so a partial dump
+    #    is still useful when the process dies mid-loop.
     fh.write(f"--- top {_TRACEMALLOC_TOP_N} allocators by file:line ---\n")
     try:
         stats = snapshot.statistics("lineno")
@@ -187,12 +197,31 @@ def _write_tracemalloc_section(fh) -> None:
         fh.write(f"  (failed to compute lineno stats: {exc})\n")
         stats = []
     for i, stat in enumerate(stats[:_TRACEMALLOC_TOP_N], 1):
-        fh.write(f"#{i:>2}  {_format_bytes(stat.size)}  count={stat.count}  {stat.traceback}\n")
+        try:
+            fh.write(f"#{i:>2}  {_format_bytes(stat.size)}  count={stat.count}  {stat.traceback}\n")
+            fh.flush()
+        except Exception as exc:
+            fh.write(f"  (entry #{i} write failed: {exc})\n")
+            break
 
     fh.write("\n")
+    try:
+        fh.flush()
+    except Exception:
+        pass
 
-    # 2) Top by full traceback — best for deduplicating leaks that share
-    #    a low-level allocation but came from different call paths.
+    # 2) Top by full traceback — opt-in via MEMDIAG_TRACEMALLOC_TRACEBACKS=1.
+    #    With high allocation counts this section is the one that hangs /
+    #    OOMs the dump (it walks every captured traceback), so we skip it
+    #    by default. Set MEMDIAG_TRACEMALLOC_FRAMES>1 *and* the env var
+    #    to opt back in once the by-lineno top has narrowed the suspect.
+    if not _env_bool("MEMDIAG_TRACEMALLOC_TRACEBACKS", default=False):
+        fh.write(
+            "--- top allocators by full traceback (skipped) ---\n"
+            "  Set MEMDIAG_TRACEMALLOC_TRACEBACKS=1 (and frames>1) to enable.\n"
+        )
+        return
+
     fh.write(f"--- top {_TRACEMALLOC_TOP_N} allocators by traceback ---\n")
     try:
         stats = snapshot.statistics("traceback")
@@ -200,10 +229,15 @@ def _write_tracemalloc_section(fh) -> None:
         fh.write(f"  (failed to compute traceback stats: {exc})\n")
         stats = []
     for i, stat in enumerate(stats[:_TRACEMALLOC_TOP_N], 1):
-        fh.write(f"#{i:>2} {_format_bytes(stat.size)}  count={stat.count}\n")
-        for line in stat.traceback.format():
-            fh.write(f"    {line}\n")
-        fh.write("\n")
+        try:
+            fh.write(f"#{i:>2} {_format_bytes(stat.size)}  count={stat.count}\n")
+            for line in stat.traceback.format():
+                fh.write(f"    {line}\n")
+            fh.write("\n")
+            fh.flush()
+        except Exception as exc:
+            fh.write(f"  (entry #{i} write failed: {exc})\n")
+            break
 
 
 def write_memory_dump(reason: str = "manual") -> Optional[str]:
@@ -341,10 +375,15 @@ def install_memdiag_handlers(
         enable_tracemalloc = _env_bool("MEMDIAG_TRACEMALLOC", default=False)
 
     if tracemalloc_frames is None:
+        # Default to 1 frame: just enough to populate the by-lineno top.
+        # 10-frame stacks (the previous default) bloated tracemalloc's
+        # internal storage to the point where statistics("lineno") could
+        # OOM on a leaking process — the very situation the dump is
+        # supposed to diagnose.
         try:
-            tracemalloc_frames = int(os.environ.get("MEMDIAG_TRACEMALLOC_FRAMES", "10"))
+            tracemalloc_frames = int(os.environ.get("MEMDIAG_TRACEMALLOC_FRAMES", "1"))
         except ValueError:
-            tracemalloc_frames = 10
+            tracemalloc_frames = 1
     tracemalloc_frames = max(1, tracemalloc_frames)
 
     if enable_tracemalloc:

--- a/systemd/eas-station-hardware.service
+++ b/systemd/eas-station-hardware.service
@@ -24,6 +24,21 @@ Environment="GPIOZERO_PIN_FACTORY=lgpio"
 # PrivateTmp=true below would hide /tmp dumps from a normal shell.
 Environment="MEMDIAG_TRACEMALLOC=1"
 Environment="MEMDIAG_DUMP_DIR=/var/log/eas-station"
+# glibc malloc tuning. Multi-threaded Python services on glibc default
+# to one malloc arena per CPU thread (= 8 on a Pi 5), and each arena
+# holds onto freed memory in a per-thread free-list rather than
+# returning it to the kernel. Combined with NMEA reader / gpsd reader /
+# screen manager / Flask API / health-check threads all allocating and
+# freeing small objects in a hot loop, the result is RSS that grows to
+# multiples of the actual live working set. The first SIGUSR1 dump on
+# this branch confirmed Python heap = 580 MiB while RSS = 3.05 GiB —
+# i.e. ~2.5 GiB lives in glibc arenas, not Python objects.
+#   * MALLOC_ARENA_MAX=2 caps arena count to 2 (forces sharing).
+#   * MALLOC_TRIM_THRESHOLD_=131072 lowers the threshold at which
+#     glibc returns top-of-heap memory to the kernel (default is 128 KiB
+#     dynamically tuned upward; pinning it low keeps RSS honest).
+Environment="MALLOC_ARENA_MAX=2"
+Environment="MALLOC_TRIM_THRESHOLD_=131072"
 EnvironmentFile=/opt/eas-station/.env
 
 # Logging to systemd journal


### PR DESCRIPTION
Three problems diagnosed from the first SIGUSR1 dump (RSS 3.05 GiB, tracemalloc.peak 580 MiB — i.e. ~2.5 GiB of the leak lives outside the Python heap, in glibc arenas + native extensions):

* Cap glibc malloc arenas via the systemd unit (MALLOC_ARENA_MAX=2, MALLOC_TRIM_THRESHOLD_=131072). Multi-threaded Python on glibc defaults to one arena per CPU, none of which return memory to the kernel. This single change typically reclaims 50–80% of RSS in services with the per-thread allocation pattern this one has (NMEA reader / gpsd reader / PPS poller / screen manager / Flask API / health-check loop all touching small objects in tight loops).

* Throttle GPSManager._publish_current_fix() to ≥1 Hz. It was firing on every NMEA sentence (~10 Hz on a multi-constellation receiver), doing dict copy + json.dumps + Redis SETEX each time. Lifecycle events (start/reconnect/stop) still publish immediately via force=True so the UI sees state transitions without delay.

* Cap the gpsd reader's recv buffer at 1 MiB. A misbehaving peer that never delimits messages would otherwise grow the buffer without bound — the one Python-heap leak path in the hot loop.

Also harden memdiag itself: the previous SIGUSR1 produced a 367-byte stub because statistics("lineno") OOM'd or hung mid-write with 10-frame stacks captured for ~9.4M live objects. Drop default frames to 1, write each top-N entry with explicit flush, and gate the (much more expensive) by-traceback section behind MEMDIAG_TRACEMALLOC_TRACEBACKS=1.