### PR TITLE
Add PPS jitter, Allan deviation, and holdover monitoring to GPS dashboard

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -58,6 +58,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional, Set, Tuple
 
+from . import ubx
+
 # ---------------------------------------------------------------------------
 # clock_settime(2) helpers — used by _apply_system_time to set CLOCK_REALTIME
 # directly without sudo.  The systemd unit grants CAP_SYS_TIME via
@@ -221,6 +223,23 @@ class GPSManager:
         # we're still steering chrony from the host clock.
         self._last_3d_fix_at: Optional[datetime] = None
 
+        # UBX poll cadence (seconds).  30 s is well below the ~100 ms
+        # NMEA cycle the dashboard reads at, so the antenna and leap
+        # tiles stay fresh, but it's also low enough that we don't add
+        # measurable load to a 9600-baud serial link (a single MON-HW
+        # response is ~70 bytes including the frame).  Set to 0 to
+        # disable; we'll honour that for tests and for gpsd mode where
+        # we can't share the receiver.
+        self._ubx_poll_interval_s: float = 30.0
+        # Monotonic timestamp of the last poll *attempt* (whether or
+        # not the receiver replied) — set in the reader loop so the
+        # cadence stays steady even when the response is slow.
+        self._ubx_last_poll_mono: float = 0.0
+        # Read-side accumulator for the byte-level demuxer.  The
+        # serial reader appends raw bytes here and pulls completed
+        # frames off the front via ubx.find_frame() / NMEA scan.
+        self._ubx_buf: bytearray = bytearray()
+
         # Recent raw NMEA sentences (protected by _lock).  Sized for ~20s of
         # traffic on a multi-GNSS receiver so the UI's filter/pause UX has
         # something to scroll through.
@@ -335,6 +354,12 @@ class GPSManager:
             return False
         self._gpsd_sock = sock
         self._active_source = "gpsd"
+        # In gpsd mode we don't own the serial port and can't send UBX
+        # polls.  Mark the supported flag explicitly so the dashboard
+        # tile renders an informative "via gpsd" placeholder rather
+        # than spinning on "polling…" forever.
+        with self._lock:
+            self._fix["ubx_poll_supported"] = False
         self._running = True
         self._thread = threading.Thread(
             target=self._gpsd_reader_loop,
@@ -684,18 +709,26 @@ class GPSManager:
     def _derive_leap_state(fix: Dict[str, Any]) -> str:
         """Best-effort leap-second annunciator from current fix state.
 
-        Until the UBX-NAV-TIMELS poll lands in Phase 2 we don't have an
-        authoritative source from the receiver itself — chrony's
-        ``leap_status`` (parsed elsewhere) is what the dashboard tile
-        actually displays.  This helper returns a coarse string so the
-        tile has a fallback when chrony is unavailable.
+        Resolution order:
+
+        1. ``UBX-NAV-TIMELS`` (Phase 2) — when ``leap_pending`` is True
+           the receiver knows about a scheduled insert/delete and we
+           surface it directly.  When it's False but ``leap_seconds`` is
+           populated, the receiver has confirmed "no event imminent"
+           and we render that as "normal".
+        2. ``has_fix`` — without UBX data, hold "normal" while we have
+           a fix so the tile isn't permanently grey.
+        3. Otherwise "unknown".
         """
+        leap_seconds = fix.get("leap_seconds")
+        leap_pending = fix.get("leap_pending")
+        if leap_pending:
+            change = fix.get("leap_change") or 0
+            return "insert_pending" if change > 0 else "delete_pending"
+        if leap_seconds is not None:
+            return "normal"
         if not fix.get("has_fix"):
             return "unknown"
-        # No NMEA standard field carries the leap-second alert; the
-        # u-blox proprietary RMC navigation-status field is too vendor-
-        # specific to rely on here.  Return "normal" while we hold a
-        # fix and let chrony override.
         return "normal"
 
     # ------------------------------------------------------------------
@@ -750,10 +783,49 @@ class GPSManager:
             "sentence_errors": 0,
             # Raw NMEA sentences (populated separately, not stored in _fix)
             "recent_sentences": [],
+            # UBX-MON-HW telemetry (Phase 2).  All None until the first
+            # successful MON-HW response is parsed; the dashboard
+            # renders "—" / "polling" when unset.
+            "antenna_status": None,         # init|unknown|ok|short|open
+            "antenna_power": None,          # off|on|unknown
+            "jamming_state": None,          # unknown|ok|warning|critical
+            "noise_level": None,            # raw 16-bit "noise per ms"
+            "agc_count": None,              # raw 16-bit AGC count
+            "ubx_last_poll_at": None,       # ISO timestamp of last reply
+            "ubx_poll_supported": None,     # True after first reply,
+                                            # False after timeout or
+                                            # explicit "skip in gpsd"
+            # UBX-NAV-TIMELS telemetry — authoritative leap-second
+            # state from the receiver (overrides chrony's leap_status
+            # on the dashboard when present).
+            "leap_seconds": None,
+            "leap_source": None,
+            "leap_pending": None,
+            "leap_seconds_to_event": None,
+            "leap_event_gps_week": None,
+            "leap_event_gps_dow": None,
         }
 
     def _reader_loop(self) -> None:
-        """Main NMEA reader loop — runs in background thread."""
+        """Main reader loop — demuxes NMEA + UBX from the serial stream.
+
+        The loop pulls raw bytes (rather than line-buffered text) so it
+        can interleave UBX poll responses with NMEA sentences.  A small
+        state machine in ``_drain_buffer()`` extracts whichever message
+        type comes off the front of ``self._ubx_buf`` next:
+
+        * Bytes leading up to ``$`` are treated as NMEA (terminated by
+          ``\\n``) and dispatched to :py:meth:`_handle_sentence`.
+        * Bytes leading with the ``B5 62`` sync pair are framed as UBX
+          and dispatched to :py:meth:`_handle_ubx`.
+        * Anything else is junk; we drop a single byte and retry so a
+          stray binary byte can't desync the parser permanently.
+
+        Periodically (every ``self._ubx_poll_interval_s``) we write a
+        ``UBX-MON-HW`` and a ``UBX-NAV-TIMELS`` poll request; the
+        receiver's responses come back through the same stream and are
+        captured by the demuxer.
+        """
         try:
             import pynmea2  # type: ignore[import]
         except ImportError:
@@ -770,44 +842,49 @@ class GPSManager:
             self._fix["status"] = "reading"
 
         consecutive_errors = 0
+        # Cap the buffer so a malicious / corrupted stream can't OOM
+        # the service.  16 KiB is ~17 s of 9600-baud traffic — anything
+        # larger means we're not draining and we're better off dropping.
+        MAX_BUF = 16 * 1024
 
         while self._running:
             try:
                 if not self._ser or not self._ser.is_open:
                     break
 
