### PR TITLE
Account for external LNAs in auto-gain logic

### DIFF
--- a/app_core/_models_radio.py
+++ b/app_core/_models_radio.py
@@ -46,6 +46,7 @@ class RadioReceiver(db.Model):
     audio_sample_rate = db.Column(db.Integer, nullable=True)  # Audio output rate (kHz range, e.g., 48000)
     frequency_correction_ppm = db.Column(db.Float, nullable=False, default=0.0)  # PPM correction for clock drift
     gain = db.Column(db.Float)
+    external_lna_db = db.Column(db.Float, nullable=False, default=0.0)  # External LNA ahead of SDR (dB)
     channel = db.Column(db.Integer)
     serial = db.Column(db.String(128))
     auto_start = db.Column(db.Boolean, nullable=False, default=True)
@@ -109,6 +110,7 @@ class RadioReceiver(db.Model):
             audio_sample_rate=int(audio_rate),
             frequency_correction_ppm=float(self.frequency_correction_ppm or 0.0),
             gain=self.gain,
+            external_lna_db=float(self.external_lna_db or 0.0),
             channel=self.channel,
             serial=self.serial,
             enabled=bool(self.enabled),

--- a/app_core/migrations/versions/20260512_add_external_lna_db_to_radio_receivers.py
+++ b/app_core/migrations/versions/20260512_add_external_lna_db_to_radio_receivers.py
@@ -1,0 +1,63 @@
+"""Add external_lna_db column to radio_receivers.
+
+Outboard LNAs sit between the antenna and the SDR; the SDR's hardware AGC
+has no idea they exist and will happily drive the front-end into clipping
+when one is present. We record the LNA's gain (dB) per receiver so the
+driver can disable AGC and pick a manual gain biased down to compensate.
+
+Revision ID: 20260512_add_external_lna_db_to_radio_receivers
+Revises: 20251114_add_radio_squelch_controls
+Create Date: 2026-05-12
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20260512_add_external_lna_db_to_radio_receivers"
+down_revision = "20251114_add_radio_squelch_controls"
+branch_labels = None
+depends_on = None
+
+
+TABLE_NAME = "radio_receivers"
+COLUMN_NAME = "external_lna_db"
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    inspector = inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _existing_columns(bind, table_name: str) -> set[str]:
+    inspector = inspect(bind)
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, TABLE_NAME):
+        return
+
+    if COLUMN_NAME in _existing_columns(bind, TABLE_NAME):
+        return
+
+    op.add_column(
+        TABLE_NAME,
+        sa.Column(COLUMN_NAME, sa.Float(), nullable=False, server_default=sa.text("0")),
+    )
+    op.alter_column(TABLE_NAME, COLUMN_NAME, server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, TABLE_NAME):
+        return
+
+    if COLUMN_NAME not in _existing_columns(bind, TABLE_NAME):
+        return
+
+    op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -946,20 +946,54 @@ class _SoapySDRReceiver(ReceiverInterface):
                 )
             
             # Configure Gain
+            external_lna_db = float(self.config.external_lna_db or 0.0)
             if self.config.gain is not None:
                 try:
                     device.setGain(SoapySDR.SOAPY_SDR_RX, channel, float(self.config.gain))
                     self._interface_logger.info(
-                        "Set gain to %.1f dB for %s", 
-                        float(self.config.gain), 
-                        self.config.identifier
+                        "Set gain to %.1f dB for %s (external LNA: %+.1f dB)",
+                        float(self.config.gain),
+                        self.config.identifier,
+                        external_lna_db,
                     )
                 except Exception as exc:
                     self._interface_logger.warning(
-                        "Failed to set gain to %.1f dB for %s: %s", 
-                        float(self.config.gain), 
+                        "Failed to set gain to %.1f dB for %s: %s",
+                        float(self.config.gain),
                         self.config.identifier,
                         exc
+                    )
+            elif external_lna_db > 0.0:
+                # An external LNA is present and the user didn't pin a gain.
+                # Hardware AGC has no visibility into the outboard amp, so
+                # leaving it on tends to drive the front-end into clipping.
+                # Disable AGC and pick a manual gain biased down by the LNA's
+                # contribution.
+                try:
+                    if device.hasGainMode(SoapySDR.SOAPY_SDR_RX, channel):
+                        device.setGainMode(SoapySDR.SOAPY_SDR_RX, channel, False)
+                    gain_range = device.getGainRange(SoapySDR.SOAPY_SDR_RX, channel)
+                    g_min = float(gain_range.minimum())
+                    g_max = float(gain_range.maximum())
+                    # Aim at the lower-middle of the range, then back off by the
+                    # external LNA's gain. Clamp to the device range.
+                    target = g_min + 0.4 * (g_max - g_min) - external_lna_db
+                    target = max(g_min, min(g_max, target))
+                    device.setGain(SoapySDR.SOAPY_SDR_RX, channel, target)
+                    self._interface_logger.info(
+                        "Disabled AGC for %s and set manual gain to %.1f dB "
+                        "(range %.1f-%.1f, external LNA: %+.1f dB)",
+                        self.config.identifier,
+                        target,
+                        g_min,
+                        g_max,
+                        external_lna_db,
+                    )
+                except Exception as exc:
+                    self._interface_logger.warning(
+                        "Failed to set LNA-compensated gain for %s: %s",
+                        self.config.identifier,
+                        exc,
                     )
             else:
                 # Enable AGC if gain is not specified and device supports it
@@ -967,18 +1001,18 @@ class _SoapySDRReceiver(ReceiverInterface):
                     if device.hasGainMode(SoapySDR.SOAPY_SDR_RX, channel):
                         device.setGainMode(SoapySDR.SOAPY_SDR_RX, channel, True)
                         self._interface_logger.info(
-                            "Enabled Automatic Gain Control (AGC) for %s (no fixed gain specified)", 
+                            "Enabled Automatic Gain Control (AGC) for %s (no fixed gain specified)",
                             self.config.identifier
                         )
                     else:
                         self._interface_logger.debug(
-                            "Device %s does not support AGC and no gain specified", 
+                            "Device %s does not support AGC and no gain specified",
                             self.config.identifier
                         )
                 except Exception as exc:
                     self._interface_logger.debug(
-                        "Failed to enable AGC for %s: %s", 
-                        self.config.identifier, 
+                        "Failed to enable AGC for %s: %s",
+                        self.config.identifier,
                         exc
                     )
 
@@ -1771,8 +1805,9 @@ class AirspyReceiver(_SoapySDRReceiver):
             channel = self.config.channel if self.config.channel is not None else 0
 
             # Configure gain mode based on whether gain is specified
-            if self.config.gain is None:
-                # No gain specified - enable AGC (automatic gain control)
+            external_lna_db = float(self.config.external_lna_db or 0.0)
+            if self.config.gain is None and external_lna_db <= 0.0:
+                # No gain specified and no outboard amp - enable hardware AGC
                 try:
                     handle.device.setGainMode(handle.sdr.SOAPY_SDR_RX, channel, True)  # Enable AGC
                     self._interface_logger.info(
@@ -1792,16 +1827,26 @@ class AirspyReceiver(_SoapySDRReceiver):
                     except Exception:
                         pass
             else:
-                # Gain specified - use manual gain mode with linearity optimization
+                # Either the user pinned a gain, or there's an external LNA in
+                # front of the SDR. In the LNA case, hardware AGC has no idea
+                # the outboard amp exists and will overload the front-end, so
+                # we disable AGC and pick a manual gain biased down by the
+                # LNA's gain. Airspy linearity range is 0-21 dB.
+                if self.config.gain is not None:
+                    requested_gain = float(self.config.gain)
+                else:
+                    # Aim ~10 dB without an LNA; back off as the LNA grows.
+                    requested_gain = 10.0 - external_lna_db
+                actual_gain = max(0.0, min(21.0, requested_gain))
                 try:
                     handle.device.setGainMode(handle.sdr.SOAPY_SDR_RX, channel, False)  # Disable AGC
-                    # Clamp gain to valid Airspy range (0-21 dB)
-                    actual_gain = max(0.0, min(21.0, float(self.config.gain)))
                     handle.device.setGain(handle.sdr.SOAPY_SDR_RX, channel, actual_gain)
                     self._interface_logger.info(
-                        "Set Airspy %s to manual gain %.1f dB (range 0-21)",
+                        "Set Airspy %s to manual gain %.1f dB (range 0-21, "
+                        "external LNA: %+.1f dB)",
                         self.config.identifier,
-                        actual_gain
+                        actual_gain,
+                        external_lna_db,
                     )
                 except Exception as e:
                     self._interface_logger.warning(

--- a/app_core/radio/manager.py
+++ b/app_core/radio/manager.py
@@ -48,6 +48,11 @@ class ReceiverConfig:
     sample_rate: int  # IQ sample rate (MHz range, e.g., 2400000)
     audio_sample_rate: int = 48000  # Audio output rate (kHz range, e.g., 48000)
     gain: Optional[float] = None
+    # External LNA between antenna and SDR, in dB. When non-zero we treat the
+    # SDR's "auto gain" path as unsafe (hardware AGC has no idea about the
+    # outboard amp and will happily drive the front-end into clipping), so we
+    # disable AGC and pick a manual gain biased down by this amount.
+    external_lna_db: float = 0.0
     channel: Optional[int] = None
     serial: Optional[str] = None
     enabled: bool = True

--- a/tests/test_radio_drivers.py
+++ b/tests/test_radio_drivers.py
@@ -238,6 +238,171 @@ def test_unknown_error_code_still_formats_message():
     assert annotated == "generic error"
 
 
+class _GainRecordingDevice:
+    """Mock SoapySDR device that records gain-related calls."""
+
+    def __init__(self) -> None:
+        self.stream = object()
+        self.calls: list[tuple] = []
+
+    def setSampleRate(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def setFrequency(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def getFrequency(self, *args, **kwargs):  # noqa: N802
+        return 162_550_000.0
+
+    def hasGainMode(self, *args, **kwargs):  # noqa: N802
+        return True
+
+    def setGainMode(self, direction, channel, enable):  # noqa: N802
+        self.calls.append(("setGainMode", bool(enable)))
+
+    def getGainRange(self, *args, **kwargs):  # noqa: N802
+        class _Range:
+            def minimum(self_inner):
+                return 0.0
+
+            def maximum(self_inner):
+                return 49.6
+
+        return _Range()
+
+    def setGain(self, direction, channel, value):  # noqa: N802
+        self.calls.append(("setGain", float(value)))
+
+    def setBandwidth(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def listAntennas(self, *args, **kwargs):  # noqa: N802
+        return []
+
+    def setupStream(self, *args, **kwargs):  # noqa: N802
+        return "stream"
+
+    def activateStream(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def readStream(self, stream, buffers, length, **kwargs):  # noqa: N802
+        buffer = buffers[0]
+        buffer[:length] = 0.25 + 0.25j
+        return _Result(length)
+
+    def deactivateStream(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def closeStream(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def unmake(self, *args, **kwargs):  # noqa: N802
+        pass
+
+    def close(self, *args, **kwargs):  # noqa: N802
+        pass
+
+
+def _install_recording_soapysdr_stub(monkeypatch, recorded: list):
+    class _Factory:
+        def __new__(cls, args):
+            device = _GainRecordingDevice()
+            recorded.append(device)
+            return device
+
+        @classmethod
+        def enumerate(cls):
+            return []
+
+    module = _SoapyModule()
+    module.SOAPY_SDR_RX = 1
+    module.SOAPY_SDR_CF32 = 2
+    module.Device = _Factory
+    monkeypatch.setitem(sys.modules, "SoapySDR", module)
+
+
+def _wait_for_calls(device, predicate, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate(device.calls):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_external_lna_disables_agc_and_biases_gain_down(monkeypatch):
+    """When external_lna_db is set and gain is None, AGC must be off and the
+    manual gain must be reduced by the external LNA's contribution."""
+
+    devices: list = []
+    _install_recording_soapysdr_stub(monkeypatch, devices)
+
+    config = ReceiverConfig(
+        identifier="lna-test",
+        driver="rtlsdr",
+        frequency_hz=162_550_000,
+        sample_rate=2_400_000,
+        gain=None,
+        external_lna_db=20.0,
+        auto_start=True,
+    )
+
+    receiver = RTLSDRReceiver(config)
+    receiver.start()
+    try:
+        assert devices, "device factory never invoked"
+        device = devices[0]
+        assert _wait_for_calls(
+            device, lambda c: any(name == "setGain" for name, *_ in c)
+        ), f"no setGain call recorded: {device.calls}"
+
+        gain_mode_calls = [v for n, v in device.calls if n == "setGainMode"]
+        set_gain_calls = [v for n, v in device.calls if n == "setGain"]
+
+        # AGC must be disabled when an external LNA is present.
+        assert gain_mode_calls and gain_mode_calls[-1] is False, gain_mode_calls
+        # Auto target was 0 + 0.4*49.6 = 19.84 dB; minus 20 dB LNA -> clamped to 0.
+        assert set_gain_calls, set_gain_calls
+        assert set_gain_calls[-1] == 0.0, set_gain_calls
+    finally:
+        receiver.stop()
+        monkeypatch.delitem(sys.modules, "SoapySDR", raising=False)
+
+
+def test_no_external_lna_keeps_agc_path(monkeypatch):
+    """Without an external LNA, the legacy AGC-on path must still run."""
+
+    devices: list = []
+    _install_recording_soapysdr_stub(monkeypatch, devices)
+
+    config = ReceiverConfig(
+        identifier="no-lna",
+        driver="rtlsdr",
+        frequency_hz=162_550_000,
+        sample_rate=2_400_000,
+        gain=None,
+        external_lna_db=0.0,
+        auto_start=True,
+    )
+
+    receiver = RTLSDRReceiver(config)
+    receiver.start()
+    try:
+        assert devices
+        device = devices[0]
+        assert _wait_for_calls(
+            device, lambda c: any(name == "setGainMode" for name, *_ in c)
+        ), f"no setGainMode call recorded: {device.calls}"
+
+        gain_mode_calls = [v for n, v in device.calls if n == "setGainMode"]
+        # AGC enabled (True) and no manual setGain call.
+        assert gain_mode_calls[-1] is True, gain_mode_calls
+        assert not any(n == "setGain" for n, *_ in device.calls), device.calls
+    finally:
+        receiver.stop()
+        monkeypatch.delitem(sys.modules, "SoapySDR", raising=False)
+
+
 def test_dynamic_buffer_size_calculation():
     """Test that buffer size is calculated dynamically based on sample rate."""
     # Test with low sample rate (48kHz) - should use minimum buffer

