### PR TITLE
Apply MALLOC_ARENA_MAX=2 from inside hardware_service via mallopt()

### DIFF
--- a/app_utils/glibc_tuning.py
+++ b/app_utils/glibc_tuning.py
@@ -1,0 +1,160 @@
+"""Runtime glibc malloc tuning for long-running Python services.
+
+The previous hardware-service memory leak (commit eb48eea — "MALLOC_ARENA_MAX=2
+already cut RSS from 9.68 GB to ~320 MB") was fixed by setting environment
+variables in the systemd unit::
+
+    Environment="MALLOC_ARENA_MAX=2"
+    Environment="MALLOC_TRIM_THRESHOLD_=131072"
+
+Those only take effect at process startup and only when the unit file on
+the live host actually carries them.  On hosts where the unit drifted
+(operator override, missed ``daemon-reload`` after an update, container
+image that didn't pick up the new unit, etc.) the leak resurfaces — and
+because the recently-added GPS code (PPS deque grown 1024 → 16 384,
+ADEV τ=1000 s) does ~17× more allocation per ``get_status()`` than it
+used to, the unchecked arenas now grow at ~1 GB/min instead of the
+~3 MB/min residual we saw before.
+
+This module applies the same tuning *from inside the process* via
+``mallopt(3)`` so the fix is robust to systemd-unit drift, and runs a
+periodic :py:func:`malloc_trim` to actively return free top-of-heap
+memory to the kernel.  It's a no-op on non-glibc platforms (the symbols
+just won't resolve), so it's safe to call unconditionally.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+M_TRIM_THRESHOLD = -1
+M_ARENA_MAX = -8
+
+_libc: Optional[ctypes.CDLL] = None
+
+
+def _get_libc() -> Optional[ctypes.CDLL]:
+    global _libc
+    if _libc is not None:
+        return _libc
+    try:
+        name = ctypes.util.find_library("c") or "libc.so.6"
+        _libc = ctypes.CDLL(name, use_errno=True)
+    except OSError as exc:
+        logger.debug("glibc_tuning: libc not loadable (%s); tuning disabled", exc)
+        _libc = None
+    return _libc
+
+
+def apply_glibc_tuning(arena_max: int = 2, trim_threshold: int = 131072) -> bool:
+    """Apply ``MALLOC_ARENA_MAX`` / ``MALLOC_TRIM_THRESHOLD_`` at runtime.
+
+    Multi-threaded Python on glibc defaults to one malloc arena per CPU,
+    none of which return memory to the kernel.  With the hardware service
+    spawning NMEA / gpsd / PPS / screen / Flask / health-check threads,
+    that grows RSS to multiples of the live working set.  Capping the
+    arena count and lowering the trim threshold keeps RSS honest.
+
+    ``mallopt()`` returns 1 on success and 0 on failure.  This function
+    logs the outcome and returns True iff both settings stuck.  Best
+    called from the main thread before any worker threads are spawned —
+    arena count changes only affect *new* arenas, so applying it after
+    threads have already pinned their own arena is a no-op for those.
+    """
+    libc = _get_libc()
+    if libc is None:
+        return False
+    try:
+        libc.mallopt.argtypes = [ctypes.c_int, ctypes.c_int]
+        libc.mallopt.restype = ctypes.c_int
+    except Exception as exc:
+        logger.debug("glibc_tuning: mallopt binding failed (%s)", exc)
+        return False
+
+    ok = True
+    try:
+        rc = libc.mallopt(M_ARENA_MAX, int(arena_max))
+        if rc != 1:
+            logger.warning(
+                "glibc_tuning: mallopt(M_ARENA_MAX, %d) returned %d", arena_max, rc
+            )
+            ok = False
+        else:
+            logger.info("glibc_tuning: arena cap = %d", arena_max)
+    except Exception as exc:
+        logger.warning("glibc_tuning: mallopt(M_ARENA_MAX) failed: %s", exc)
+        ok = False
+
+    try:
+        rc = libc.mallopt(M_TRIM_THRESHOLD, int(trim_threshold))
+        if rc != 1:
+            logger.warning(
+                "glibc_tuning: mallopt(M_TRIM_THRESHOLD, %d) returned %d",
+                trim_threshold, rc,
+            )
+            ok = False
+        else:
+            logger.info("glibc_tuning: trim threshold = %d", trim_threshold)
+    except Exception as exc:
+        logger.warning("glibc_tuning: mallopt(M_TRIM_THRESHOLD) failed: %s", exc)
+        ok = False
+
+    return ok
+
+
+def malloc_trim(pad: int = 0) -> bool:
+    """Ask glibc to return free top-of-heap memory to the kernel now.
+
+    Returns True if any memory was actually released.  The arenas hold
+    onto small free blocks that ``MALLOC_TRIM_THRESHOLD_`` won't reach
+    on its own once they get fragmented under sustained allocation;
+    calling this periodically is what keeps RSS bounded for services
+    that allocate in tight loops.
+    """
+    libc = _get_libc()
+    if libc is None:
+        return False
+    try:
+        libc.malloc_trim.argtypes = [ctypes.c_size_t]
+        libc.malloc_trim.restype = ctypes.c_int
+        return bool(libc.malloc_trim(int(pad)))
+    except Exception as exc:
+        logger.debug("glibc_tuning: malloc_trim failed: %s", exc)
+        return False
+
+
+def start_malloc_trim_thread(
+    interval_s: float = 60.0,
+    pad: int = 0,
+    stop_event: Optional[threading.Event] = None,
+) -> threading.Thread:
+    """Start a daemon thread that calls :py:func:`malloc_trim` every
+    ``interval_s`` seconds.
+
+    Returns the thread (already started).  Pass ``stop_event`` to halt
+    it from the caller's shutdown path; otherwise the daemon flag means
+    it'll die with the interpreter.
+    """
+    # Use a private event when the caller didn't supply one so we can
+    # still wait()-with-timeout (responsive to interpreter shutdown via
+    # daemon=True) instead of a bare ``time.sleep`` that ignores the
+    # stop signal until the next tick.
+    waiter = stop_event if stop_event is not None else threading.Event()
+
+    def _loop() -> None:
+        while not waiter.wait(timeout=interval_s):
+            try:
+                malloc_trim(pad)
+            except Exception:
+                pass
+
+    thread = threading.Thread(target=_loop, name="glibc-malloc-trim", daemon=True)
+    thread.start()
+    return thread

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -71,6 +71,14 @@ from app_utils.network import (
 # the live host.
 from app_utils.memdiag import install_memdiag_handlers
 
+# Runtime glibc malloc tuning.  The systemd unit sets MALLOC_ARENA_MAX=2
+# / MALLOC_TRIM_THRESHOLD_=131072 (the fix from eb48eea that cut RSS
+# from 9.68 GB → 320 MB), but those only take effect if the live unit
+# carries them.  Apply the same caps from inside the process so the fix
+# is robust to unit drift, and run a periodic malloc_trim() to actively
+# return free top-of-heap memory to the kernel.
+from app_utils.glibc_tuning import apply_glibc_tuning, start_malloc_trim_thread
+
 # Configure logging early
 logging.basicConfig(
     level=logging.INFO,
@@ -3073,6 +3081,21 @@ def main():
     logger.info("=" * 60)
     logger.info("🔌 EAS Station - Dedicated Hardware Service")
     logger.info("=" * 60)
+
+    # Cap glibc arenas and pin the trim threshold *before* any worker
+    # threads spawn — mallopt(M_ARENA_MAX) only affects arenas created
+    # after the call, so doing this here (before the screen / GPIO /
+    # GPS / Flask threads start below) ensures every thread shares the
+    # capped pool.  Mirrors MALLOC_ARENA_MAX=2 / MALLOC_TRIM_THRESHOLD_
+    # in the systemd unit; applying it from inside the process makes
+    # the fix survive unit-file drift on the live host.
+    apply_glibc_tuning(arena_max=2, trim_threshold=131072)
+    # Start a 60 s malloc_trim() ticker so freed top-of-heap memory
+    # actually returns to the kernel under sustained allocation (the
+    # GPS dashboard polling get_status() copies a 16 K-int deque and
+    # builds a phase array per call — without active trim the freed
+    # blocks linger as arena fragmentation).
+    start_malloc_trim_thread(interval_s=60.0)
 
     # Register signal handlers
     signal.signal(signal.SIGTERM, signal_handler)

--- a/tests/test_glibc_tuning.py
+++ b/tests/test_glibc_tuning.py
@@ -1,0 +1,72 @@
+"""Tests for app_utils.glibc_tuning.
+
+The module is a thin ctypes wrapper around glibc's mallopt / malloc_trim,
+so the tests just verify that the wrappers don't blow up and that the
+public surface behaves sensibly on platforms where libc is reachable
+(every Linux host this service ships on).  Non-glibc platforms return
+False, which is fine — these tests skip themselves when libc can't be
+loaded so they don't false-positive on a dev macOS box.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Load directly from file (same trick test_memdiag.py uses) so we don't
+# trigger app_utils/__init__.py — glibc_tuning only needs the stdlib.
+_MOD_PATH = Path(__file__).resolve().parents[1] / "app_utils" / "glibc_tuning.py"
+_spec = importlib.util.spec_from_file_location(
+    "app_utils_glibc_tuning_test", _MOD_PATH
+)
+glibc_tuning = importlib.util.module_from_spec(_spec)
+sys.modules["app_utils_glibc_tuning_test"] = glibc_tuning
+_spec.loader.exec_module(glibc_tuning)
+
+
+def _libc_available() -> bool:
+    return glibc_tuning._get_libc() is not None
+
+
+pytestmark = pytest.mark.skipif(
+    not _libc_available(), reason="libc not reachable (non-glibc platform)"
+)
+
+
+def test_apply_glibc_tuning_returns_true_on_glibc():
+    """Both mallopt() calls succeed on the production target."""
+    assert glibc_tuning.apply_glibc_tuning(arena_max=2, trim_threshold=131072) is True
+
+
+def test_apply_glibc_tuning_is_idempotent():
+    """Repeat calls keep returning True — the previous fix recommends
+    applying this once at startup but a hot reload (or an opportunistic
+    re-arm from a watchdog) shouldn't break."""
+    assert glibc_tuning.apply_glibc_tuning(2, 131072) is True
+    assert glibc_tuning.apply_glibc_tuning(2, 131072) is True
+
+
+def test_malloc_trim_does_not_raise():
+    """malloc_trim() returns a bool — its truthiness depends on whether
+    glibc had anything to release, which we can't force from Python.
+    The contract is just "doesn't raise"."""
+    result = glibc_tuning.malloc_trim(0)
+    assert isinstance(result, bool)
+
+
+def test_start_malloc_trim_thread_runs_and_stops():
+    """The ticker thread should honour the stop event so the service's
+    shutdown path can wind it down cleanly."""
+    stop = threading.Event()
+    # Tiny interval so the thread loops at least once during the test
+    # without us having to sleep for a minute.
+    thread = glibc_tuning.start_malloc_trim_thread(interval_s=0.05, stop_event=stop)
+    assert thread.is_alive()
+    time.sleep(0.2)  # let it tick a couple of times
+    stop.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "trim thread did not stop after stop_event was set"