-                raw = self._ser.readline()
-                if not raw:
-                    continue
+                # Pull whatever's currently in the kernel buffer.  read(1)
+                # blocks for up to the serial timeout (2 s, set in
+                # _start_serial_only); follow it with an in_waiting drain
+                # so a burst of bytes is consumed in a single syscall
+                # batch instead of one byte per readline iteration.
+                chunk = self._ser.read(1)
+                if chunk:
+                    waiting = getattr(self._ser, "in_waiting", 0)
+                    if waiting:
+                        chunk += self._ser.read(waiting)
+                    self._ubx_buf.extend(chunk)
+                    if len(self._ubx_buf) > MAX_BUF:
+                        # Drop the oldest half rather than the whole
+                        # buffer so a partial NMEA or UBX frame at the
+                        # tail still has a chance of completing.
+                        del self._ubx_buf[: len(self._ubx_buf) // 2]
 
-                line = raw.decode("ascii", errors="replace").strip()
-                if not line.startswith("$"):
-                    continue
+                # Drain whatever framed messages are now available.
+                self._drain_buffer(pynmea2)
 
-                # Store raw sentence for UI display
-                with self._lock:
-                    self._recent_sentences.append(line)
-
-                consecutive_errors = 0
-
-                try:
-                    msg = pynmea2.parse(line)
-                except pynmea2.ParseError:
-                    # pynmea2 validates the NMEA checksum during parse; this
-                    # branch is a useful health signal for noisy UART wiring.
-                    with self._lock:
-                        self._fix["sentence_errors"] = (
-                            self._fix.get("sentence_errors", 0) + 1
-                        )
-                    continue
-
-                self._handle_sentence(msg)
+                # Send the next UBX poll if it's due.  Writes are
+                # independent of reads, so there's no risk of stalling
+                # the NMEA stream.
+                self._maybe_send_ubx_polls()
 
                 # Apply system time if a sync was queued (outside lock)
                 if self._pending_time_sync is not None:
                     pending = self._pending_time_sync
                     self._pending_time_sync = None
                     self._apply_system_time(pending)
+
+                if chunk:
+                    consecutive_errors = 0
 
             except Exception as exc:
                 consecutive_errors += 1
@@ -824,6 +901,135 @@ class GPSManager:
             self._fix["status"] = "stopped"
         self._publish_status("stopped")
         self._logger.info("GPS reader loop exited")
+
+    def _drain_buffer(self, pynmea2_mod) -> None:
+        """Pull complete NMEA lines and UBX frames off ``self._ubx_buf``.
+
+        Runs in the reader thread.  Each iteration looks at the first
+        byte: ``$`` starts an NMEA sentence (terminated by ``\\n``);
+        ``0xB5`` is the first UBX sync byte (followed by ``0x62``).
+        Anything else is dropped one byte at a time so the parser can
+        re-sync on the next valid header.
+        """
+        buf = self._ubx_buf
+        while buf:
+            head = buf[0]
+            if head == ord("$"):
+                # NMEA: find the terminating \n.  If none yet, we need
+                # more bytes — leave the partial line in the buffer.
+                nl = buf.find(b"\n")
+                if nl < 0:
+                    return
+                line_bytes = bytes(buf[:nl]).rstrip(b"\r")
+                del buf[: nl + 1]
+                try:
+                    line = line_bytes.decode("ascii", errors="replace").strip()
+                except Exception:
+                    continue
+                if not line.startswith("$"):
+                    continue
+                with self._lock:
+                    self._recent_sentences.append(line)
+                try:
+                    msg = pynmea2_mod.parse(line)
+                except pynmea2_mod.ParseError:
+                    with self._lock:
+                        self._fix["sentence_errors"] = (
+                            self._fix.get("sentence_errors", 0) + 1
+                        )
+                    continue
+                self._handle_sentence(msg)
+            elif head == ubx.UBX_SYNC_1:
+                # UBX: try to extract a complete frame.  None means we
+                # need more bytes (the frame isn't fully arrived yet) —
+                # break and let the next read top up the buffer.
+                # Note that find_frame() consumes any leading garbage
+                # AND the frame itself when successful, so we don't
+                # need to del[] here.
+                if len(buf) < 2:
+                    return
+                if buf[1] != ubx.UBX_SYNC_2:
+                    # False sync — drop the lone B5 and keep scanning.
+                    del buf[0]
+                    continue
+                result = ubx.find_frame(buf)
+                if result is None:
+                    return
+                _leading, cls, mid, payload = result
+                self._handle_ubx(cls, mid, payload)
+            else:
+                # Stray byte — drop it and re-evaluate.  Common after a
+                # partial UBX frame whose checksum failed: find_frame
+                # leaves the remainder of the discarded frame in the
+                # buffer for us to skip past.
+                del buf[0]
+
+    def _maybe_send_ubx_polls(self) -> None:
+        """Issue MON-HW + NAV-TIMELS polls when the cadence elapses.
+
+        Called from the reader thread only.  Writes are best-effort: a
+        failed write is logged at debug and the next attempt happens
+        on schedule.  ``ubx_poll_supported`` is set to True the first
+        time we get a reply (see :py:meth:`_handle_ubx`); until then
+        the dashboard tile shows "polling…" instead of "—".
+        """
+        if self._ubx_poll_interval_s <= 0:
+            return
+        if self._active_source != "serial":
+            # gpsd owns the port in gpsd mode; we'd have to teach
+            # gpsd to forward our writes which is a much bigger
+            # rabbit hole (Phase 3 territory).  Surface that we're
+            # not polling so the UI tile can explain why.
+            with self._lock:
+                self._fix["ubx_poll_supported"] = False
+            return
+        if not self._ser or not self._ser.is_open:
+            return
+
+        now = time.monotonic()
+        if now - self._ubx_last_poll_mono < self._ubx_poll_interval_s:
+            return
+        self._ubx_last_poll_mono = now
+        try:
+            self._ser.write(ubx.POLL_MON_HW)
+            self._ser.write(ubx.POLL_NAV_TIMELS)
+            try:
+                self._ser.flush()
+            except Exception:
+                pass
+        except Exception as exc:
+            self._logger.debug("UBX poll write failed: %s", exc)
+
+    def _handle_ubx(self, class_id: int, msg_id: int, payload: bytes) -> None:
+        """Decode a UBX response and merge it into the live fix dict.
+
+        Unknown class/id combinations are silently ignored — receivers
+        will sometimes emit other UBX messages we never asked for
+        (e.g. ``UBX-NAV-PVT`` if a previous session enabled it via
+        ``CFG-MSG``), and we don't want those to look like errors.
+        """
+        try:
+            if class_id == ubx.CLASS_MON and msg_id == ubx.ID_MON_HW:
+                fields = ubx.parse_mon_hw(payload)
+            elif class_id == ubx.CLASS_NAV and msg_id == ubx.ID_NAV_TIMELS:
+                fields = ubx.parse_nav_timels(payload)
+            else:
+                return
+        except Exception as exc:
+            self._logger.debug(
+                "UBX parse error for class=0x%02X id=0x%02X: %s",
+                class_id, msg_id, exc,
+            )
+            return
+        if not fields:
+            return
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            for key, value in fields.items():
+                self._fix[key] = value
+            self._fix["ubx_last_poll_at"] = now_iso
+            self._fix["ubx_poll_supported"] = True
 
     def _handle_sentence(self, msg) -> None:
         """Update internal fix state from a parsed NMEA sentence."""

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -47,6 +47,7 @@ import ctypes
 import ctypes.util
 import json
 import logging
+import math
 import os
 import socket
 import subprocess
@@ -55,7 +56,7 @@ import time
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Deque, Dict, Optional, Set
+from typing import Any, Deque, Dict, List, Optional, Set, Tuple
 
 # ---------------------------------------------------------------------------
 # clock_settime(2) helpers — used by _apply_system_time to set CLOCK_REALTIME
@@ -208,6 +209,17 @@ class GPSManager:
         self._pps_kernel_device: Optional[str] = None  # e.g. "/sys/class/pps/pps0"
         self._pps_kernel_baseline_seq: Optional[int] = None
         self._pps_kernel_thread: Optional[threading.Thread] = None
+
+        # Inter-pulse intervals in nanoseconds, captured from the kernel
+        # PPS device's nanosecond-precision assert timestamp. Used by
+        # get_status() to derive a jitter histogram and overlapping Allan
+        # deviation at τ = 1/10/100 s. Capacity sized for ~17 minutes of
+        # 1 Hz pulses, which is more than enough for ADEV at τ=100s.
+        self._pps_interval_ns: Deque[int] = deque(maxlen=1024)
+        # Captured at last 3D fix (from GSA fix_mode==3) so the dashboard
+        # can compute a holdover timer when the receiver loses lock but
+        # we're still steering chrony from the host clock.
+        self._last_3d_fix_at: Optional[datetime] = None
 
         # Recent raw NMEA sentences (protected by _lock).  Sized for ~20s of
         # traffic on a multi-GNSS receiver so the UI's filter/pause UX has
@@ -434,22 +446,257 @@ class GPSManager:
         self._logger.info("GPS reader stopped")
 
     def get_status(self) -> Dict[str, Any]:
-        """Return the most-recently parsed GPS fix as a dictionary."""
+        """Return the most-recently parsed GPS fix as a dictionary.
+
+        In addition to the raw fix fields the dict carries a handful of
+        derived values that the GPS dashboard renders directly:
+
+        * ``pps_pulse_age_s`` — seconds since the last PPS rising edge.
+        * ``pps_jitter`` — ``{histogram, mean_ns, stddev_ns, peak_ns,
+          sample_count}`` summarising the inter-pulse interval ring buffer.
+        * ``allan_deviation`` — overlapping ADEV at τ = 1, 10, 100 s
+          (returned as ``{tau_s: σ_y}`` with float values; entries omitted
+          when the buffer is too short for that τ).
+        * ``fix_age_s`` — seconds since the last NMEA sentence carrying a
+          fix updated the manager.
+        * ``holdover_s`` — seconds since the last 3D fix (None until we
+          have ever seen one).  When a 3D fix is currently held this is
+          ``0``.
+        * ``leap_state`` — best-effort leap-second annunciator from the
+          NMEA path; chrony's ``leap_status`` is the authoritative
+          source on the dashboard, this is just a fallback.
+        """
         with self._lock:
             data = dict(self._fix)
             data["recent_sentences"] = list(self._recent_sentences)
+            interval_samples = list(self._pps_interval_ns)
+            last_3d = self._last_3d_fix_at
+        now_utc = datetime.now(timezone.utc)
+
         # Compute age of the last PPS pulse so the UI can colour the blinkenlite
         last_pulse = data.get("pps_last_pulse_at")
         if last_pulse:
             try:
                 pulse_dt = datetime.fromisoformat(last_pulse)
-                age = (datetime.now(timezone.utc) - pulse_dt).total_seconds()
+                age = (now_utc - pulse_dt).total_seconds()
                 data["pps_pulse_age_s"] = round(age, 2)
             except Exception:
                 data["pps_pulse_age_s"] = None
         else:
             data["pps_pulse_age_s"] = None
+
+        # Jitter histogram & Allan deviation from the interval buffer.
+        # Both helpers tolerate empty input and return JSON-friendly dicts.
+        data["pps_jitter"] = self._compute_jitter_summary(interval_samples)
+        data["allan_deviation"] = self._compute_allan_deviation(interval_samples)
+
+        # Fix age — drives the "GPS Fix Age" tile.  When we have an active
+        # fix this tracks NMEA freshness; when we don't, it's the time
+        # since the last sentence (handy for spotting a frozen UART).
+        last_sentence = data.get("last_sentence_at")
+        if last_sentence:
+            try:
+                sentence_dt = datetime.fromisoformat(last_sentence)
+                data["fix_age_s"] = round(
+                    (now_utc - sentence_dt).total_seconds(), 2
+                )
+            except Exception:
+                data["fix_age_s"] = None
+        else:
+            data["fix_age_s"] = None
+
+        # Holdover timer — wall-clock seconds since the last 3D fix.
+        # ``0`` while we currently hold a 3D fix; ``None`` when we have
+        # never seen one (e.g. cold start with no antenna).
+        if last_3d is None:
+            data["holdover_s"] = None
+            data["last_3d_fix_at"] = None
+        else:
+            data["last_3d_fix_at"] = last_3d.isoformat()
+            if data.get("fix_mode") == 3:
+                data["holdover_s"] = 0.0
+            else:
+                data["holdover_s"] = round(
+                    (now_utc - last_3d).total_seconds(), 2
+                )
+
+        # Leap-second annunciator — Phase 2 will replace this with a
+        # UBX-NAV-TIMELS poll; for now we surface a best-effort string
+        # so the UI tile has something to display.  Chrony's leap_status
+        # remains the authoritative source on the dashboard.
+        data["leap_state"] = self._derive_leap_state(data)
+
         return data
+
+    @staticmethod
+    def _compute_jitter_summary(intervals_ns: List[int]) -> Dict[str, Any]:
+        """Summarise inter-pulse intervals as a histogram + scalars.
+
+        The histogram spans ``±100 µs`` (10 buckets of 20 µs each, plus
+        an under/over-flow bucket on each side).  That matches what we
+        actually see on a Raspberry Pi reading the pps-gpio kernel
+        device: the IRQ-handler timestamping path adds ~10–30 µs of
+        host-side jitter to the receiver's own ~ns-scale PPS edge,
+        with rare scheduling outliers landing in the overflow bucket.
+        For receivers feeding chrony directly we'd want ns-scale buckets,
+        but the overhead of histogramming at that resolution isn't worth
+        it when the kernel itself has already smeared the edge.
+
+        Returns ``{}`` when the buffer holds fewer than two samples.
+        """
+        if not intervals_ns or len(intervals_ns) < 2:
+            return {
+                "sample_count": len(intervals_ns or []),
+                "histogram": [],
+                "mean_ns": None,
+                "stddev_ns": None,
+                "peak_ns": None,
+                "median_ns": None,
+            }
+
+        nominal_ns = 1_000_000_000  # 1 second
+        deltas_ns = [v - nominal_ns for v in intervals_ns]
+
+        n = len(deltas_ns)
+        mean = sum(deltas_ns) / n
+        var = sum((d - mean) * (d - mean) for d in deltas_ns) / n
+        stddev = math.sqrt(var)
+        peak = max(abs(d) for d in deltas_ns)
+        sorted_deltas = sorted(deltas_ns)
+        median = sorted_deltas[n // 2]
+
+        # Histogram bucket layout:
+        #   bucket 0     : delta < -100 µs              (underflow)
+        #   buckets 1-10 : 20 µs wide, spanning -100 µs to +100 µs
+        #   bucket 11    : delta > +100 µs              (overflow)
+        # Each bucket entry is {label, count, lo_ns, hi_ns} so the JS
+        # side can render the label without knowing the layout.
+        bucket_count = 12
+        edges_ns = [-100_000, -80_000, -60_000, -40_000, -20_000,
+                    0, 20_000, 40_000, 60_000, 80_000, 100_000]
+        counts = [0] * bucket_count
+        for d in deltas_ns:
+            if d < edges_ns[0]:
+                counts[0] += 1
+            elif d >= edges_ns[-1]:
+                counts[-1] += 1
+            else:
+                # Find the first edge that exceeds d (linear scan; only
+                # ~10 edges, not worth bisect).
+                placed = False
+                for i in range(len(edges_ns) - 1):
+                    if edges_ns[i] <= d < edges_ns[i + 1]:
+                        counts[i + 1] += 1
+                        placed = True
+                        break
+                if not placed:
+                    counts[-1] += 1
+
+        def _label(lo: Optional[int], hi: Optional[int]) -> str:
+            if lo is None:
+                return f"<{hi // 1000} µs"
+            if hi is None:
+                return f"≥{lo // 1000} µs"
+            return f"{lo // 1000} to {hi // 1000} µs"
+
+        histogram: List[Dict[str, Any]] = []
+        for i, c in enumerate(counts):
+            if i == 0:
+                lo, hi = None, edges_ns[0]
+            elif i == bucket_count - 1:
+                lo, hi = edges_ns[-1], None
+            else:
+                lo, hi = edges_ns[i - 1], edges_ns[i]
+            histogram.append({
+                "label": _label(lo, hi),
+                "lo_ns": lo,
+                "hi_ns": hi,
+                "count": c,
+            })
+
+        return {
+            "sample_count": n,
+            "histogram": histogram,
+            "mean_ns": round(mean, 1),
+            "stddev_ns": round(stddev, 1),
+            "peak_ns": int(peak),
+            "median_ns": int(median),
+        }
+
+    @staticmethod
+    def _compute_allan_deviation(intervals_ns: List[int]) -> Dict[str, Any]:
+        """Overlapping Allan deviation σ_y(τ) at τ = 1, 10, 100 s.
+
+        Reconstructs the phase sequence from inter-pulse intervals
+        (x_i = cumulative interval error vs. the 1 s nominal) and
+        applies the standard overlapping ADEV estimator:
+
+            σ²_y(τ) = sum_i (x_{i+2m} - 2·x_{i+m} + x_i)²
+                      ───────────────────────────────────────
+                              2 · τ² · (N − 2m)
+
+        where m = τ / τ₀ and τ₀ = 1 s.  Returned as a flat
+        ``{tau_s: σ_y}`` dict; entries are omitted when the buffer is
+        too short to estimate ADEV at that τ.
+        """
+        if not intervals_ns or len(intervals_ns) < 4:
+            return {"tau_s": [], "sigma_y": [], "sample_count": len(intervals_ns or [])}
+
+        nominal_ns = 1_000_000_000
+        # Phase samples in seconds (cumulative timing error vs. ideal).
+        phase = []
+        running = 0.0
+        for v in intervals_ns:
+            running += (v - nominal_ns) / 1e9
+            phase.append(running)
+
+        n = len(phase)
+        results_tau: List[int] = []
+        results_sigma: List[float] = []
+
+        for tau_s in (1, 10, 100):
+            m = tau_s  # τ₀ = 1 s
+            # Need at least 2m + 1 samples for a single ADEV term.
+            if n < 2 * m + 1:
+                continue
+            tau = float(m)
+            acc = 0.0
+            count = 0
+            for i in range(n - 2 * m):
+                d = phase[i + 2 * m] - 2.0 * phase[i + m] + phase[i]
+                acc += d * d
+                count += 1
+            if count <= 0:
+                continue
+            sigma_sq = acc / (2.0 * tau * tau * count)
+            if sigma_sq < 0:
+                continue
+            results_tau.append(tau_s)
+            results_sigma.append(math.sqrt(sigma_sq))
+
+        return {
+            "tau_s": results_tau,
+            "sigma_y": results_sigma,
+            "sample_count": n,
+        }
+
+    @staticmethod
+    def _derive_leap_state(fix: Dict[str, Any]) -> str:
+        """Best-effort leap-second annunciator from current fix state.
+
+        Until the UBX-NAV-TIMELS poll lands in Phase 2 we don't have an
+        authoritative source from the receiver itself — chrony's
+        ``leap_status`` (parsed elsewhere) is what the dashboard tile
+        actually displays.  This helper returns a coarse string so the
+        tile has a fallback when chrony is unavailable.
+        """
+        if not fix.get("has_fix"):
+            return "unknown"
+        # No NMEA standard field carries the leap-second alert; the
+        # u-blox proprietary RMC navigation-status field is too vendor-
+        # specific to rely on here.  Return "normal" while we hold a
+        # fix and let chrony override.
+        return "normal"
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -783,7 +1030,15 @@ class GPSManager:
                     fix_mode_raw = getattr(msg, "mode_fix_type", None)
                     if fix_mode_raw is not None:
                         try:
-                            self._fix["fix_mode"] = int(fix_mode_raw)
+                            mode_int = int(fix_mode_raw)
+                            self._fix["fix_mode"] = mode_int
+                            # Holdover anchor — the wall-clock instant of
+                            # the most recent 3D fix.  Used by get_status()
+                            # to compute holdover_s once the receiver loses
+                            # lock.  We capture at any 3D fix in the stream
+                            # so even brief reacquisitions reset the timer.
+                            if mode_int == 3:
+                                self._last_3d_fix_at = datetime.now(timezone.utc)
                         except (ValueError, TypeError):
                             pass
                     # Position dilution of precision
@@ -1007,6 +1262,9 @@ class GPSManager:
             self._fix["fix_quality"] = quality
             self._fix["has_fix"] = has_fix
             self._fix["fix_mode"] = mode if mode in (1, 2, 3) else None
+            if mode == 3:
+                # Mirror the NMEA path's holdover anchor in gpsd mode.
+                self._last_3d_fix_at = datetime.now(timezone.utc)
             if isinstance(obj.get("lat"), (int, float)):
                 self._fix["latitude"] = float(obj["lat"])
             if isinstance(obj.get("lon"), (int, float)):
@@ -1192,12 +1450,15 @@ class GPSManager:
             self._pps_kernel_baseline_seq,
         )
 
-    def _read_pps_assert(self, device: str) -> Optional[tuple]:
-        """Parse ``<device>/assert`` and return ``(sequence, timestamp_iso)``.
+    def _read_pps_assert(self, device: str) -> Optional[Tuple[int, int, str]]:
+        """Parse ``<device>/assert`` and return ``(sequence, ts_ns, ts_iso)``.
 
         The kernel exports the line as ``<seconds>.<nanoseconds>#<sequence>``
-        (see ``Documentation/ABI/testing/sysfs-pps``). Returns ``None`` if
-        the file is missing or the sequence is zero (no pulse yet seen).
+        (see ``Documentation/ABI/testing/sysfs-pps``).  The integer
+        nanosecond timestamp is what enables sub-microsecond jitter
+        and Allan deviation calculations downstream — float seconds
+        loses ~100 ns of precision near current epoch values.  Returns
+        ``None`` if the file is missing or the sequence is zero.
         """
         try:
             raw = self._safe_read(Path(device) / "assert")
@@ -1210,31 +1471,56 @@ class GPSManager:
             secs_str, _, ns_str = ts_part.partition(".")
             secs = int(secs_str)
             ns = int(ns_str.ljust(9, "0")[:9]) if ns_str else 0
+            ts_ns = secs * 1_000_000_000 + ns
             ts = datetime.fromtimestamp(secs + ns / 1e9, tz=timezone.utc)
-            return seq, ts.isoformat()
+            return seq, ts_ns, ts.isoformat()
         except Exception as exc:
             self._logger.debug("Failed to parse %s/assert: %s", device, exc)
             return None
 
     def _pps_kernel_loop(self) -> None:
-        """Poll the kernel PPS device once a second while the manager runs."""
+        """Poll the kernel PPS device at 10 Hz while the manager runs.
+
+        The 10 Hz cadence is fast enough to never miss a 1 Hz pulse while
+        still being trivially cheap (one sysfs read per 100 ms).  When
+        a new sequence number is observed we append the inter-pulse
+        interval (in nanoseconds) to ``self._pps_interval_ns`` so
+        ``get_status()`` can derive jitter/ADEV later — gaps from
+        missed pulses are skipped (interval > 1.5 s) so a flapping
+        receiver doesn't poison the histogram.
+        """
         last_seq: Optional[int] = self._pps_kernel_baseline_seq
+        last_ts_ns: Optional[int] = None
         device = self._pps_kernel_device or ""
         while self._running and device:
             try:
                 result = self._read_pps_assert(device)
                 if result is not None:
-                    seq, ts_iso = result
+                    seq, ts_ns, ts_iso = result
                     if last_seq is None or seq != last_seq:
+                        # Only count intervals when the sequence advanced
+                        # by exactly one — anything else is a missed pulse
+                        # or a baseline catch-up and would skew jitter.
+                        if (
+                            last_seq is not None
+                            and last_ts_ns is not None
+                            and seq == last_seq + 1
+                        ):
+                            interval_ns = ts_ns - last_ts_ns
+                            # Drop bogus intervals (clock step, rollover).
+                            if 500_000_000 <= interval_ns <= 1_500_000_000:
+                                with self._lock:
+                                    self._pps_interval_ns.append(interval_ns)
                         baseline = self._pps_kernel_baseline_seq or 0
                         count = max(0, seq - baseline)
                         with self._lock:
                             self._fix["pps_last_pulse_at"] = ts_iso
                             self._fix["pps_pulse_count"] = count
                         last_seq = seq
+                        last_ts_ns = ts_ns
             except Exception as exc:
                 self._logger.debug("PPS kernel poll error: %s", exc)
-            time.sleep(1.0)
+            time.sleep(0.1)
 
     def _start_pps_gpio_monitor(self) -> None:
         """Set up an RPi.GPIO rising-edge interrupt to detect PPS pulses.

--- a/app_core/gps/ubx.py
+++ b/app_core/gps/ubx.py
@@ -1,0 +1,297 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+from __future__ import annotations
+
+"""UBX (u-blox proprietary) protocol helpers — read-only subset.
+
+Phase 2 of the GNSS observability work uses these helpers to poll
+two messages from the receiver:
+
+* ``UBX-MON-HW`` (0x0A 0x09) — antenna supervisor status (OK / SHORT /
+  OPEN), antenna power, RF jamming indicator, and noise/AGC counters.
+  This is the only place the antenna fault state is exposed; NMEA-0183
+  has no equivalent sentence.
+* ``UBX-NAV-TIMELS`` (0x01 0x26) — authoritative GPS-UTC leap-second
+  offset plus the next scheduled leap event (insert/delete and the
+  GPS week/day-of-week it lands on).
+
+We deliberately keep this module narrow: only the two readers above
+plus the framing primitives needed to send a poll request.  Phase 3
+will add ``UBX-CFG-GNSS`` writers for constellation profile
+management; this module is the natural home for that code when it
+lands.
+
+Frame layout (see u-blox 8 receiver protocol manual §32):
+
+    0xB5 0x62 | class | id | length (LE u16) | payload | CK_A | CK_B
+
+The two checksum bytes are an 8-bit Fletcher computed over
+``class || id || length || payload`` (the sync chars are excluded).
+"""
+
+import struct
+from typing import Any, Dict, Optional, Tuple
+
+# UBX message classes / IDs we care about.
+UBX_SYNC_1 = 0xB5
+UBX_SYNC_2 = 0x62
+
+CLASS_NAV = 0x01
+CLASS_MON = 0x0A
+
+ID_NAV_TIMELS = 0x26
+ID_MON_HW = 0x09
+
+# UBX-MON-HW antenna-status enum (aStatus byte at offset 20 in the
+# 60-byte payload).  Mapped to the strings the dashboard renders.
+_ANT_STATUS = {
+    0: "init",
+    1: "unknown",
+    2: "ok",
+    3: "short",
+    4: "open",
+}
+
+# UBX-MON-HW antenna-power enum (aPower byte at offset 21).
+_ANT_POWER = {
+    0: "off",
+    1: "on",
+    2: "unknown",
+}
+
+# UBX-MON-HW jammingState — bits 2..3 of the flags byte at offset 22.
+_JAMMING_STATE = {
+    0: "unknown",
+    1: "ok",
+    2: "warning",
+    3: "critical",
+}
+
+# UBX-NAV-TIMELS srcOfCurrLs byte (offset 8) — provenance of the
+# currently-applied leap-second value.  Same enum is used for
+# srcOfLsChange (offset 10) but with the upper values reserved.
+_LS_SOURCE = {
+    0: "default",
+    1: "gps_glonass_diff",
+    2: "gps",
+    3: "sbas",
+    4: "beidou",
+    5: "galileo",
+    6: "aided",
+    7: "configured",
+    8: "navic",
+    255: "unknown",
+}
+
+
+def _checksum(payload: bytes) -> Tuple[int, int]:
+    """Compute the UBX 8-bit Fletcher checksum over ``payload``.
+
+    ``payload`` should be ``class || id || length || body`` — i.e.
+    everything between the sync chars and the checksum bytes.  Returns
+    ``(CK_A, CK_B)`` as integers in ``[0, 255]``.
+    """
+    ck_a = 0
+    ck_b = 0
+    for byte in payload:
+        ck_a = (ck_a + byte) & 0xFF
+        ck_b = (ck_b + ck_a) & 0xFF
+    return ck_a, ck_b
+
+
+def build_poll(class_id: int, msg_id: int, body: bytes = b"") -> bytes:
+    """Frame a UBX message ready to write to the serial port.
+
+    A "poll request" is just a normal UBX frame with an empty body —
+    the receiver replies with the same class/id and the populated
+    payload.  ``body`` is exposed so the same helper can serve the
+    Phase 3 ``UBX-CFG-*`` writers.
+    """
+    length = len(body)
+    header = struct.pack("<BBH", class_id, msg_id, length)
+    ck_a, ck_b = _checksum(header + body)
+    return bytes([UBX_SYNC_1, UBX_SYNC_2]) + header + body + bytes([ck_a, ck_b])
+
+
+def parse_mon_hw(payload: bytes) -> Dict[str, Any]:
+    """Decode the fields of ``UBX-MON-HW`` we surface on the dashboard.
+
+    Layout (60 bytes total — see protocol manual):
+
+      offset  size  field
+      ------  ----  ---------------------------------------------
+        0     U4    pinSel
+        4     U4    pinBank
+        8     U4    pinDir
+       12     U4    pinVal
+       16     U2    noisePerMS
+       18     U2    agcCnt
+       20     U1    aStatus
+       21     U1    aPower
+       22     U1    flags        (bit 0=rtcCalib, 1=safeBoot,
+                                   2..3=jammingState, 4=xtalAbsent)
+       23     U1    reserved1
+       24..   …     pinIrq, pullH, pullL (unused here)
+
+    Older firmware reports a 56-byte payload instead; we tolerate
+    either by only reading what's present.  Returns ``{}`` if the
+    payload is too short to contain ``aStatus``.
+    """
+    if len(payload) < 23:
+        return {}
+
+    noise = struct.unpack_from("<H", payload, 16)[0]
+    agc = struct.unpack_from("<H", payload, 18)[0]
+    a_status = payload[20]
+    a_power = payload[21]
+    flags = payload[22]
+    jamming_bits = (flags >> 2) & 0x03
+
+    return {
+        "antenna_status": _ANT_STATUS.get(a_status, "unknown"),
+        "antenna_power": _ANT_POWER.get(a_power, "unknown"),
+        "jamming_state": _JAMMING_STATE.get(jamming_bits, "unknown"),
+        "noise_level": int(noise),
+        # AGC is a 16-bit count; receivers usually scale 8192 as the
+        # nominal mid-point.  We expose the raw value and let the UI
+        # render it.
+        "agc_count": int(agc),
+        "rtc_calibrated": bool(flags & 0x01),
+        "safe_boot": bool(flags & 0x02),
+        "xtal_absent": bool(flags & 0x10),
+    }
+
+
+def parse_nav_timels(payload: bytes) -> Dict[str, Any]:
+    """Decode the fields of ``UBX-NAV-TIMELS`` we surface on the
+    dashboard.
+
+    Layout (24 bytes):
+
+      offset  size  field
+      ------  ----  ---------------------------------------------
+        0     U1    version
+        1..3  reserved
+        4     U4    iTOW
+        8     U1    srcOfCurrLs
+        9     I1    currLs                (current GPS-UTC offset, s)
+       10     U1    srcOfLsChange
+       11     I1    lsChange              (signed, +1/-1/0)
+       12     I4    timeToLsEvent         (signed seconds)
+       16     U2    dateOfLsGpsWn         (week the event lands in)
+       18     U2    dateOfLsGpsDn         (1=Sun..7=Sat within wn)
+       20..22  reserved
+       23     U1    valid                 (bit 0=currLsValid,
+                                           bit 1=timeToLsEventValid)
+
+    Returns ``{}`` for short or zero-version payloads (some firmwares
+    emit the message before they've sourced a value).
+    """
+    if len(payload) < 24:
+        return {}
+
+    src_curr = payload[8]
+    curr_ls = struct.unpack_from("<b", payload, 9)[0]
+    src_change = payload[10]
+    ls_change = struct.unpack_from("<b", payload, 11)[0]
+    time_to_event = struct.unpack_from("<i", payload, 12)[0]
+    date_wn = struct.unpack_from("<H", payload, 16)[0]
+    date_dn = struct.unpack_from("<H", payload, 18)[0]
+    valid = payload[23]
+
+    curr_valid = bool(valid & 0x01)
+    event_valid = bool(valid & 0x02)
+
+    return {
+        "leap_seconds": int(curr_ls) if curr_valid else None,
+        "leap_source": _LS_SOURCE.get(src_curr, "unknown"),
+        "leap_pending": bool(event_valid and ls_change != 0),
+        "leap_change": int(ls_change),
+        "leap_change_source": _LS_SOURCE.get(src_change, "unknown"),
+        "leap_seconds_to_event": int(time_to_event) if event_valid else None,
+        "leap_event_gps_week": int(date_wn) if event_valid else None,
+        "leap_event_gps_dow": int(date_dn) if event_valid else None,
+    }
+
+
+def find_frame(buf: bytearray) -> Optional[Tuple[int, int, int, bytes]]:
+    """Look for a complete UBX frame at the start of ``buf``.
+
+    The buffer is scanned for the ``0xB5 0x62`` sync pair.  If a
+    well-formed frame is found, its bytes are removed from ``buf`` and
+    we return ``(start_offset, class_id, msg_id, payload)``.
+
+    Returns ``None`` when no complete frame is present yet — caller
+    should keep accumulating bytes and retry.  On checksum failure the
+    frame is consumed and dropped (the caller learns nothing about it,
+    which matches u-blox's own approach: bad frames are noise).
+
+    The ``start_offset`` returned tells the caller how many leading
+    bytes were skipped before the frame began (typically 0; non-zero
+    means stray bytes that should be re-checked for NMEA framing by
+    the caller).
+    """
+    # Find the sync pair.
+    for start in range(len(buf) - 1):
+        if buf[start] == UBX_SYNC_1 and buf[start + 1] == UBX_SYNC_2:
+            break
+    else:
+        return None
+
+    # Need at least sync + class + id + length = 6 bytes before we
+    # can read the payload size.
+    if len(buf) - start < 6:
+        return None
+
+    class_id = buf[start + 2]
+    msg_id = buf[start + 3]
+    length = buf[start + 4] | (buf[start + 5] << 8)
+
+    # Sanity-clamp the length so a corrupt header can't make us wait
+    # forever (u-blox max payload is well under 1 KiB for the messages
+    # we poll).
+    if length > 4096:
+        # Drop the bogus sync and let the caller retry.
+        del buf[: start + 1]
+        return None
+
+    total = 6 + length + 2  # header + payload + checksum
+    if len(buf) - start < total:
+        return None
+
+    payload = bytes(buf[start + 6 : start + 6 + length])
+    ck_a_recv = buf[start + 6 + length]
+    ck_b_recv = buf[start + 6 + length + 1]
+
+    ck_a, ck_b = _checksum(bytes(buf[start + 2 : start + 6 + length]))
+    if (ck_a, ck_b) != (ck_a_recv, ck_b_recv):
+        # Drop just the leading sync byte and let the caller retry —
+        # otherwise we'd discard real NMEA traffic that follows.
+        del buf[: start + 1]
+        return None
+
+    leading = start
+    del buf[: start + total]
+    return leading, class_id, msg_id, payload
+
+
+# Convenience constants for callers that only need the polls.
+POLL_MON_HW = build_poll(CLASS_MON, ID_MON_HW)
+POLL_NAV_TIMELS = build_poll(CLASS_NAV, ID_NAV_TIMELS)

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -903,11 +903,25 @@ def _collect_gps_for_trends() -> dict:
     ]
     avg_snr = (sum(snrs) / len(snrs)) if snrs else None
 
