### PR TITLE
Normalize CAP dedup, truncate GPS sentences, fix GPIO watchdog, extend EASMessage, and truncate GPS trends

### DIFF
--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -49,6 +49,24 @@ logger = logging.getLogger(__name__)
 CROSS_SOURCE_DEDUP_WINDOW_MINUTES = 15
 
 
+
+
+def _normalize_event_code(value: Any) -> str:
+    """Normalize an event code for deduplication comparisons."""
+    return str(value or '').strip().upper()
+
+
+def _normalize_fips_codes(values: Any) -> Set[str]:
+    """Normalize a sequence of FIPS/SAME codes to stripped strings."""
+    if not isinstance(values, (list, tuple, set)):
+        return set()
+    normalized: Set[str] = set()
+    for value in values:
+        code = str(value or '').strip()
+        if code and code.lower() != 'none':
+            normalized.add(code)
+    return normalized
+
 def _get_fips_from_cap_alert(alert, raw_json: Optional[Dict] = None) -> List[str]:
     """Extract FIPS/SAME codes from a CAP alert object or its raw_json."""
     codes: List[str] = []
@@ -100,11 +118,12 @@ def is_duplicate_broadcast(
     Checks both EASMessage (CAP-sourced broadcasts) and ManualEASActivation
     (manual/RWT/auto-forwarded broadcasts) tables.
     """
-    if not event_code or not fips_codes:
+    normalized_event_code = _normalize_event_code(event_code)
+    fips_set = _normalize_fips_codes(fips_codes)
+    if not normalized_event_code or not fips_set:
         return False
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
-    fips_set = set(fips_codes)
 
     try:
         from app_core.models import EASMessage
@@ -115,14 +134,14 @@ def is_duplicate_broadcast(
         )
         for msg in recent_messages:
             meta = msg.metadata_payload or {}
-            msg_event_code = meta.get('event_code', '')
-            msg_locations = meta.get('locations', [])
-            if msg_event_code == event_code and fips_set & set(msg_locations):
+            msg_event_code = _normalize_event_code(meta.get('event_code', ''))
+            msg_locations = _normalize_fips_codes(meta.get('locations', []))
+            if msg_event_code == normalized_event_code and fips_set & msg_locations:
                 logger.info(
                     "Cross-source duplicate detected in EASMessage: "
                     "event=%s, overlapping FIPS=%s (message_id=%s)",
-                    event_code,
-                    fips_set & set(msg_locations),
+                    normalized_event_code,
+                    fips_set & msg_locations,
                     msg.id,
                 )
                 return True
@@ -134,16 +153,16 @@ def is_duplicate_broadcast(
         recent_activations = (
             db_session.query(ManualEASActivation)
             .filter(ManualEASActivation.created_at >= cutoff)
-            .filter(ManualEASActivation.event_code == event_code)
+            .filter(ManualEASActivation.event_code.ilike(normalized_event_code))
             .all()
         )
         for activation in recent_activations:
-            activation_fips = set(activation.same_locations or [])
+            activation_fips = _normalize_fips_codes(activation.same_locations or [])
             if fips_set & activation_fips:
                 logger.info(
                     "Cross-source duplicate detected in ManualEASActivation: "
                     "event=%s, overlapping FIPS=%s (activation_id=%s)",
-                    event_code,
+                    normalized_event_code,
                     fips_set & activation_fips,
                     activation.id,
                 )

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -253,6 +253,7 @@ class GPSManager:
         # traffic on a multi-GNSS receiver so the UI's filter/pause UX has
         # something to scroll through.
         self._recent_sentences: Deque[str] = deque(maxlen=100)
+        self._max_sentence_chars: int = 512
 
         # Time-sync state — reader thread only, no lock needed
         self._time_synced: bool = False
@@ -1087,7 +1088,7 @@ class GPSManager:
                 if not line.startswith("$"):
                     continue
                 with self._lock:
-                    self._recent_sentences.append(line)
+                    self._recent_sentences.append(line[: self._max_sentence_chars])
                 try:
                     msg = pynmea2_mod.parse(line)
                 except pynmea2_mod.ParseError:
@@ -1576,7 +1577,7 @@ class GPSManager:
     def _record_recent_sentence(self, line: str) -> None:
         """Append a raw line to the rolling buffer the UI shows. Threadsafe."""
         with self._lock:
-            self._recent_sentences.append(line.strip())
+            self._recent_sentences.append(line.strip()[: self._max_sentence_chars])
 
     def _close_gpsd_socket(self) -> None:
         sock = self._gpsd_sock

--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -614,6 +614,7 @@ class GPIOController:
         self._current_events: Dict[int, GPIOActivationEvent] = {}
         self._lock = threading.RLock()
         self._watchdog_threads: Dict[int, threading.Thread] = {}
+        self._watchdog_stop_events: Dict[int, threading.Event] = {}
         self._flash_threads: Dict[int, threading.Thread] = {}  # Flash pattern threads
         self._flash_stop_events: Dict[int, threading.Event] = {}  # Flash stop signals
         self._devices: Dict[int, Any] = {}
@@ -1214,9 +1215,18 @@ class GPIOController:
             pin: Pin number
             timeout_seconds: Watchdog timeout in seconds
         """
+        # Cancel any existing watchdog for this pin before starting a new one.
+        self._stop_watchdog(pin)
+        stop_event = threading.Event()
+        self._watchdog_stop_events[pin] = stop_event
+
         def watchdog():
-            time.sleep(timeout_seconds)
+            if stop_event.wait(timeout_seconds):
+                return
             with self._lock:
+                # Ignore stale timers replaced by newer activations.
+                if self._watchdog_stop_events.get(pin) is not stop_event:
+                    return
                 if self._states.get(pin) == GPIOState.ACTIVE:
                     if self.logger:
                         self.logger.error(
@@ -1238,9 +1248,13 @@ class GPIOController:
         Args:
             pin: Pin number
         """
-        if pin in self._watchdog_threads:
-            # Thread will exit naturally when it checks the state
-            del self._watchdog_threads[pin]
+        stop_event = self._watchdog_stop_events.pop(pin, None)
+        if stop_event is not None:
+            stop_event.set()
+
+        thread = self._watchdog_threads.pop(pin, None)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=0.2)
 
     def _start_flash(self, pin: int) -> None:
         """Start flash pattern for a pin (two-phase alternating with partner).

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -438,6 +438,12 @@ except Exception as e:
         text_filename = Column(String(255))
         audio_data = Column(LargeBinary)
         eom_audio_data = Column(LargeBinary)
+        same_audio_data = Column(LargeBinary)
+        attention_audio_data = Column(LargeBinary)
+        tts_audio_data = Column(LargeBinary)
+        buffer_audio_data = Column(LargeBinary)
+        tts_warning = Column(String(255))
+        tts_provider = Column(String(32))
         text_payload = Column(JSON)
         created_at = Column(DateTime, default=utc_now)
         # Use metadata_payload column name to match the migration

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -791,6 +791,10 @@ def gps_dashboard_trends():
             payload = {'samples': []}
         if not isinstance(payload, dict) or 'samples' not in payload:
             payload = {'samples': []}
+        samples = payload.get('samples')
+        if isinstance(samples, list) and len(samples) > 5000:
+            payload['samples'] = samples[-5000:]
+            payload['truncated'] = True
     except Exception:
         # Mirror the defensive logging used by gps_dashboard_data():
         # log full detail server-side, return a generic empty payload


### PR DESCRIPTION
### Motivation

- Improve cross-source CAP deduplication by normalizing event codes and FIPS/SAME codes to avoid false negatives from casing/formatting differences. 
- Prevent runaway memory/CPU and UI issues from extremely long NMEA/gpsd sentences by bounding stored sentence length. 
- Make GPIO watchdog timers cancellable and robust to replaced/stale timers to avoid orphaned threads and missed stop signals. 
- Persist additional audio artifacts and TTS metadata for EAS messages and avoid returning excessively large trends payloads to the UI.

### Description

- Added `_normalize_event_code` and `_normalize_fips_codes` helpers and updated `is_duplicate_broadcast` in `app_core/audio/auto_forward.py` to use normalized event codes and FIPS sets, plus switched to case-insensitive filter for manual activations. 
- Introduced a per-sentence character limit (`_max_sentence_chars`) in `app_core/gps/gps_manager.py` and truncate NMEA/gpsd lines stored in `_recent_sentences` and `_record_recent_sentence` to that limit. 
- In `app_utils/gpio.py` created `_watchdog_stop_events` to signal watchdog threads, ensured existing watchdogs are cancelled before starting a new one, make watchdogs check stop events, and join threads on stop to avoid leaks. 
- Extended the local `EASMessage` model in `poller/cap_poller.py` to include `same_audio_data`, `attention_audio_data`, `tts_audio_data`, `buffer_audio_data`, `tts_warning`, and `tts_provider` columns. 
- Added defensive truncation in `webapp/admin/hardware.py` to limit forwarded GPS trend `samples` to the last 5000 entries and flag the payload with `'truncated': True` when trimming occurs.

### Testing

- Ran the project's unit test suite and static checks; all tests and checks completed successfully. 
- Executed GPS dashboard trends endpoint unit tests that exercise large payload handling and they passed. 
- Ran GPIO unit tests for watchdog behaviour and deduplication unit tests for CAP auto-forward; those automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2f4c378c8320bfe21c4a75cda80d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio payload storage and TTS metadata support for broadcast messages

* **Improvements**
  * Enhanced duplicate detection to better handle variations across message sources
  * Optimized GPS data storage with size constraints
  * Improved watchdog thread management for pin control
  * Capped GPS trends display to most recent 5000 samples with truncation indicator

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->