### PR TITLE
Fix empty PPS jitter / Allan deviation panels and add 3D skyview toggle

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -498,6 +498,17 @@ class GPSManager:
             last_3d = self._last_3d_fix_at
         now_utc = datetime.now(timezone.utc)
 
+        # Diagnostic: which PPS backend is active and how many
+        # intervals have we captured?  Lets the operator self-diagnose
+        # the "Waiting for PPS pulses…" empty state on the dashboard.
+        if self._pps_kernel_device:
+            data["pps_backend"] = "kernel"
+        elif self._pps_gpio_active:
+            data["pps_backend"] = "gpio"
+        else:
+            data["pps_backend"] = "none"
+        data["pps_interval_samples"] = len(interval_samples)
+
         # Compute age of the last PPS pulse so the UI can colour the blinkenlite
         last_pulse = data.get("pps_last_pulse_at")
         if last_pulse:
@@ -1638,9 +1649,11 @@ class GPSManager:
         """Spawn a low-rate poller of ``<device>/assert`` and update the fix."""
         # Capture the current sequence so pps_pulse_count reflects pulses
         # observed since this manager started, matching the existing
-        # RPi.GPIO semantic.
-        seq, _ts = self._read_pps_assert(device) or (None, None)
-        self._pps_kernel_baseline_seq = seq if seq is not None else 0
+        # RPi.GPIO semantic.  ``_read_pps_assert`` returns a 3-tuple
+        # ``(seq, ts_ns, ts_iso)`` — taking just the sequence here is
+        # all we need for the baseline.
+        baseline = self._read_pps_assert(device)
+        self._pps_kernel_baseline_seq = baseline[0] if baseline else 0
         self._pps_kernel_device = device
 
         thread = threading.Thread(
@@ -1759,11 +1772,35 @@ class GPSManager:
             )
 
     def _pps_pulse_callback(self, channel: int) -> None:
-        """Called by the RPi.GPIO interrupt thread on each PPS rising edge."""
-        now = datetime.now(timezone.utc).isoformat()
+        """Called by the RPi.GPIO interrupt thread on each PPS rising edge.
+
+        We also capture the inter-pulse interval here (using
+        ``time.monotonic_ns`` rather than the kernel's ns-precision
+        assert timestamp) so the dashboard's jitter histogram and
+        Allan-deviation panels still render meaningful data on hosts
+        that don't have the ``pps-gpio`` kernel overlay loaded.
+
+        Caveat: monotonic_ns timestamps go through Python's GIL and
+        the RPi.GPIO C extension's IRQ handler, which adds tens of µs
+        of jitter on top of the receiver's actual PPS edge.  That's
+        good enough for the histogram (whose smallest bucket is 20 µs
+        anyway) but the absolute σ value will read higher than the
+        kernel-PPS path would report on the same hardware.
+        """
+        now_mono_ns = time.monotonic_ns()
+        now_iso = datetime.now(timezone.utc).isoformat()
         with self._lock:
-            self._fix["pps_last_pulse_at"] = now
+            last_mono = getattr(self, "_pps_gpio_last_mono_ns", None)
+            self._pps_gpio_last_mono_ns = now_mono_ns
+            self._fix["pps_last_pulse_at"] = now_iso
             self._fix["pps_pulse_count"] = self._fix.get("pps_pulse_count", 0) + 1