+    # PPS jitter (1σ in nanoseconds) — included in the trend ring so
+    # the GPS dashboard can plot a "Receiver Stability" sparkline
+    # alongside chrony's RMS offset.  Empty when the manager hasn't
+    # accumulated enough PPS pulses yet for a stddev to mean anything.
+    jitter = status.get("pps_jitter") or {}
+    jitter_stddev_ns = jitter.get("stddev_ns") if isinstance(jitter, dict) else None
+
+    # Holdover seconds for the holdover-timer trend.  ``0`` while we
+    # have a 3D fix; counts upward when we don't.
+    holdover_s = status.get("holdover_s")
+
     return {
-        "hdop":    _num(status.get("hdop")),
-        "vdop":    _num(status.get("vdop")),
-        "pdop":    _num(status.get("pdop")),
-        "avg_snr": avg_snr,
+        "hdop":            _num(status.get("hdop")),
+        "vdop":            _num(status.get("vdop")),
+        "pdop":            _num(status.get("pdop")),
+        "avg_snr":         avg_snr,
+        "fix_age_s":       _num(status.get("fix_age_s")),
+        "holdover_s":      _num(holdover_s),
+        "pps_jitter_ns":   _num(jitter_stddev_ns),
     }
 
 

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -391,7 +391,10 @@
                     <dt>Hardware</dt>       <dd id="g-hw">—</dd>
                     <dt>Fix age</dt>        <dd id="g-fix-age" class="num">—</dd>
                     <dt>Holdover</dt>       <dd id="g-holdover" class="num">—</dd>