--- a/tests/test_radio_drivers.py
+++ b/tests/test_radio_drivers.py
@@ -403,6 +403,50 @@ def test_no_external_lna_keeps_agc_path(monkeypatch):
         monkeypatch.delitem(sys.modules, "SoapySDR", raising=False)
 
 
+def test_airspy_external_lna_biases_gain_down(monkeypatch):
+    """Airspy receivers must also disable AGC and back off gain when an
+    external LNA is present. Airspy uses its own 0-21 dB linearity range
+    rather than the generic getGainRange path."""
+
+    devices: list = []
+    _install_recording_soapysdr_stub(monkeypatch, devices)
+
+    config = ReceiverConfig(
+        identifier="airspy-lna",
+        driver="airspy",
+        frequency_hz=162_550_000,
+        sample_rate=2_500_000,  # Valid Airspy R2 rate
+        gain=None,
+        external_lna_db=5.0,
+        auto_start=True,
+    )
+
+    receiver = AirspyReceiver(config)
+    receiver.start()
+    try:
+        assert devices
+        device = devices[0]
+        # Airspy override runs after the parent path, so we wait until the
+        # parent's setGain has been followed by the Airspy-specific one.
+        assert _wait_for_calls(
+            device,
+            lambda c: sum(1 for n, *_ in c if n == "setGain") >= 2,
+            timeout=3.0,
+        ), f"Airspy override never ran: {device.calls}"
+
+        gain_mode_calls = [v for n, v in device.calls if n == "setGainMode"]
+        set_gain_calls = [v for n, v in device.calls if n == "setGain"]
+
+        # AGC disabled at every step where it's been touched.
+        assert gain_mode_calls, gain_mode_calls
+        assert all(v is False for v in gain_mode_calls), gain_mode_calls
+        # Airspy override is the last setGain call; target = 10 - 5 = 5.0 dB.
+        assert set_gain_calls[-1] == 5.0, set_gain_calls
+    finally:
+        receiver.stop()
+        monkeypatch.delitem(sys.modules, "SoapySDR", raising=False)
+
+
 def test_dynamic_buffer_size_calculation():
     """Test that buffer size is calculated dynamically based on sample rate."""
     # Test with low sample rate (48kHz) - should use minimum buffer

--- a/tests/test_radio_manager.py
+++ b/tests/test_radio_manager.py
@@ -100,6 +100,7 @@ def test_receiver_config_preserves_auto_start_flag():
         audio_sample_rate = None
         frequency_correction_ppm = 0.0
         gain = None
+        external_lna_db = 0.0
         channel = None
         serial = None
         enabled = True


### PR DESCRIPTION
When a receiver has an outboard LNA between antenna and SDR, the SDR's
hardware AGC has no idea the amp exists and drives the front-end into
clipping. Add an `external_lna_db` setting (default 0.0); when non-zero
and no manual gain is pinned, disable hardware AGC and pick a manual
gain biased down by the LNA's contribution. Generic SoapySDR path uses
40% of the device gain range as the auto target; Airspy targets ~10 dB
in its 0-21 dB linearity range.

https://claude.ai/code/session_019NMwb8bhGv3oL1czyHRi9B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external Low Noise Amplifier (LNA) gain configuration support. When an external LNA is connected ahead of your SDR, you can now specify its gain value; the system will automatically adjust gain settings and disable auto-gain control for optimal performance.

* **Tests**
  * Added comprehensive tests validating external LNA behavior across supported receivers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2087)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->