### PR TITLE
Fix audio source stall detection and DB session recovery

### DIFF
--- a/app_core/audio/ingest.py
+++ b/app_core/audio/ingest.py
@@ -126,6 +126,58 @@ class AudioSourceConfig:
             self.device_params = {}
 
 
+def _describe_stall(adapter: "AudioSourceAdapter", now: float, last_update: float) -> str:
+    """Summarise an adapter's state for stall diagnostics.
+
+    Designed for one-line operator-facing logs.  Pulls the bits most useful
+    for triage — uptime, restart count, last error, and adapter-specific
+    health signals (ffmpeg process state for streams, capture-handle state
+    for SDR sources) — so root cause is visible without flipping debug logs.
+    """
+    parts: List[str] = []
+
+    uptime = now - adapter._start_time if adapter._start_time else 0.0
+    parts.append(f"uptime={uptime:.1f}s")
+    parts.append(f"restarts={adapter._restart_count}")
+
+    if last_update and last_update > 0:
+        parts.append(f"last_sample_age={now - last_update:.1f}s")
+    else:
+        parts.append("last_sample_age=never")
+
+    last_err = (adapter._last_error or "").strip()
+    if last_err:
+        parts.append(f"last_error={last_err[:120]!r}")
+
+    # Stream-source-specific signals — exposed by StreamSourceAdapter only.
+    process = getattr(adapter, "_ffmpeg_process", None)
+    if process is not None:
+        try:
+            rc = process.poll()
+        except Exception:
+            rc = "poll-error"
+        if rc is None:
+            parts.append(f"ffmpeg_pid={process.pid}(running)")
+        else:
+            parts.append(f"ffmpeg_pid={process.pid}(exit={rc})")
+        attempts = getattr(adapter, "_connection_attempts", None)
+        successes = getattr(adapter, "_successful_connections", None)
+        if attempts is not None:
+            parts.append(f"ffmpeg_connects={successes}/{attempts}")
+        url = getattr(adapter, "_resolved_stream_url", None) or getattr(adapter, "_stream_url", None)
+        if url:
+            parts.append(f"url={url}")
+
+    # SDR-source-specific signals — exposed by SDRSourceAdapter.
+    receiver_id = getattr(adapter, "_receiver_id", None)
+    if receiver_id:
+        parts.append(f"receiver={receiver_id}")
+        if getattr(adapter, "_capture_handle", None) is None:
+            parts.append("capture_handle=none")
+
+    return ", ".join(parts)
+
+
 class AudioSourceAdapter(ABC):
     """Abstract base class for audio source adapters."""
 
@@ -704,6 +756,15 @@ class AudioIngestController:
         self._flask_app = flask_app  # Store Flask app for app context in background threads
         self._metadata_change_callback = None  # Applied to every source (current and future)
         self._source_alert_callback = None  # Optional: called on source events (restart/error/stop)
+        # Tracks how many times in a row a source has stalled without producing a
+        # single fresh sample between restarts.  ``adapter.restart()`` only counts
+        # a restart as failed when ``start()`` raises or returns False, so a stream
+        # whose ffmpeg launches fine but never delivers audio (dead URL, dead SDR)
+        # would otherwise cycle forever.  When this counter exceeds
+        # ``_stall_quarantine_threshold`` the monitor escalates the source to
+        # ERROR and lets the adapter's own quarantine timer back off the loop.
+        self._consecutive_stalls: Dict[str, int] = {}
+        self._stall_quarantine_threshold = 3
         # Headers injected via inject_eas_test_signal() — decoded alerts whose
         # raw_header matches an entry here are known-synthetic and get confidence=1.0.
         self._synthetic_headers: set = set()
@@ -1105,6 +1166,7 @@ class AudioIngestController:
         now: float,
     ) -> None:
         if not adapter.config.enabled:
+            self._consecutive_stalls.pop(name, None)
             return
 
         # Quarantined sources are skipped to break the restart-storm cycle
@@ -1120,8 +1182,60 @@ class AudioIngestController:
                 return
             last_update = adapter._last_metrics_update or (adapter.metrics.timestamp if adapter.metrics else 0.0)
             if last_update == 0.0 or now - last_update > self._monitor_stall_seconds:
+                stalls = self._consecutive_stalls.get(name, 0) + 1
+                self._consecutive_stalls[name] = stalls
+                diagnostics = _describe_stall(adapter, now, last_update)
+                logger.warning(
+                    "%s: stalled capture detected (no audio samples for %.1fs, "
+                    "consecutive=%d/%d) — %s",
+                    name,
+                    now - last_update if last_update else -1.0,
+                    stalls,
+                    self._stall_quarantine_threshold,
+                    diagnostics,
+                )
                 self._fire_source_alert(adapter.config.name, "stall", "stalled capture (no audio samples)")