+                    <dt>Antenna</dt>        <dd id="g-antenna">—</dd>
+                    <dt>RF / jamming</dt>   <dd id="g-jamming">—</dd>
                     <dt>Leap state</dt>     <dd id="g-leap-state">—</dd>
+                    <dt>Leap (GPS-UTC)</dt> <dd id="g-leap-seconds" class="num">—</dd>
                 </dl>
 
                 <div class="gps-const-row" id="gps-dash-const-chips"></div>
@@ -1210,13 +1213,87 @@
             }
         }
 
-        // Leap-second state — chrony's leap_status is the authoritative
-        // tell, fall back to the GPS manager's coarse string when chrony
-        // is unavailable (e.g. running this on a host without chronyc).
+        // Antenna status — sourced from UBX-MON-HW (Phase 2).  When
+        // running via gpsd we can't poll, so render an explanatory
+        // placeholder instead of a misleading "—".  When the receiver
+        // hasn't replied yet (cold start, or a non-u-blox HAT that
+        // ignores the poll) we render "polling" until the ubx_poll
+        // _supported flag flips.
+        var antEl = document.getElementById('g-antenna');
+        if (antEl) {
+            antEl.classList.remove('pos', 'neg');
+            var antStatus = gps && gps.antenna_status;
+            var antPower = gps && gps.antenna_power;
+            var pollSupported = gps && gps.ubx_poll_supported;
+            if (pollSupported === false && antStatus === null) {
+                antEl.textContent = 'via gpsd (polls disabled)';
+            } else if (antStatus === null || antStatus === undefined) {
+                antEl.textContent = 'polling…';
+            } else {
+                var label = antStatus.toUpperCase();
+                if (antPower) label += ' · ' + antPower.toUpperCase();
+                antEl.textContent = label;
+                if (antStatus === 'ok')             antEl.classList.add('pos');
+                else if (antStatus === 'short' || antStatus === 'open') antEl.classList.add('neg');
+            }
+        }
+
+        // RF / jamming tile — receiver's broadband interference
+        // monitor.  "ok" is the healthy state; "warning" / "critical"
+        // call attention to a noisy environment without committing to
+        // a root cause.
+        var jamEl = document.getElementById('g-jamming');
+        if (jamEl) {
+            jamEl.classList.remove('pos', 'neg');
+            var jamming = gps && gps.jamming_state;
+            var noise = gps && gps.noise_level;
+            if (jamming === null || jamming === undefined) {
+                jamEl.textContent = '—';
+            } else {
+                var jamLabel = jamming.toUpperCase();
+                if (typeof noise === 'number') jamLabel += ' · noise ' + noise;
+                jamEl.textContent = jamLabel;
+                if (jamming === 'ok')                     jamEl.classList.add('pos');
+                else if (jamming === 'warning' || jamming === 'critical') jamEl.classList.add('neg');
+            }
+        }
+
+        // Leap-second state — UBX-NAV-TIMELS is authoritative; fall
+        // back to chrony's leap_status; finally to the GPS manager's
+        // coarse string.  Insert/delete pending warnings include the
+        // ETA in days when the receiver supplied it.
         var chronyLeap = (lastSnapshot && lastSnapshot.chrony && lastSnapshot.chrony.tracking
                           && lastSnapshot.chrony.tracking.leap_status) || null;
         var gpsLeap = (gps && gps.leap_state) || null;
