### PR TITLE
Add runtime diagnostics, bound GPS/GPIO buffers, normalize CAP dedupe, and GPIO watchdog hardening

### DIFF
--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -49,6 +49,24 @@ logger = logging.getLogger(__name__)
 CROSS_SOURCE_DEDUP_WINDOW_MINUTES = 15
 
 
+
+
+def _normalize_event_code(value: Any) -> str:
+    """Normalize an event code for deduplication comparisons."""
+    return str(value or '').strip().upper()
+
+
+def _normalize_fips_codes(values: Any) -> Set[str]:
+    """Normalize a sequence of FIPS/SAME codes to stripped strings."""
+    if not isinstance(values, (list, tuple, set)):
+        return set()
+    normalized: Set[str] = set()
+    for value in values:
+        code = str(value or '').strip()
+        if code and code.lower() != 'none':
+            normalized.add(code)
+    return normalized
+
 def _get_fips_from_cap_alert(alert, raw_json: Optional[Dict] = None) -> List[str]:
     """Extract FIPS/SAME codes from a CAP alert object or its raw_json."""
     codes: List[str] = []
@@ -100,11 +118,12 @@ def is_duplicate_broadcast(
     Checks both EASMessage (CAP-sourced broadcasts) and ManualEASActivation
     (manual/RWT/auto-forwarded broadcasts) tables.
     """
-    if not event_code or not fips_codes:
+    normalized_event_code = _normalize_event_code(event_code)
+    fips_set = _normalize_fips_codes(fips_codes)
+    if not normalized_event_code or not fips_set:
         return False
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
-    fips_set = set(fips_codes)
 
     try:
         from app_core.models import EASMessage
@@ -115,14 +134,14 @@ def is_duplicate_broadcast(
         )
         for msg in recent_messages:
             meta = msg.metadata_payload or {}
-            msg_event_code = meta.get('event_code', '')
-            msg_locations = meta.get('locations', [])
-            if msg_event_code == event_code and fips_set & set(msg_locations):
+            msg_event_code = _normalize_event_code(meta.get('event_code', ''))
+            msg_locations = _normalize_fips_codes(meta.get('locations', []))
+            if msg_event_code == normalized_event_code and fips_set & msg_locations:
                 logger.info(
                     "Cross-source duplicate detected in EASMessage: "
                     "event=%s, overlapping FIPS=%s (message_id=%s)",
-                    event_code,
-                    fips_set & set(msg_locations),
+                    normalized_event_code,
+                    fips_set & msg_locations,
                     msg.id,
                 )
                 return True
@@ -134,16 +153,16 @@ def is_duplicate_broadcast(
         recent_activations = (
             db_session.query(ManualEASActivation)
             .filter(ManualEASActivation.created_at >= cutoff)
-            .filter(ManualEASActivation.event_code == event_code)
+            .filter(ManualEASActivation.event_code.ilike(normalized_event_code))
             .all()
         )
         for activation in recent_activations:
-            activation_fips = set(activation.same_locations or [])
+            activation_fips = _normalize_fips_codes(activation.same_locations or [])
             if fips_set & activation_fips:
                 logger.info(
                     "Cross-source duplicate detected in ManualEASActivation: "
                     "event=%s, overlapping FIPS=%s (activation_id=%s)",
-                    event_code,
+                    normalized_event_code,
                     fips_set & activation_fips,
                     activation.id,
                 )

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -253,6 +253,7 @@ class GPSManager:
         # traffic on a multi-GNSS receiver so the UI's filter/pause UX has
         # something to scroll through.
         self._recent_sentences: Deque[str] = deque(maxlen=100)
+        self._max_sentence_chars: int = 512
 
         # Time-sync state — reader thread only, no lock needed
         self._time_synced: bool = False
@@ -1087,7 +1088,7 @@ class GPSManager:
                 if not line.startswith("$"):
                     continue
                 with self._lock:
-                    self._recent_sentences.append(line)
+                    self._recent_sentences.append(line[: self._max_sentence_chars])
                 try:
                     msg = pynmea2_mod.parse(line)
                 except pynmea2_mod.ParseError:
@@ -1576,7 +1577,7 @@ class GPSManager:
     def _record_recent_sentence(self, line: str) -> None:
         """Append a raw line to the rolling buffer the UI shows. Threadsafe."""
         with self._lock:
-            self._recent_sentences.append(line.strip())
+            self._recent_sentences.append(line.strip()[: self._max_sentence_chars])
 
     def _close_gpsd_socket(self) -> None:
         sock = self._gpsd_sock

--- a/app_utils/gpio.py
+++ b/app_utils/gpio.py
@@ -614,6 +614,7 @@ class GPIOController:
         self._current_events: Dict[int, GPIOActivationEvent] = {}
         self._lock = threading.RLock()
         self._watchdog_threads: Dict[int, threading.Thread] = {}
+        self._watchdog_stop_events: Dict[int, threading.Event] = {}
         self._flash_threads: Dict[int, threading.Thread] = {}  # Flash pattern threads
         self._flash_stop_events: Dict[int, threading.Event] = {}  # Flash stop signals
         self._devices: Dict[int, Any] = {}
@@ -621,6 +622,7 @@ class GPIOController:
         self._backend: Optional[GPIOBackend] = None
         self._backend_failures: Set[type] = set()
         self._environment_issues: Set[str] = set()
+        self._max_environment_issues: int = 256
         self._gpiozero_available = bool(
             OutputDevice is not None
             and _ensure_pin_factory(
@@ -646,8 +648,13 @@ class GPIOController:
     def _record_environment_issue(self, detail: str) -> None:
         explanation = _explain_environment_issue(detail)
         message = explanation or detail
-        if message:
-            self._environment_issues.add(message)
+        if not message:
+            return
+        if message in self._environment_issues:
+            return
+        if len(self._environment_issues) >= self._max_environment_issues:
+            return
+        self._environment_issues.add(message)
 
     def _current_backend_label(self, backend: Optional[GPIOBackend] = None) -> str:
         target = backend if backend is not None else self._backend
@@ -1148,6 +1155,30 @@ class GPIOController:
 
             return result
 
+    def get_runtime_diagnostics(self) -> Dict[str, Any]:
+        """Return bounded runtime counters useful for leak diagnostics."""
+
+        with self._lock:
+            active_watchdogs = sum(
+                1 for t in self._watchdog_threads.values() if t is not None and t.is_alive()
+            )
+            active_flash_threads = sum(
+                1 for t in self._flash_threads.values() if t is not None and t.is_alive()
+            )
+            return {
+                'configured_pins': len(self._pins),
+                'active_pins': sum(1 for s in self._states.values() if s == GPIOState.ACTIVE),
+                'current_events': len(self._current_events),
+                'watchdog_threads_tracked': len(self._watchdog_threads),
+                'watchdog_threads_alive': active_watchdogs,
+                'watchdog_stop_events': len(self._watchdog_stop_events),
+                'flash_threads_tracked': len(self._flash_threads),
+                'flash_threads_alive': active_flash_threads,
+                'flash_stop_events': len(self._flash_stop_events),
+                'environment_issues_count': len(self._environment_issues),
+                'environment_issues_cap': self._max_environment_issues,
+            }
+
     def get_environment_issues(self) -> List[str]:
         """Return detected environment issues preventing GPIO access."""
 
@@ -1214,9 +1245,18 @@ class GPIOController:
             pin: Pin number
             timeout_seconds: Watchdog timeout in seconds
         """
+        # Cancel any existing watchdog for this pin before starting a new one.
+        self._stop_watchdog(pin)
+        stop_event = threading.Event()
+        self._watchdog_stop_events[pin] = stop_event
+
         def watchdog():
-            time.sleep(timeout_seconds)
+            if stop_event.wait(timeout_seconds):
+                return
             with self._lock:
+                # Ignore stale timers replaced by newer activations.
+                if self._watchdog_stop_events.get(pin) is not stop_event:
+                    return
                 if self._states.get(pin) == GPIOState.ACTIVE:
                     if self.logger:
                         self.logger.error(
@@ -1238,9 +1278,13 @@ class GPIOController:
         Args:
             pin: Pin number
         """
-        if pin in self._watchdog_threads:
-            # Thread will exit naturally when it checks the state
-            del self._watchdog_threads[pin]
+        stop_event = self._watchdog_stop_events.pop(pin, None)
+        if stop_event is not None:
+            stop_event.set()
+
+        thread = self._watchdog_threads.pop(pin, None)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=0.2)
 
     def _start_flash(self, pin: int) -> None:
         """Start flash pattern for a pin (two-phase alternating with partner).

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -46,6 +46,9 @@ import json
 import redis
 import subprocess
 import threading
+import gc
+import tracemalloc
+from collections import Counter
 import ipaddress
 from typing import Optional
 from datetime import datetime, timezone
@@ -2667,6 +2670,92 @@ def create_api_app():
             return jsonify({'success': False, 'error': str(e)}), 500
 
     # GPS Hardware Endpoints
+
+
+    @api_app.route('/api/hardware/runtime/diagnostics', methods=['GET'])
+    def get_runtime_diagnostics():
+        """Return broad runtime diagnostics for leak triage."""
+        try:
+            import os
+            import resource
+
+            if not tracemalloc.is_tracing():
+                tracemalloc.start(25)
+
+            rss_kb = None
+            try:
+                with open('/proc/self/status', 'r', encoding='utf-8') as fh:
+                    for line in fh:
+                        if line.startswith('VmRSS:'):
+                            rss_kb = int(line.split()[1])
+                            break
+            except Exception:
+                pass
+
+            thread_details = []
+            for th in threading.enumerate():
+                thread_details.append({
+                    'name': th.name,
+                    'daemon': bool(th.daemon),
+                    'alive': bool(th.is_alive()),
+                })
+
+            top_types = []
+            try:
+                objs = gc.get_objects()
+                counts = Counter(type(o).__name__ for o in objs)
+                for name, count in counts.most_common(20):
+                    top_types.append({'type': name, 'count': int(count)})
+            except Exception:
+                top_types = []
+
+            alloc_top = []
+            try:
+                snapshot = tracemalloc.take_snapshot()
+                for stat in snapshot.statistics('lineno')[:20]:
+                    frame = stat.traceback[0]
+                    alloc_top.append({
+                        'file': str(frame.filename),
+                        'line': int(frame.lineno),
+                        'size_kb': round(stat.size / 1024.0, 2),
+                        'count': int(stat.count),
+                    })
+            except Exception:
+                alloc_top = []
+
+            payload = {
+                'pid': os.getpid(),
+                'threads': threading.active_count(),
+                'thread_details': thread_details,
+                'rss_kb': rss_kb,
+                'maxrss_kb': resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+                'gc_counts': gc.get_count(),
+                'top_object_types': top_types,
+                'alloc_top': alloc_top,
+                'gpio': None,
+                'gps': None,
+            }
+
+            if _gpio_controller is not None and hasattr(_gpio_controller, 'get_runtime_diagnostics'):
+                payload['gpio'] = _gpio_controller.get_runtime_diagnostics()
+
+            if _gps_manager is not None:
+                try:
+                    gps = _gps_manager.get_status() or {}
+                    payload['gps'] = {
+                        'running': bool(gps.get('running', False)),
+                        'status': gps.get('status'),
+                        'fix_mode': gps.get('fix_mode'),
+                        'pps_interval_samples': gps.get('pps_interval_samples', 0),
+                        'recent_sentences': len(gps.get('recent_sentences') or []),
+                    }
+                except Exception:
+                    payload['gps'] = {'running': False, 'status': 'status_read_failed'}
+
+            return jsonify(payload)
+        except Exception:
+            logger.error('Error getting hardware runtime diagnostics', exc_info=True)
+            return jsonify({'success': False, 'error': 'runtime_diagnostics_unavailable'}), 500
 
     @api_app.route('/api/hardware/gps/status', methods=['GET'])
     def get_gps_status():

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -438,6 +438,12 @@ except Exception as e:
         text_filename = Column(String(255))
         audio_data = Column(LargeBinary)
         eom_audio_data = Column(LargeBinary)
+        same_audio_data = Column(LargeBinary)
+        attention_audio_data = Column(LargeBinary)
+        tts_audio_data = Column(LargeBinary)
+        buffer_audio_data = Column(LargeBinary)
+        tts_warning = Column(String(255))
+        tts_provider = Column(String(32))
         text_payload = Column(JSON)
         created_at = Column(DateTime, default=utc_now)
         # Use metadata_payload column name to match the migration

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -5158,6 +5158,18 @@
         filter: '',
         lastSentences: []
     };
+    
+    function renderRuntimeDiagnostics(snapshot) {
+        var pre = document.getElementById('runtime-diag-pre');
+        if (!pre) return;
+        var runtime = (snapshot && snapshot.runtime) || {};
+        try {
+            pre.textContent = JSON.stringify(runtime, null, 2);
+        } catch (e) {
+            pre.textContent = '{}';
+        }
+    }
+
     function renderNmeaInspector(sentences) {
         var pauseEl  = document.getElementById('ts-nmea-pause');
         var filterEl = document.getElementById('ts-nmea-filter');
@@ -5302,6 +5314,7 @@
         renderJammingTimeSeries();
         renderStaleness(gps);
         renderNmeaInspector(gps.recent_sentences || []);
+        renderRuntimeDiagnostics(snapshot);
     }
 
     // ── Polling.  Configurable interval; "0" means paused.

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -748,6 +748,15 @@ def gps_dashboard_data():
 
     chrony_payload = _collect_chrony_dashboard_data()
 
+    runtime_payload: Dict[str, Any] = {}
+    try:
+        runtime_payload = call_hardware_service('/api/hardware/runtime/diagnostics', method='GET') or {}
+        if not isinstance(runtime_payload, dict):
+            runtime_payload = {}
+    except Exception:
+        logger.warning('GPS dashboard: hardware runtime diagnostics call failed', exc_info=True)
+        runtime_payload = {'_error': 'hardware_runtime_unavailable'}
+
     host_info: Dict[str, Any] = {
         "hostname": socket.gethostname(),
         "now_utc": datetime.now(timezone.utc).isoformat(),
@@ -758,6 +767,7 @@ def gps_dashboard_data():
         "gps": gps_payload,
         "chrony": chrony_payload,
         "host": host_info,
+        "runtime": runtime_payload,
     })
 
 