-                adapter.restart("stalled capture (no audio samples)")
+
+                if stalls >= self._stall_quarantine_threshold:
+                    # adapter.restart() keeps succeeding because ``start()`` only
+                    # checks process/handle creation, not whether samples ever
+                    # arrive.  Force ERROR + quarantine here so the monitor
+                    # stops cycling and operators get a visible failure state
+                    # in the UI instead of an endless WARNING stream.
+                    logger.error(
+                        "%s: escalating to ERROR after %d consecutive stalls — %s",
+                        name,
+                        stalls,
+                        diagnostics,
+                    )
+                    try:
+                        adapter.stop()
+                    except Exception as exc:
+                        logger.error("%s: error stopping stalled source: %s", name, exc, exc_info=True)
+                    adapter.status = AudioSourceStatus.ERROR
+                    adapter.error_message = f"no audio samples after {stalls} restarts ({diagnostics})"
+                    adapter._last_error = adapter.error_message
+                    adapter._quarantined_until = time.time() + adapter._quarantine_seconds
+                    self._fire_source_alert(
+                        adapter.config.name,
+                        "error",
+                        adapter.error_message,
+                    )
+                    self._consecutive_stalls[name] = 0
+                else:
+                    adapter.restart("stalled capture (no audio samples)")
+            else:
+                # Only treat the tick as "healthy" — and reset the stall
+                # counter — when ``_last_metrics_update`` reflects an actual
+                # audio chunk, not the timestamp ``start()`` writes at launch.
+                # Without this guard the counter would clear on every cycle
+                # immediately after ``adapter.restart()``, since the restart
+                # itself bumps ``_last_metrics_update`` to "now" even when no
+                # samples ever flowed — turning the escalation into a no-op
+                # on streams that always stall.
+                started_at = adapter._start_time or 0.0
+                if last_update > started_at + self._monitor_grace_period:
+                    self._consecutive_stalls.pop(name, None)
             return
 
         if status in (AudioSourceStatus.ERROR, AudioSourceStatus.DISCONNECTED):

--- a/app_core/websocket_push.py
+++ b/app_core/websocket_push.py
@@ -185,6 +185,25 @@ def stop_websocket_push() -> None:
     logger.info("WebSocket push service stopped")
 
 
