### PR TITLE
Throttle screen_manager._update_rotations to 1 Hz

### DIFF
--- a/scripts/screen_manager.py
+++ b/scripts/screen_manager.py
@@ -178,6 +178,14 @@ class ScreenManager:
         self._active_alert_cache: List[Dict[str, Any]] = []
         self._active_alert_cache_timestamp = datetime.min
         self._active_alert_cache_ttl = timedelta(seconds=1)
+        # _update_rotations runs three SQLAlchemy queries; without this
+        # throttle it fires on every _run_loop tick (60 Hz = 180 queries/s),
+        # which manifests as a slow heap leak in the long-lived hardware
+        # service (each query allocates Connection / RowProxy / ORM
+        # objects that the identity map only releases on session close).
+        # Rotation configs change infrequently — once per second is plenty.
+        self._last_rotation_refresh_mono: float = 0.0
+        self._rotation_refresh_interval_s: float = 1.0
 
     def init_app(self, app: Flask):
         """Initialize with Flask app context.
@@ -239,7 +247,16 @@ class ScreenManager:
                 time.sleep(sleep_time)
 
     def _update_rotations(self):
-        """Load active screen rotations from database."""
+        """Load active screen rotations from database.
+
+        Throttled to ``self._rotation_refresh_interval_s`` (1 s) — see
+        ``_last_rotation_refresh_mono`` in __init__ for rationale.
+        """
+        now_mono = time.monotonic()
+        if now_mono - self._last_rotation_refresh_mono < self._rotation_refresh_interval_s:
+            return
+        self._last_rotation_refresh_mono = now_mono
+
         try:
             from app_core.models import ScreenRotation
 


### PR DESCRIPTION
Was firing on every _run_loop tick — 60 FPS × 3 SQLAlchemy queries = 180 queries/s. Each query allocates Connection / RowProxy / ORM instances that the identity map only releases on session close, which matches the residual ~1.5 MB/min RSS growth observed on the live host after MALLOC_ARENA_MAX=2 cleared the bulk of the leak. Rotation configs change infrequently — 1 Hz is plenty, and the cached rotation dicts continue to drive the 60 FPS render cycle (scroll animations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized screen rotation configuration refresh to reduce system load and improve responsiveness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2067)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->