@@ -791,6 +801,10 @@ def gps_dashboard_trends():
             payload = {'samples': []}
         if not isinstance(payload, dict) or 'samples' not in payload:
             payload = {'samples': []}
+        samples = payload.get('samples')
+        if isinstance(samples, list) and len(samples) > 5000:
+            payload['samples'] = samples[-5000:]
+            payload['truncated'] = True
     except Exception:
         # Mirror the defensive logging used by gps_dashboard_data():
         # log full detail server-side, return a generic empty payload

--- a/webapp/admin/network.py
+++ b/webapp/admin/network.py
@@ -378,6 +378,15 @@ def get_gps_status():
     return jsonify(call_hardware_service('/api/hardware/gps/status', method='GET'))
 
 
+
+
+@network_bp.route('/api/hardware/runtime/diagnostics')
+@require_permission('system.configure')
+def get_hardware_runtime_diagnostics():
+    """Get hardware-service runtime diagnostics via proxy."""
+    return jsonify(call_hardware_service('/api/hardware/runtime/diagnostics', method='GET'))
+
+
 @network_bp.route('/api/hardware/gps/configure', methods=['POST'])
 @require_permission('system.configure')
 def configure_gps():

--- a/webapp/routes/system_controls.py
+++ b/webapp/routes/system_controls.py
@@ -593,6 +593,7 @@ def register(app: Flask, logger) -> None:
                 current_user=_get_current_user(),
                 configured_pin_count=configured_count,
                 environment_issues=controller.get_environment_issues(),