-        setText('g-leap-state', chronyLeap || gpsLeap || '—');
+        var leapText = chronyLeap || gpsLeap || '—';
+        var leapEl = document.getElementById('g-leap-state');
+        if (leapEl) {
+            leapEl.classList.remove('pos', 'neg');
+            if (gps && gps.leap_pending) {
+                var direction = (gps.leap_change || 0) > 0 ? 'INSERT' : 'DELETE';
+                var etaSecs = gps.leap_seconds_to_event;
+                var etaPart = (typeof etaSecs === 'number' && isFinite(etaSecs))
+                    ? ' in ' + Math.round(etaSecs / 86400) + ' d'
+                    : '';
+                leapEl.textContent = direction + etaPart;
+                leapEl.classList.add('neg');
+            } else {
+                leapEl.textContent = leapText;
+                if (leapText === 'normal' || leapText === 'Normal') leapEl.classList.add('pos');
+            }
+        }
+        // GPS-UTC offset (in seconds) — usually 18 today.  Surfaces
+        // the receiver's authoritative value when present.
+        var leapSecs = gps && gps.leap_seconds;
+        var leapSecEl = document.getElementById('g-leap-seconds');
+        if (leapSecEl) {
+            if (typeof leapSecs === 'number') {
+                var srcSuffix = gps.leap_source ? ' (' + gps.leap_source + ')' : '';
+                leapSecEl.textContent = leapSecs + ' s' + srcSuffix;
+            } else {
+                leapSecEl.textContent = '—';
+            }
+        }
 
         var sats = (gps && gps.satellites_in_view) || [];
         var active = (gps && gps.active_satellite_prns) || [];

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -389,6 +389,9 @@
                     <dt>Altitude</dt>       <dd id="g-alt" class="num">—</dd>
                     <dt>Geometry (DOP)</dt> <dd id="g-dop" class="num">—</dd>
                     <dt>Hardware</dt>       <dd id="g-hw">—</dd>
+                    <dt>Fix age</dt>        <dd id="g-fix-age" class="num">—</dd>
+                    <dt>Holdover</dt>       <dd id="g-holdover" class="num">—</dd>
+                    <dt>Leap state</dt>     <dd id="g-leap-state">—</dd>
                 </dl>
 
                 <div class="gps-const-row" id="gps-dash-const-chips"></div>
@@ -584,6 +587,111 @@
                 </div>
             </div>
         </div>