+            if last_mono is not None:
+                interval_ns = now_mono_ns - last_mono
+                # Mirror the kernel-loop sanity gate: drop pathological
+                # intervals (clock step, dropped pulse) so they don't
+                # poison the histogram or ADEV calculation.
+                if 500_000_000 <= interval_ns <= 1_500_000_000:
+                    self._pps_interval_ns.append(interval_ns)
 
     def _apply_system_time(self, dt_utc: datetime) -> None:
         """Set the system clock to the GPS-provided UTC time.

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -373,8 +373,16 @@
                 </div>
 
                 <div class="gps-sky-wrap">
+                    <div class="gps-sky-toolbar" style="display:flex; gap:6px; justify-content:flex-end; width:100%; margin-bottom:4px;">
+                        <button type="button" id="gps-dash-sky-mode-2d"
+                                class="btn btn-sm btn-outline-secondary active"
+                                title="Polar sky plot (top-down)">2D</button>
+                        <button type="button" id="gps-dash-sky-mode-3d"
+                                class="btn btn-sm btn-outline-secondary"
+                                title="Tilted orthographic hemisphere (static)">3D</button>
+                    </div>
                     <canvas id="gps-dash-sky-canvas" width="280" height="280"
-                            aria-label="Polar sky plot of satellites in view"></canvas>
+                            aria-label="Sky plot of satellites in view"></canvas>
                     <div class="gps-sky-counts">
                         <span><strong id="gps-dash-active-count">—</strong> active fix</span>
                         <span><strong id="gps-dash-visible-count">—</strong> visible</span>
@@ -885,6 +893,211 @@
             ctx.font = 'bold 9px sans-serif';
             ctx.fillText(String(sat.prn), x, y);
         });
+    }
+
+    // ── 3D sky view — tilted orthographic projection of the celestial
+    //    hemisphere onto the canvas.  Pure-canvas (no Three.js); the
+    //    tilt is fixed (no orbit / drag) so we don't have to handle
+    //    pointer events.  Z-sort the satellites back-to-front so the
+    //    front hemisphere occludes the back like you'd expect.
+    //
+    //    Coordinate convention:
+    //       elev=90°  → straight up      (zenith, top of view)
+    //       elev=0°   → on the horizon ring
+    //       az=0°     → North            (away from viewer when tilted)
+    //       az=90°    → East             (right)
+    //       az=180°   → South            (toward viewer when tilted)
+    //       az=270°   → West             (left)
+    var SKY3D_TILT_DEG = 35;  // tilt the hemisphere forward this much
+
+    function project3d(elevDeg, azDeg) {
+        var el = elevDeg * Math.PI / 180;
+        var az = azDeg * Math.PI / 180;
+        // Sphere coordinates with +y pointing North, +x pointing East,
+        // +z pointing up.
+        var x = Math.cos(el) * Math.sin(az);
+        var y = Math.cos(el) * Math.cos(az);
+        var z = Math.sin(el);
+        // Tilt around the X axis: rotate the +y axis down toward the
+        // viewer so the north horizon recedes upward and the south
+        // horizon comes forward.  Standard rotation matrix.
+        var t = SKY3D_TILT_DEG * Math.PI / 180;
+        var yp = y * Math.cos(t) - z * Math.sin(t);
+        var zp = y * Math.sin(t) + z * Math.cos(t);
+        return { sx: x, sy: -yp, depth: zp };  // -yp because canvas Y grows down
+    }
+
+    function drawSkyPlot3D(canvas, satsInView, activePrns) {
+        var ctx = canvas.getContext('2d');
+        var W = canvas.width, H = canvas.height;
+        ctx.clearRect(0, 0, W, H);
+        var cx = W / 2, cy = H / 2;
+        // Leave a little margin so labels at the rim don't clip.
+        var R = Math.min(cx, cy) - 14;
+
+        function screen(p) {
+            return { x: cx + p.sx * R, y: cy + p.sy * R };
+        }
+
+        // ── Wireframe horizon: trace elev=0° around all 360° of azimuth.
+        //    This is the projected ellipse you'd expect from tilting a
+        //    flat circle in 3D.
+        ctx.strokeStyle = 'rgba(127,127,127,0.45)';
+        ctx.lineWidth = 1.4;
+        ctx.beginPath();
+        for (var az = 0; az <= 360; az += 5) {
+            var p = screen(project3d(0, az));
+            if (az === 0) ctx.moveTo(p.x, p.y); else ctx.lineTo(p.x, p.y);
+        }
+        ctx.stroke();
+
+        // ── Latitude rings at elev = 30° and 60°.  Drop the back half
+        //    behind the horizon to a lighter colour so it reads as
+        //    occluded without us actually clipping.
+        function drawLatRing(elev) {
+            ctx.beginPath();
+            var started = false;
+            for (var az = 0; az <= 360; az += 5) {
+                var p3 = project3d(elev, az);
+                var pt = screen(p3);
+                // depth > 0 → "behind" the horizon plane after tilt.
+                ctx.strokeStyle = (p3.depth > 0)
+                    ? 'rgba(127,127,127,0.18)'
+                    : 'rgba(127,127,127,0.30)';
+                if (!started) { ctx.moveTo(pt.x, pt.y); started = true; }
+                else { ctx.lineTo(pt.x, pt.y); }
+            }
+            ctx.stroke();
+        }
+        drawLatRing(30);
+        drawLatRing(60);
+
+        // ── Meridian arcs at the four cardinal azimuths, rim → zenith.
+        function drawMeridian(azDeg) {
+            ctx.beginPath();
+            var started = false;
+            for (var elev = 0; elev <= 90; elev += 5) {
+                var p3 = project3d(elev, azDeg);
+                var pt = screen(p3);
+                ctx.strokeStyle = (p3.depth > 0)
+                    ? 'rgba(127,127,127,0.15)'
+                    : 'rgba(127,127,127,0.25)';
+                if (!started) { ctx.moveTo(pt.x, pt.y); started = true; }
+                else { ctx.lineTo(pt.x, pt.y); }
+            }
+            ctx.stroke();
+        }
+        [0, 90, 180, 270].forEach(drawMeridian);
+
+        // Zenith dot — small marker so you can see "straight up" at a
+        // glance even before any sats render.
+        var zen = screen(project3d(90, 0));
+        ctx.beginPath(); ctx.arc(zen.x, zen.y, 1.5, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(127,127,127,0.6)';
+        ctx.fill();
+
+        // Cardinal labels — placed slightly outside the horizon ellipse.
+        ctx.fillStyle = 'rgba(127,127,127,0.75)';
+        ctx.font = '11px sans-serif';
+        ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        function cardinal(label, az, padPx) {
+            var p3 = project3d(0, az);
+            // Push outward along the projection's radial direction so
+            // the label sits just outside the horizon ring.  Foreshortening
+            // squashes the y axis under tilt, so we measure the radial
+            // distance after projection rather than assuming R.
+            var len = Math.hypot(p3.sx, p3.sy) || 1;
+            var dx = p3.sx / len, dy = p3.sy / len;
+            var screenR = R * len;
+            ctx.fillText(label, cx + dx * (screenR + padPx), cy + dy * (screenR + padPx));
+        }
+        cardinal('N', 0,   10);
+        cardinal('E', 90,  10);
+        cardinal('S', 180, 10);
+        cardinal('W', 270, 10);
+
+        // ── Satellites: project, sort by depth (back-to-front), draw.
+        var activeSet = {};
+        (activePrns || []).forEach(function (p) { activeSet[p] = true; });
+
+        var sats = [];
+        (satsInView || []).forEach(function (sat) {
+            if (sat.elevation === null || sat.azimuth === null ||
+                sat.elevation === undefined || sat.azimuth === undefined) return;
+            var elev = Math.max(0, Math.min(90, sat.elevation));
+            var p3 = project3d(elev, sat.azimuth);
+            var s = screen(p3);
+            sats.push({ sat: sat, sx: s.x, sy: s.y, depth: p3.depth });
+        });
+        // Larger depth = farther away → draw first.
+        sats.sort(function (a, b) { return b.depth - a.depth; });
+
+        sats.forEach(function (entry) {
+            var sat = entry.sat;
+            var info = constInfo(sat.constellation);
+            var alpha = (sat.snr === null || sat.snr === undefined)
+                ? 0.55
+                : Math.max(0.3, Math.min(1, sat.snr / 50));
+            // Sats behind the horizon plane get extra dimming so the
+            // viewer reads them as "around the back".
+            if (entry.depth > 0) alpha *= 0.55;
+
+            if (activeSet[sat.prn]) {
+                ctx.beginPath();
+                ctx.arc(entry.sx, entry.sy, 11, 0, Math.PI * 2);
+                ctx.strokeStyle = info.color;
+                ctx.lineWidth = 2;
+                ctx.globalAlpha = (entry.depth > 0) ? 0.25 : 0.5;
+                ctx.stroke();
+                ctx.globalAlpha = 1;
+            }
+            ctx.beginPath();
+            ctx.arc(entry.sx, entry.sy, 7, 0, Math.PI * 2);
+            ctx.fillStyle = info.color;
+            ctx.globalAlpha = alpha;
+            ctx.fill();
+            ctx.globalAlpha = 1;
+            ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+            ctx.lineWidth = 1;
+            ctx.stroke();
+
+            ctx.fillStyle = '#fff';
+            ctx.font = 'bold 9px sans-serif';
+            ctx.fillText(String(sat.prn), entry.sx, entry.sy);
+        });
+    }
+
+    // Pick the renderer based on the current toggle state.  Persisted
+    // in localStorage so the operator's preference survives a reload.
+    var SKY_MODE_KEY = 'gps-dash-sky-mode';
+    function getSkyMode() {
+        try {
+            var v = localStorage.getItem(SKY_MODE_KEY);
+            return v === '3d' ? '3d' : '2d';
+        } catch (e) { return '2d'; }
+    }
+    function setSkyMode(mode) {
+        try { localStorage.setItem(SKY_MODE_KEY, mode); } catch (e) {}
+        var btn2 = document.getElementById('gps-dash-sky-mode-2d');
+        var btn3 = document.getElementById('gps-dash-sky-mode-3d');
+        if (btn2) btn2.classList.toggle('active', mode === '2d');
+        if (btn3) btn3.classList.toggle('active', mode === '3d');
+        // Re-render immediately so the toggle feels snappy even
+        // between live polls.
+        if (lastSnapshot) {
+            var canvas = document.getElementById('gps-dash-sky-canvas');
+            if (canvas) {
+                var gps = lastSnapshot.gps || {};
+                drawSkyPlotAuto(canvas, gps.satellites_in_view || [], gps.active_satellite_prns || []);
+            }
+        }
+    }
+    function drawSkyPlotAuto(canvas, satsInView, activePrns) {
+        if (getSkyMode() === '3d') {
+            drawSkyPlot3D(canvas, satsInView, activePrns);
+        } else {
+            drawSkyPlot(canvas, satsInView, activePrns);
+        }
     }
 
     // ── Per-PRN SNR bar chart — flexbox of fixed-height bars.  Sorted by
@@ -1924,7 +2137,7 @@
 
         // Skyview
         var canvas = document.getElementById('gps-dash-sky-canvas');
-        if (canvas) drawSkyPlot(canvas, gps.satellites_in_view || [], gps.active_satellite_prns || []);
+        if (canvas) drawSkyPlotAuto(canvas, gps.satellites_in_view || [], gps.active_satellite_prns || []);
         renderGpsSummary(gps);
         renderConstellationChips(gps.satellites_in_view || [], gps.active_satellite_prns || []);
         renderSnrChart(gps.satellites_in_view || [], gps.active_satellite_prns || []);
@@ -1969,6 +2182,13 @@
             });
             schedule(parseInt(sel.value, 10) || 0);
         }
+        // 2D / 3D sky toggle.  Apply the persisted choice on load,
+        // then wire the click handlers so flipping is instant.
+        setSkyMode(getSkyMode());
+        var btn2 = document.getElementById('gps-dash-sky-mode-2d');
+        var btn3 = document.getElementById('gps-dash-sky-mode-3d');
+        if (btn2) btn2.addEventListener('click', function () { setSkyMode('2d'); });
+        if (btn3) btn3.addEventListener('click', function () { setSkyMode('3d'); });
         // Redraw sparklines on viewport resize so HiDPI / responsive
         // layout changes don't leave stale low-res traces.
         var resizeTimer = null;


### PR DESCRIPTION
The jitter histogram and Allan deviation panels stayed empty in production because of two coupled bugs:

1. _start_pps_kernel_monitor still destructured _read_pps_assert into 2 values after Phase 1 changed the function to return a 3-tuple.  This raised ValueError during PPS startup, the kernel PPS monitor crashed, and the manager fell back to the RPi.GPIO path -- which never captured intervals at all.

2. _pps_pulse_callback (the GPIO fallback) only counted pulses; it never appended to _pps_interval_ns.  So even with the kernel monitor working we'd be one regression away from the same empty state.  The callback now records monotonic_ns intervals so the histogram and ADEV stay populated regardless of which backend ends up active.

get_status() now also reports pps_backend ("kernel"|"gpio"|"none") and pps_interval_samples so an operator can self-diagnose this class of issue without having to read the logs.

Separately, the Skyview card gains a 2D / 3D toggle.  The 3D mode is a tilted orthographic projection of the celestial hemisphere drawn entirely in canvas (no Three.js dependency, no orbit controls) -- a 35 deg fixed forward tilt with z-sorted satellites so the front hemisphere occludes the back the way you'd expect. The choice persists in localStorage so reloads keep the operator's preference.