+def _recover_db_session() -> None:
+    """Roll back the shared SQLAlchemy session after a failed emit.
+
+    The push worker reuses one ``app.app_context()`` for its entire lifetime,
+    so all emits share a single scoped session.  When any DB call inside an
+    emit raises (network blip, query error, etc.) PostgreSQL leaves that
+    session's transaction in the aborted state and every subsequent statement
+    fails with InFailedSqlTransaction — including the ``SELECT version()``
+    probe in the system-health snapshot, which then bubbles up to the UI as
+    a "Critical System Notice".  Rolling back here lets the next emit start
+    clean.
+    """
+    try:
+        from app_core.extensions import db
+        db.session.rollback()
+    except Exception:
+        pass
+
+
 def _push_worker(app: 'Flask', socketio: 'SocketIO') -> None:
     """Background worker that pushes real-time updates via WebSocket.
 
@@ -377,6 +396,13 @@ def _push_worker(app: 'Flask', socketio: 'SocketIO') -> None:
                     last_alerts_emit = now
                 except Exception as e:
                     logger.debug(f"Error emitting alerts_update: {e}")
+
+            # Roll back the shared session once per iteration so a failed
+            # DB call in any emit above doesn't leave the next iteration's
+            # queries running against an aborted PostgreSQL transaction.
+            # SQLAlchemy short-circuits rollback when no transaction is
+            # active, so this is effectively free on the happy path.
+            _recover_db_session()
 
             # Sleep for 250ms (4Hz base loop) — low CPU, smooth VU meters
             _stop_event.wait(AUDIO_MONITORING_INTERVAL)

--- a/app_utils/system.py
+++ b/app_utils/system.py
@@ -372,6 +372,15 @@ def build_system_health_snapshot(db, logger) -> SystemHealth:
 
         db_status = "unknown"
         db_info: Dict[str, Any] = {}
+        # If a prior query in the same scoped session left the PostgreSQL
+        # transaction in the aborted state (InFailedSqlTransaction), every
+        # subsequent statement raises until a rollback. The websocket push
+        # loop reuses one session across many emits, so a single failed
+        # query elsewhere would otherwise wedge this probe forever.
+        try:
+            db.session.rollback()
+        except Exception:
+            pass
         try:
             version_result = db.session.execute(text("SELECT version()"))
             if version_result:
@@ -386,6 +395,10 @@ def build_system_health_snapshot(db, logger) -> SystemHealth:
                     if size_result:
                         db_info["size"] = size_result[0]
                 except Exception:
+                    try:
+                        db.session.rollback()
+                    except Exception:
+                        pass
                     db_info["size"] = "Unknown"
 
                 try:
@@ -395,9 +408,19 @@ def build_system_health_snapshot(db, logger) -> SystemHealth:
                     if conn_result:
                         db_info["active_connections"] = conn_result[0]
                 except Exception:
+                    try:
+                        db.session.rollback()
+                    except Exception:
+                        pass
                     db_info["active_connections"] = "Unknown"
         except Exception as exc:
-            db_status = f"error: {exc}"
+            try:
+                db.session.rollback()
+            except Exception:
+                pass
+            logger.warning("Database health probe failed: %s", exc)
+            db_status = "error"
+            db_info["error"] = str(exc)[:200]
 
         systemd_services = _collect_systemd_services(logger)
         services_status: Dict[str, Any] = {

--- a/tests/test_stall_detection_fix.py
+++ b/tests/test_stall_detection_fix.py
@@ -232,5 +232,54 @@ def test_ffmpeg_analyzeduration_is_2s():
     )
 
 
+# ---------------------------------------------------------------------------
+# Test 6: a source that never produces audio gets escalated to ERROR and
+#         quarantined after _stall_quarantine_threshold consecutive stalls,
+#         rather than restart-looping forever.
+# ---------------------------------------------------------------------------
+def test_persistent_stall_escalates_to_error_and_quarantine():
+    """A stream that always stalls must eventually surface as ERROR + quarantine.
+
+    Regression guard against the original behaviour: ``adapter.restart()``
+    only counts a restart as failed when ``start()`` raises or returns False,
+    so a stream whose ffmpeg launches fine but never delivers audio (dead
+    URL, dead SDR) would otherwise cycle forever.  The monitor must track
+    its own consecutive-stall counter and force ERROR + quarantine.
+    """
+    adapter = SlowStartAdapter("stall-test-escalate")
+    controller = AudioIngestController(
+        enable_monitor=True,
+        monitor_interval=0.2,
+        stall_seconds=2,  # tight so the test runs in seconds, not minutes
+    )
+    controller._monitor_grace_period = 0.5
+    controller._stall_quarantine_threshold = 3
+    controller.add_source(adapter)
+    adapter.start()
+
+    # Each stall cycle takes roughly grace(0.5) + stall(2) + restart_delay ~ 3s
+    # so 3 cycles fit comfortably in ~15s.
+    deadline = time.time() + 20
+    while adapter.status != AudioSourceStatus.ERROR and time.time() < deadline:
+        time.sleep(0.2)
+
+    final_status = adapter.status
+    final_quarantined = adapter.is_quarantined()
+    final_error = adapter.error_message
+
+    controller.stop_all()
+
+    assert final_status == AudioSourceStatus.ERROR, (
+        "Expected adapter to be escalated to ERROR after consecutive stalls, "
+        f"got status={final_status!r}, error={final_error!r}"
+    )
+    assert final_quarantined, (
+        "Expected adapter to be quarantined after ERROR escalation"
+    )
+    assert final_error and "no audio samples" in final_error, (
+        f"Expected error_message to mention missing audio, got {final_error!r}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
This PR addresses two critical issues: (1) audio sources that fail to produce samples but whose adapters successfully start would restart indefinitely without surfacing as errors, and (2) failed database queries in the WebSocket push loop would leave the shared session in an aborted state, causing subsequent health probes to fail.

## Key Changes

### Audio Source Stall Escalation
- **Added `_describe_stall()` helper function** to generate operator-friendly diagnostic summaries for stalled sources, including uptime, restart count, last error, and adapter-specific signals (ffmpeg process state, SDR receiver status, connection attempts).
- **Implemented consecutive stall tracking** via `_consecutive_stalls` dictionary in `AudioIngestController` to count how many times a source stalls without producing audio between restarts.
- **Added stall escalation logic** that forces a source to ERROR status and quarantine after exceeding `_stall_quarantine_threshold` (default: 3) consecutive stalls, rather than restarting indefinitely.
- **Added grace period guard** to prevent the stall counter from resetting immediately after a restart when `_last_metrics_update` reflects the launch timestamp rather than actual audio samples.
- **Enhanced logging** with detailed diagnostics at WARNING level for each stall and ERROR level when escalating to quarantine.

### Database Session Recovery
- **Added `_recover_db_session()` function** in `websocket_push.py` to roll back the shared SQLAlchemy session after failed emits, preventing subsequent queries from failing with `InFailedSqlTransaction`.
- **Integrated session recovery** into the push worker loop to run once per iteration, ensuring a single failed DB call doesn't wedge the entire monitoring pipeline.
- **Added defensive rollback calls** in `build_system_health_snapshot()` before and after database queries to handle cases where the session is already in an aborted state.
- **Improved error handling** in the health probe to gracefully degrade when database queries fail, logging warnings instead of surfacing raw exceptions to the UI.

## Notable Implementation Details
- The stall escalation only triggers when `_last_metrics_update` is older than the adapter's start time plus a grace period, ensuring the counter doesn't reset on false positives immediately after restart.
- The `_describe_stall()` function uses `getattr()` with defaults to safely inspect adapter-specific attributes without coupling to concrete subclass implementations.
- Session rollback is idempotent and short-circuits when no transaction is active, making it safe to call unconditionally.
- Test coverage added for the persistent stall escalation scenario to prevent regression.

https://claude.ai/code/session_019HkF4j2WxDC2ykBgufzFTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stall monitoring for audio sources; stalled sources are now automatically escalated to error status if the condition persists.

* **Bug Fixes**
  * Improved database session handling to prevent transaction deadlocks.
  * Enhanced system health monitoring with better error recovery during database connectivity issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2082)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->