+
+        <!-- ============================================================
+             PPS JITTER HISTOGRAM — distribution of inter-pulse intervals
+             relative to the 1 s nominal.  Drawn from the manager's
+             nanosecond ring buffer (sub-µs precision when the pps-gpio
+             kernel device is available).
+             ============================================================ -->
+        <div class="col-12 col-xl-6">
+            <div class="gps-card h-100 gps-chart-card">
+                <div class="gps-card-head">
+                    <h3><i class="fas fa-chart-column me-1"></i> PPS Jitter Histogram</h3>
+                    <div class="badge-area">
+                        <span class="text-muted small">interval Δ vs 1 s nominal</span>
+                    </div>
+                </div>
+                <div class="chart-meta">
+                    <span><span class="label">σ</span> <span id="ts-jitter-stddev" class="value">—</span></span>
+                    <span><span class="label">peak</span> <span id="ts-jitter-peak" class="value">—</span></span>
+                    <span><span class="label">median</span> <span id="ts-jitter-median" class="value">—</span></span>
+                    <span><span class="label">samples</span> <span id="ts-jitter-n" class="value">0</span></span>
+                </div>
+                <div class="gps-chart-canvas-wrap">
+                    <canvas id="ts-jitter-canvas" width="600" height="160" aria-label="PPS jitter histogram"></canvas>
+                    <div id="ts-jitter-empty" class="gps-chart-empty">Waiting for PPS pulses…</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ============================================================
+             ALLAN DEVIATION — overlapping σ_y(τ) at τ = 1, 10, 100 s.
+             Plotted on a log-log axis (the standard frequency-stability
+             chart).  Empty until the manager has at least 3 pulses.
+             ============================================================ -->
+        <div class="col-12 col-xl-6">
+            <div class="gps-card h-100 gps-chart-card">
+                <div class="gps-card-head">
+                    <h3><i class="fas fa-wave-square me-1"></i> Allan Deviation</h3>
+                    <div class="badge-area">
+                        <span class="text-muted small">overlapping σ_y(τ), log-log</span>
+                    </div>
+                </div>
+                <div class="chart-meta">
+                    <span><span class="label">τ=1 s</span> <span id="ts-adev-1" class="value">—</span></span>
+                    <span><span class="label">τ=10 s</span> <span id="ts-adev-10" class="value">—</span></span>
+                    <span><span class="label">τ=100 s</span> <span id="ts-adev-100" class="value">—</span></span>
+                    <span><span class="label">samples</span> <span id="ts-adev-n" class="value">0</span></span>
+                </div>
+                <div class="gps-chart-canvas-wrap">
+                    <canvas id="ts-adev-canvas" width="600" height="160" aria-label="Allan deviation log-log plot"></canvas>
+                    <div id="ts-adev-empty" class="gps-chart-empty">Need ≥3 PPS pulses…</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ============================================================
+             SNR vs ELEVATION — scatter plot of every satellite in view.
+             Diagnostic for antenna obstruction, multipath, and noisy LNAs:
+             a healthy install shows SNR climbing roughly linearly with
+             elevation, with the curve sitting around 35–50 dBHz at
+             zenith.  Outliers under the curve are usually obstruction.
+             ============================================================ -->
+        <div class="col-12 col-xl-6">
+            <div class="gps-card h-100 gps-chart-card">
+                <div class="gps-card-head">
+                    <h3><i class="fas fa-chart-line me-1"></i> SNR vs Elevation</h3>
+                    <div class="badge-area">
+                        <span class="text-muted small">live scatter · all constellations</span>
+                    </div>
+                </div>
+                <div class="chart-meta">
+                    <span><span class="label">visible</span> <span id="ts-elev-n" class="value">0</span></span>
+                    <span><span class="label">avg</span> <span id="ts-elev-avg" class="value">—</span></span>
+                    <span><span class="label">at zenith</span> <span id="ts-elev-zenith" class="value">—</span></span>
+                </div>
+                <div class="gps-chart-canvas-wrap">
+                    <canvas id="ts-elev-canvas" width="600" height="160" aria-label="SNR vs elevation scatter"></canvas>
+                    <div id="ts-elev-empty" class="gps-chart-empty">No satellites in view…</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ============================================================
+             HOLDOVER TIMER — running seconds since the last 3D fix.
+             Stays at 0 while the receiver holds 3D; counts up when it
+             drops out (e.g. antenna unplugged, building shadowing).
+             ============================================================ -->
+        <div class="col-12 col-xl-6">
+            <div class="gps-card h-100 gps-chart-card">
+                <div class="gps-card-head">
+                    <h3><i class="fas fa-hourglass-half me-1"></i> Holdover Timer</h3>
+                    <div class="badge-area">
+                        <span class="text-muted small">seconds since last 3D fix</span>
+                    </div>
+                </div>
+                <div class="chart-meta">
+                    <span><span class="swatch" style="background:#d29922;"></span><span class="label">Now</span> <span id="ts-hold-now" class="value">—</span></span>
+                    <span><span class="label">peak</span> <span id="ts-hold-max" class="value">—</span></span>
+                    <span><span class="label">samples</span> <span id="ts-hold-n" class="value">0</span></span>
+                </div>
+                <div class="gps-chart-canvas-wrap">
+                    <canvas id="ts-hold-canvas" width="600" height="110" aria-label="Holdover history sparkline"></canvas>
+                    <div id="ts-hold-empty" class="gps-chart-empty">Collecting samples…</div>
+                </div>
+            </div>
+        </div>
     </div>
 
     <p class="text-muted small mt-3">
@@ -657,6 +765,33 @@
     function fmtSeconds2(v) {
         if (v === null || v === undefined || isNaN(v)) return '—';
         return v.toFixed(1) + ' s';
+    }
+    // Adaptive duration formatter for fix-age + holdover tiles. Chrogps-dash
+    // convention: stay in the smallest unit that keeps the number readable.
+    function fmtDuration(seconds) {
+        if (seconds === null || seconds === undefined || isNaN(seconds)) return '—';
+        if (seconds < 60)    return seconds.toFixed(1) + ' s';
+        if (seconds < 3600)  return Math.floor(seconds / 60) + 'm ' + Math.round(seconds % 60) + 's';
+        if (seconds < 86400) return Math.floor(seconds / 3600) + 'h ' + Math.floor((seconds % 3600) / 60) + 'm';
+        return Math.floor(seconds / 86400) + 'd ' + Math.floor((seconds % 86400) / 3600) + 'h';
+    }
+    // Render a small ns/µs/ms label for jitter & ADEV chart annotations.
+    function fmtNs(ns) {
+        if (ns === null || ns === undefined || isNaN(ns)) return '—';
+        var abs = Math.abs(ns);
+        if (abs < 1000)       return ns.toFixed(0) + ' ns';
+        if (abs < 1_000_000)  return (ns / 1000).toFixed(2) + ' µs';
+        if (abs < 1_000_000_000) return (ns / 1_000_000).toFixed(3) + ' ms';
+        return (ns / 1_000_000_000).toFixed(3) + ' s';
+    }
+    // ADEV is a dimensionless fractional-frequency quantity; render with
+    // engineering-style scientific notation for compactness.
+    function fmtAdev(v) {
+        if (v === null || v === undefined || isNaN(v)) return '—';
+        if (v === 0) return '0';
+        var exp = Math.floor(Math.log10(Math.abs(v)));
+        var mantissa = v / Math.pow(10, exp);
+        return mantissa.toFixed(2) + 'e' + exp;
     }
     // chronyc -c tracking emits "ref time" as a Unix timestamp string
     // (e.g. "1778355459.498333426").  Render it as a human-readable UTC
@@ -1044,6 +1179,45 @@
             : '—';
         setText('g-hw', hw);
 
+        // Fix age — colour-code so a frozen UART stands out.  Anything
+        // over 5 s without a sentence is suspicious on a 1 Hz receiver.
+        var fixAge = (gps && typeof gps.fix_age_s === 'number') ? gps.fix_age_s : null;
+        var fixAgeEl = document.getElementById('g-fix-age');
+        if (fixAgeEl) {
+            fixAgeEl.classList.remove('pos', 'neg');
+            if (fixAge === null) {
+                fixAgeEl.textContent = '—';
+            } else {
+                fixAgeEl.textContent = fmtDuration(fixAge);
+                if (fixAge > 5) fixAgeEl.classList.add('neg');
+                else if (fixAge < 2) fixAgeEl.classList.add('pos');
+            }
+        }
+
+        // Holdover — 0 while we have a 3D fix; counts up when we don't.
+        var hold = (gps && typeof gps.holdover_s === 'number') ? gps.holdover_s : null;
+        var holdEl = document.getElementById('g-holdover');
+        if (holdEl) {
+            holdEl.classList.remove('pos', 'neg');
+            if (hold === null) {
+                holdEl.textContent = '—';
+            } else if (hold === 0) {
+                holdEl.textContent = '0 s (locked)';
+                holdEl.classList.add('pos');
+            } else {
+                holdEl.textContent = fmtDuration(hold);
+                if (hold > 60) holdEl.classList.add('neg');
+            }
+        }
+
+        // Leap-second state — chrony's leap_status is the authoritative
+        // tell, fall back to the GPS manager's coarse string when chrony
+        // is unavailable (e.g. running this on a host without chronyc).
+        var chronyLeap = (lastSnapshot && lastSnapshot.chrony && lastSnapshot.chrony.tracking
+                          && lastSnapshot.chrony.tracking.leap_status) || null;
+        var gpsLeap = (gps && gps.leap_state) || null;
+        setText('g-leap-state', chronyLeap || gpsLeap || '—');
+
         var sats = (gps && gps.satellites_in_view) || [];
         var active = (gps && gps.active_satellite_prns) || [];
         setText('gps-dash-active-count', active.length);
@@ -1103,6 +1277,7 @@
             ringPush(ts.vdop,  sampleTs, pickNum(s.vdop));
             ringPush(ts.pdop,  sampleTs, pickNum(s.pdop));
             ringPush(ts.snr,   sampleTs, pickNum(s.avg_snr));