+                gpio_runtime=controller.get_runtime_diagnostics(),
             )
 
         except Exception as exc:


### PR DESCRIPTION
### Motivation

- Provide on-demand runtime diagnostics from the hardware service to aid memory-leak and thread/resource triage.  
- Prevent unbounded growth of GPS/NMEA and dashboard buffers that can drive memory use.  
- Improve cross-source CAP deduplication by normalizing event codes and FIPS/SAME lists.  
- Harden GPIO watchdog behavior and limit environment-issue bookkeeping to avoid unbounded state.

### Description

- Add a `/api/hardware/runtime/diagnostics` endpoint to the hardware service that collects `tracemalloc`, `gc`, `resource` and thread/object summaries and includes embedded `gpio` and `gps` diagnostics.  
- Wire the diagnostics through the admin UI: add a proxy route (`/api/hardware/runtime/diagnostics`) in `webapp/admin/network.py`, include the `runtime` payload in `webapp/admin/hardware.py`, and add `renderRuntimeDiagnostics` in `templates/admin/gps_dashboard.html`.  
- Bound GPS NMEA storage by adding `_max_sentence_chars` and truncating appended sentences in `app_core/gps/gps_manager.py` to avoid storing arbitrarily long lines.  
- Add normalization helpers (`_normalize_event_code`, `_normalize_fips_codes`) and use them in `is_duplicate_broadcast` in `app_core/audio/auto_forward.py` to make dedupe comparisons robust and case/format tolerant, and use an `ilike` check for manual activations.  
- Extend the `EASMessage` model in `poller/cap_poller.py` with additional audio/blob columns (`same_audio_data`, `attention_audio_data`, `tts_audio_data`, `buffer_audio_data`, `tts_warning`, `tts_provider`).  
- Improve GPIO controller robustness in `app_utils/gpio.py` by tracking watchdog stop events, canceling/replacing watchdog timers, joining stopped threads, deduplicating/capping environment issue records, and exposing `get_runtime_diagnostics()` for runtime counts and thread tracking; also surface GPIO runtime diagnostics to the GPIO control page in `webapp/routes/system_controls.py`.  
- Truncate very large trend sample payloads returned from the hardware service in the GPS dashboard proxy (`webapp/admin/hardware.py`) to the most recent 5000 samples and indicate truncation.

### Testing

- Ran the repository automated test suite (unit and integration tests) including GPS, GPIO, and CAP-related modules; no test regressions were observed.  
- Exercised the new hardware-service diagnostics endpoint and the admin proxy with automated HTTP checks against the running hardware service; responses returned expected JSON payloads.  
- Verified dashboard rendering of the added `runtime` payload and that long NMEA sentences and trend samples are truncated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2f4c378c8320bfe21c4a75cda80d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime diagnostics API endpoint for system health monitoring (memory, threads, object tracking).
  * Integrated diagnostics display in admin dashboard.

* **Improvements**
  * Optimized GPS sentence storage with character limits.
  * Enhanced audio deduplication with event-code and location normalization.
  * Improved GPIO watchdog with event-driven cancellation mechanism.
  * Added bounded environment issue tracking and per-pin diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->