### PR DESCRIPTION
The MALLOC_ARENA_MAX=2 / MALLOC_TRIM_THRESHOLD_=131072 fix from eb48eea
("Cut hardware-service CPU + RSS hot paths") cut RSS from 9.68 GB to
~320 MB by capping glibc's per-thread arena pool.  But it only takes
effect if the live systemd unit on the host actually carries those
Environment= lines — if the unit drifted (manual override, missed
daemon-reload after an update, or a stale install) the leak resurfaces
unchecked.

The recently-added GPS code makes the regression dramatic: the PPS
interval ring went from deque(maxlen=1024) to deque(maxlen=16384) and
ADEV picked up τ=1000 s, so every get_status() call now copies a 16 K-
int deque and runs ~63 K pure-Python float ops to rebuild the phase
sequence.  With the 5 s trend sampler and any open GPS dashboard tab
both polling get_status(), the un-capped arenas grow at ~1 GB/min —
matching the 6.8 GB → 10.9 GB jump observed in htop over 4 minutes.

Fix: apply the malloc caps from inside the process via mallopt() before
any worker threads spawn, so future arenas inherit the cap regardless
of unit-file state.  Also run a 60 s malloc_trim() ticker to actively
return free top-of-heap memory to the kernel — without it, the fragmen-
ted small-block free-lists accumulate even when MALLOC_TRIM_THRESHOLD_
is pinned low.

The new app_utils/glibc_tuning module is a no-op on non-glibc platforms
(libc lookup fails → all functions return False), so it's safe to call
unconditionally.  Tests cover the mallopt + malloc_trim wrappers and
the trim-thread lifecycle.

https://claude.ai/code/session_017x4YacFvQWuJkQRvvpFpVH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced memory efficiency for long-running service processes with configurable runtime memory tuning and automatic periodic memory reclamation.

* **Tests**
  * Added test suite for memory optimization functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2085)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->