+            ringPush(ts.hold,  sampleTs, pickNum(s.holdover_s));
         }
     }
     function ringStats(buf) {
@@ -1254,7 +1429,8 @@
         hdop:  makeRing(),  // gps hdop                      (unitless)
         vdop:  makeRing(),  // gps vdop                      (unitless)
         pdop:  makeRing(),  // gps pdop                      (unitless)
-        snr:   makeRing()   // average SNR across in-view    (dBHz)
+        snr:   makeRing(),  // average SNR across in-view    (dBHz)
+        hold:  makeRing()   // gps holdover_s                (seconds)
     };
 
     function ingestTimeSeries(snapshot) {
@@ -1276,6 +1452,9 @@
             ? sats.reduce(function (a, s) { return a + s.snr; }, 0) / sats.length
             : null;
         ringPush(ts.snr, now, avg);
+        // Holdover history — count of seconds since last 3D fix.  Stays
+        // pinned at 0 while we have a 3D fix; spikes when it drops out.
+        ringPush(ts.hold, now, typeof g.holdover_s === 'number' ? g.holdover_s : null);
     }
 
     // Same fmtSeconds-style formatter we use elsewhere, but typed for
@@ -1337,6 +1516,308 @@
         drawSparkline('ts-snr-canvas', [
             { buffer: ts.snr, color: '#3fb950' }
         ], { emptyEl: 'ts-snr-empty' });
