### PR TITLE
Remove hardware runtime diagnostics from GPS dashboard polling

### DIFF
--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -1294,16 +1294,6 @@
          Severity is communicated by the persistent status strip below,
          not by a handful of pills crammed into the header.
          ============================================================ -->
-    <section class="gps-card engineering-only" id="runtime-diag-card" aria-label="Hardware service runtime diagnostics" style="margin-bottom:12px;">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <h3 class="mb-0"><i class="fas fa-microchip me-1"></i> Hardware Service Runtime Diagnostics</h3>
-            <small class="text-muted">live process snapshot</small>
-        </div>
-        <div class="card-body">
-            <pre id="runtime-diag-pre" style="max-height:220px;overflow:auto;white-space:pre-wrap;margin:0"></pre>
-        </div>
-    </section>
-
     <div class="gps-dash-header" role="region" aria-label="GPS dashboard header">
         <span class="title">
             <i class="fas fa-satellite-dish"></i>
@@ -5169,17 +5159,6 @@
         lastSentences: []
     };
     
-    function renderRuntimeDiagnostics(snapshot) {
-        var pre = document.getElementById('runtime-diag-pre');
-        if (!pre) return;
-        var runtime = (snapshot && snapshot.runtime) || {};
-        try {
-            pre.textContent = JSON.stringify(runtime, null, 2);
-        } catch (e) {
-            pre.textContent = '{}';
-        }
-    }
-
     function renderNmeaInspector(sentences) {
         var pauseEl  = document.getElementById('ts-nmea-pause');
         var filterEl = document.getElementById('ts-nmea-filter');
@@ -5324,7 +5303,6 @@
         renderJammingTimeSeries();
         renderStaleness(gps);
         renderNmeaInspector(gps.recent_sentences || []);
-        renderRuntimeDiagnostics(snapshot);
     }
 
     // ── Polling.  Configurable interval; "0" means paused.

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -748,15 +748,6 @@ def gps_dashboard_data():
 
     chrony_payload = _collect_chrony_dashboard_data()
 
-    runtime_payload: Dict[str, Any] = {}
-    try:
-        runtime_payload = call_hardware_service('/api/hardware/runtime/diagnostics', method='GET') or {}
-        if not isinstance(runtime_payload, dict):
-            runtime_payload = {}
-    except Exception:
-        logger.warning('GPS dashboard: hardware runtime diagnostics call failed', exc_info=True)
-        runtime_payload = {'_error': 'hardware_runtime_unavailable'}
-
     host_info: Dict[str, Any] = {
         "hostname": socket.gethostname(),
         "now_utc": datetime.now(timezone.utc).isoformat(),
@@ -767,7 +758,6 @@ def gps_dashboard_data():
         "gps": gps_payload,
         "chrony": chrony_payload,
         "host": host_info,
-        "runtime": runtime_payload,
     })
 
 


### PR DESCRIPTION
### Motivation
- The hardware-service `/api/hardware/runtime/diagnostics` endpoint is expensive and has been timing out, causing the GPS dashboard polling path to fail and add unnecessary load.
- Remove the runtime-diagnostics coupling from the GPS dashboard so the page remains responsive while keeping the hardware diagnostics endpoint available independently.

### Description
- Stop calling `/api/hardware/runtime/diagnostics` from the GPS dashboard aggregator by removing the runtime collection and `runtime` field from the `/admin/api/gps-dashboard/data` response in `webapp/admin/hardware.py`.
- Remove the Hardware Service Runtime Diagnostics card from `templates/admin/gps_dashboard.html` so the runtime snapshot is no longer shown on the GPS dashboard page.
- Remove the client-side `renderRuntimeDiagnostics` function and its invocation from the dashboard JavaScript render loop in `templates/admin/gps_dashboard.html` so the page no longer expects a `runtime` block in snapshots.
- Keep the hardware-service diagnostics proxy route in `webapp/admin/network.py` unchanged so the diagnostics endpoint remains available for targeted use or troubleshooting.

### Testing
- Ran a repository search to confirm dashboard template and route no longer reference runtime diagnostics via `rg -n "runtime-diag|runtime diagnostics|snapshot.runtime|/api/hardware/runtime/diagnostics"`, and no GPS dashboard references remain; the check succeeded.
- Compiled the modified module with `python3 -m py_compile webapp/admin/hardware.py` to validate syntax, which succeeded with no errors.
- Verified the changes were committed (local commit message: `Remove runtime diagnostics from GPS dashboard polling`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7f5167708320b63b924277d962ca)