+
+        // Holdover history — sparkline of seconds since last 3D fix.
+        var ho = ringStats(ts.hold);
+        setText('ts-hold-now', fmtDuration(ho.last));
+        setText('ts-hold-max', fmtDuration(ho.max));
+        setText('ts-hold-n', ho.count);
+        drawSparkline('ts-hold-canvas', [
+            { buffer: ts.hold, color: '#d29922' }
+        ], { emptyEl: 'ts-hold-empty', includeZero: true });
+    }
+
+    // ── PPS jitter histogram — vertical bars sized to bucket counts.
+    //    Empty until the manager has reported at least 2 samples.
+    function renderJitterHistogram(jitter) {
+        if (!jitter || !jitter.histogram || !jitter.histogram.length || !jitter.sample_count) {
+            var emptyEl = document.getElementById('ts-jitter-empty');
+            if (emptyEl) emptyEl.style.display = '';
+            setText('ts-jitter-stddev', '—');
+            setText('ts-jitter-peak', '—');
+            setText('ts-jitter-median', '—');
+            setText('ts-jitter-n', 0);
+            return;
+        }
+        setText('ts-jitter-stddev', fmtNs(jitter.stddev_ns));
+        setText('ts-jitter-peak', fmtNs(jitter.peak_ns));
+        setText('ts-jitter-median', fmtNs(jitter.median_ns));
+        setText('ts-jitter-n', jitter.sample_count);
+
+        var canvas = document.getElementById('ts-jitter-canvas');
+        if (!canvas) return;
+        var emptyEl = document.getElementById('ts-jitter-empty');
+        if (emptyEl) emptyEl.style.display = 'none';
+
+        var fit = fitCanvas(canvas);
+        var ctx = fit.ctx, W = fit.w, H = fit.h;
+        ctx.clearRect(0, 0, W, H);
+
+        var pad = { l: 28, r: 8, t: 8, b: 30 };
+        var plotW = W - pad.l - pad.r;
+        var plotH = H - pad.t - pad.b;
+
+        var buckets = jitter.histogram;
+        var maxCount = 0;
+        for (var i = 0; i < buckets.length; i++) {
+            if (buckets[i].count > maxCount) maxCount = buckets[i].count;
+        }
+        if (maxCount === 0) maxCount = 1;
+
+        var barW = plotW / buckets.length;
+        // Centre bucket index — for the layout in _compute_jitter_summary
+        // this is the boundary between negative and positive halves
+        // (buckets 0..5 are ≤0, 6..11 are >0).  Render the centre divider.
+        var centreX = pad.l + barW * (buckets.length / 2);
+
+        // Faint grid lines at 25/50/75/100% of max count.
+        ctx.strokeStyle = 'rgba(127,127,127,0.18)';
+        ctx.lineWidth = 1;
+        for (var g = 1; g <= 4; g++) {
+            var gy = pad.t + plotH * (1 - g / 4);
+            ctx.beginPath();
+            ctx.moveTo(pad.l, gy); ctx.lineTo(pad.l + plotW, gy);
+            ctx.stroke();
+        }
+
+        // Y-axis labels — bucket-count scale.
+        ctx.fillStyle = 'rgba(127,127,127,0.85)';
+        ctx.font = '10px ui-monospace, monospace';
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        for (var g2 = 0; g2 <= 4; g2++) {
+            var yLabel = pad.t + plotH * (1 - g2 / 4);
+            ctx.fillText(Math.round(maxCount * g2 / 4).toString(), pad.l - 4, yLabel);
+        }
+
+        // Centre divider (the 0 ns boundary).
+        ctx.strokeStyle = 'rgba(127,127,127,0.45)';
+        ctx.beginPath();
+        ctx.moveTo(centreX, pad.t); ctx.lineTo(centreX, pad.t + plotH);
+        ctx.stroke();
+
+        // Bars.  Colour-code: centre buckets green (low jitter), edges
+        // amber/red so the operator's eye finds outliers at a glance.
+        for (var b = 0; b < buckets.length; b++) {
+            var count = buckets[b].count;
+            if (!count) continue;
+            var h = (count / maxCount) * plotH;
+            var x = pad.l + b * barW + 1;
+            var y = pad.t + plotH - h;
+            // Distance from centre buckets (5 & 6 are the ±200 µs core).
+            var distFromCentre = Math.min(Math.abs(b - 5), Math.abs(b - 6));
+            var color;
+            if (distFromCentre <= 1)      color = '#3fb950';   // green — healthy
+            else if (distFromCentre <= 3) color = '#d29922';   // amber — wide
+            else                          color = '#f85149';   // red — outlier
+            ctx.fillStyle = color;
+            ctx.fillRect(x, y, Math.max(1, barW - 2), h);
+        }
+
+        // X-axis labels — show -1 ms / 0 / +1 ms anchors only (a label
+        // per bucket would overlap on the 600px-wide canvas).
+        ctx.fillStyle = 'rgba(127,127,127,0.85)';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText('-100 µs', pad.l + barW * 1, pad.t + plotH + 4);
+        ctx.fillText('0',       centreX,           pad.t + plotH + 4);
+        ctx.fillText('+100 µs', pad.l + barW * (buckets.length - 1), pad.t + plotH + 4);
+    }
+
+    // ── Allan deviation log-log plot.  Renders the (τ, σ_y) tuples the
+    //    backend computed at τ = 1, 10, 100 s.  Empty until the manager
+    //    has at least 3 PPS pulses.
+    function renderAllanDeviation(adev) {
+        var emptyEl = document.getElementById('ts-adev-empty');
+        if (!adev || !adev.tau_s || !adev.tau_s.length) {
+            if (emptyEl) emptyEl.style.display = '';
+            setText('ts-adev-1', '—');
+            setText('ts-adev-10', '—');
+            setText('ts-adev-100', '—');
+            setText('ts-adev-n', adev && adev.sample_count ? adev.sample_count : 0);
+            return;
+        }
+        setText('ts-adev-n', adev.sample_count);
+
+        var bytTau = {};
+        for (var i = 0; i < adev.tau_s.length; i++) {
+            bytTau[adev.tau_s[i]] = adev.sigma_y[i];
+        }
+        setText('ts-adev-1',   fmtAdev(bytTau[1]   != null ? bytTau[1]   : null));
+        setText('ts-adev-10',  fmtAdev(bytTau[10]  != null ? bytTau[10]  : null));
+        setText('ts-adev-100', fmtAdev(bytTau[100] != null ? bytTau[100] : null));
+
+        var canvas = document.getElementById('ts-adev-canvas');
+        if (!canvas) return;
+        if (emptyEl) emptyEl.style.display = 'none';
+
+        var fit = fitCanvas(canvas);
+        var ctx = fit.ctx, W = fit.w, H = fit.h;
+        ctx.clearRect(0, 0, W, H);
+
+        var pad = { l: 56, r: 12, t: 10, b: 28 };
+        var plotW = W - pad.l - pad.r;
+        var plotH = H - pad.t - pad.b;
+
+        // X axis: log10(τ) over [0, 2] — i.e. 1 s to 100 s.  Y axis:
+        // log10(σ_y) auto-fit with at least 2 decades of range so a
+        // single-point plot still has somewhere to sit.
+        var logTauMin = 0;
+        var logTauMax = 2;
+        var sigmaMin = Infinity, sigmaMax = -Infinity;
+        for (var j = 0; j < adev.sigma_y.length; j++) {
+            var s = adev.sigma_y[j];
+            if (!isFinite(s) || s <= 0) continue;
+            if (s < sigmaMin) sigmaMin = s;
+            if (s > sigmaMax) sigmaMax = s;
+        }
+        if (!isFinite(sigmaMin) || !isFinite(sigmaMax)) return;
+        var logSigMin = Math.floor(Math.log10(sigmaMin) - 0.5);
+        var logSigMax = Math.ceil(Math.log10(sigmaMax) + 0.5);
+        if (logSigMax - logSigMin < 2) {
+            logSigMax = logSigMin + 2;
+        }
+
+        function xOf(tau) {
+            return pad.l + plotW * ((Math.log10(tau) - logTauMin) / (logTauMax - logTauMin));
+        }
+        function yOf(sigma) {
+            return pad.t + plotH * (1 - (Math.log10(sigma) - logSigMin) / (logSigMax - logSigMin));
+        }
+
+        // Grid (decade lines on both axes).
+        ctx.strokeStyle = 'rgba(127,127,127,0.18)';
+        ctx.lineWidth = 1;
+        ctx.font = '10px ui-monospace, monospace';
+        ctx.fillStyle = 'rgba(127,127,127,0.85)';
+        ctx.textBaseline = 'middle';
+        ctx.textAlign = 'right';
+        for (var ly = logSigMin; ly <= logSigMax; ly++) {
+            var yy = yOf(Math.pow(10, ly));
+            ctx.beginPath();
+            ctx.moveTo(pad.l, yy); ctx.lineTo(pad.l + plotW, yy);
+            ctx.stroke();
+            ctx.fillText('1e' + ly, pad.l - 4, yy);
+        }
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        for (var lx = logTauMin; lx <= logTauMax; lx++) {
+            var xx = xOf(Math.pow(10, lx));
+            ctx.strokeStyle = 'rgba(127,127,127,0.18)';
+            ctx.beginPath();
+            ctx.moveTo(xx, pad.t); ctx.lineTo(xx, pad.t + plotH);
+            ctx.stroke();
+            ctx.fillText(Math.pow(10, lx) + ' s', xx, pad.t + plotH + 4);
+        }
+
+        // Trace.
+        ctx.strokeStyle = '#bc8cff';
+        ctx.lineWidth = 1.8;
+        ctx.beginPath();
+        var started = false;
+        for (var k = 0; k < adev.tau_s.length; k++) {
+            var sigma = adev.sigma_y[k];
+            if (!isFinite(sigma) || sigma <= 0) continue;
+            var px = xOf(adev.tau_s[k]);
+            var py = yOf(sigma);
+            if (!started) { ctx.moveTo(px, py); started = true; }
+            else ctx.lineTo(px, py);
+        }
+        ctx.stroke();
+
+        // Markers.
+        ctx.fillStyle = '#bc8cff';
+        for (var m = 0; m < adev.tau_s.length; m++) {
+            var sm = adev.sigma_y[m];
+            if (!isFinite(sm) || sm <= 0) continue;
+            ctx.beginPath();
+            ctx.arc(xOf(adev.tau_s[m]), yOf(sm), 3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
+
+    // ── SNR-vs-elevation scatter.  Each visible satellite plotted as a
+    //    coloured dot keyed to its constellation; X = elevation in
+    //    degrees [0, 90], Y = SNR in dBHz [0, 55].
+    function renderElevationScatter(sats) {
+        var canvas = document.getElementById('ts-elev-canvas');
+        if (!canvas) return;
+        var emptyEl = document.getElementById('ts-elev-empty');
+
+        var usable = (sats || []).filter(function (s) {
+            return typeof s.elevation === 'number'
+                && typeof s.snr === 'number'
+                && s.elevation >= 0;
+        });
+
+        setText('ts-elev-n', usable.length);
+        if (!usable.length) {
+            if (emptyEl) emptyEl.style.display = '';
+            setText('ts-elev-avg', '—');
+            setText('ts-elev-zenith', '—');
+            return;
+        }
+        if (emptyEl) emptyEl.style.display = 'none';
+
+        var avg = usable.reduce(function (a, s) { return a + s.snr; }, 0) / usable.length;
+        setText('ts-elev-avg', avg.toFixed(1) + ' dBHz');
+
+        // Highest-elevation satellite — a useful single-number summary
+        // of "what does the antenna look like overhead?".
+        var highest = usable.reduce(function (best, s) {
+            return s.elevation > best.elevation ? s : best;
+        }, usable[0]);
+        setText('ts-elev-zenith', highest.elevation + '° / ' + highest.snr + ' dBHz');
+
+        var fit = fitCanvas(canvas);
+        var ctx = fit.ctx, W = fit.w, H = fit.h;
+        ctx.clearRect(0, 0, W, H);
+
+        var pad = { l: 36, r: 10, t: 10, b: 28 };
+        var plotW = W - pad.l - pad.r;
+        var plotH = H - pad.t - pad.b;
+
+        function xOf(elev) { return pad.l + plotW * (Math.max(0, Math.min(90, elev)) / 90); }
+        function yOf(snr)  { return pad.t + plotH * (1 - Math.max(0, Math.min(55, snr)) / 55); }
+
+        // Grid: elevation gridlines at 30°/60°, SNR gridlines at 20/35/50.
+        ctx.strokeStyle = 'rgba(127,127,127,0.18)';
+        ctx.lineWidth = 1;
+        ctx.font = '10px ui-monospace, monospace';
+        ctx.fillStyle = 'rgba(127,127,127,0.85)';
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        [20, 35, 50].forEach(function (val) {
+            var y = yOf(val);
+            ctx.beginPath(); ctx.moveTo(pad.l, y); ctx.lineTo(pad.l + plotW, y); ctx.stroke();
+            ctx.fillText(val, pad.l - 4, y);
+        });
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        [0, 30, 60, 90].forEach(function (deg) {
+            var x = xOf(deg);
+            ctx.beginPath(); ctx.moveTo(x, pad.t); ctx.lineTo(x, pad.t + plotH); ctx.stroke();
+            ctx.fillText(deg + '°', x, pad.t + plotH + 4);
+        });
+
+        // Reference curve — typical "good install" trend (rough heuristic):
+        // SNR rises from ~20 dBHz at 0° to ~45 dBHz at 90° on a clean roof.
+        ctx.strokeStyle = 'rgba(127,127,127,0.30)';
+        ctx.setLineDash([4, 3]);
+        ctx.beginPath();
+        ctx.moveTo(xOf(0),  yOf(20));
+        ctx.lineTo(xOf(90), yOf(45));
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        // Plot each satellite.
+        usable.forEach(function (s) {
+            var info = constInfo(s.constellation || (s.prn_string ? s.prn_string.slice(0, 2) : null));
+            ctx.fillStyle = info.color;
+            ctx.beginPath();
+            ctx.arc(xOf(s.elevation), yOf(s.snr), 3.5, 0, Math.PI * 2);
+            ctx.fill();
+        });
     }
 
     // ── Render everything from a single snapshot.  Tolerates missing
@@ -1379,6 +1860,14 @@
         // Time-series sparklines — push into ring buffers then redraw.
         ingestTimeSeries(snapshot);
         renderTimeSeriesCharts();
+
+        // Phase 1 panels: jitter histogram, Allan deviation, SNR-vs-
+        // elevation scatter.  These all read directly from the latest
+        // GPS payload (no client-side ring buffer) because the manager
+        // already owns the rolling window we'd otherwise build here.
+        renderJitterHistogram(gps.pps_jitter || null);
+        renderAllanDeviation(gps.allan_deviation || null);
+        renderElevationScatter(gps.satellites_in_view || []);
     }
 
     // ── Polling.  Configurable interval; "0" means paused.


### PR DESCRIPTION
## Summary
Extends the GPS dashboard with advanced timing diagnostics by adding four new visualization panels and supporting infrastructure for PPS (Pulse Per Second) analysis. The changes enable operators to monitor receiver stability, frequency deviation, antenna health, and GPS lock status through new charts and metrics.

## Key Changes

### Frontend (HTML/JavaScript)
- **New dashboard panels** (4 total):
  - PPS Jitter Histogram: Distribution of inter-pulse intervals relative to 1-second nominal, with color-coded buckets (green for healthy, amber for wide, red for outliers)
  - Allan Deviation: Log-log plot of overlapping σ_y(τ) at τ = 1, 10, 100 seconds for frequency stability analysis
  - SNR vs Elevation: Scatter plot of all visible satellites with reference curve for healthy antenna performance
  - Holdover Timer: Sparkline showing seconds since last 3D fix

- **New GPS status fields** in the summary tile:
  - Fix age: Time since last NMEA sentence (color-coded: green <2s, red >5s)
  - Holdover: Seconds since last 3D fix with lock indicator
  - Leap state: Leap-second annunciator (fallback to GPS manager when chrony unavailable)

- **New formatting helpers**:
  - `fmtDuration()`: Adaptive duration formatter (seconds → minutes/hours/days)
  - `fmtNs()`: Nanosecond-to-microsecond/millisecond converter
  - `fmtAdev()`: Engineering notation for dimensionless ADEV values

- **Rendering functions**:
  - `renderJitterHistogram()`: Vertical bar chart with grid lines and axis labels
  - `renderAllanDeviation()`: Log-log trace plot with decade gridlines
  - `renderElevationScatter()`: Constellation-colored scatter with reference trend line
  - Time-series ingestion now tracks holdover history in ring buffer

### Backend (Python)
- **PPS interval tracking**: Added `_pps_interval_ns` deque (1024-sample ring buffer) to capture nanosecond-precision inter-pulse intervals from kernel PPS device
- **Holdover anchor**: `_last_3d_fix_at` timestamp captures the instant of the most recent 3D fix (mode=3), enabling holdover timer calculation
- **New `get_status()` fields**:
  - `pps_jitter`: Histogram with mean/stddev/peak/median in nanoseconds
  - `allan_deviation`: τ and σ_y arrays for τ ∈ {1, 10, 100} seconds
  - `fix_age_s`: Seconds since last NMEA sentence
  - `holdover_s`: Seconds since last 3D fix (0 when locked, None if never locked)
  - `leap_state`: Best-effort leap-second string

- **Jitter computation** (`_compute_jitter_summary()`):
  - 12-bucket histogram spanning ±100 µs (20 µs per bucket)
  - Computes mean, standard deviation, peak, and median of inter-pulse deltas
  - Tolerates <2 samples gracefully

- **Allan deviation** (`_compute_allan_deviation()`):
  - Overlapping ADEV estimator using phase reconstruction from intervals
  - Supports τ = 1, 10, 100 seconds with automatic buffer-size validation
  - Returns dimensionless fractional-frequency stability metric

- **PPS kernel polling**: Changed from 1 Hz to 10 Hz cadence for better responsiveness while remaining trivially cheap; now captures nanosecond timestamps and computes inter-pulse intervals with validation (500 ms – 1.5 s range to reject missed pulses)

- **Leap-second fallback** (`_derive_leap_state()`): Returns "normal" when fix is held, "unknown" otherwise (chrony's leap_status remains authoritative on dashboard)

- **NMEA/gpsd integration**: Both paths now update `_last_3d_fix_at` when mode=3 is detected

### Hardware Service

https://claude.ai/code/session_01PaKhj5xHDhQB4q3eJhEVLN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced GPS dashboard with advanced diagnostics displays including PPS jitter histograms and Allan deviation plots.
  * New GPS metrics: fix age, holdover timer, antenna status, RF/jamming status, and leap-second state tracking.
  * Improved receiver telemetry extraction and monitoring capabilities for enhanced timing accuracy assessment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2068)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->