### PR TITLE
Make runtime diagnostics lightweight by default, add malloc_trim probe, and stop dashboard polling them

### DIFF
--- a/hardware_service.py
+++ b/hardware_service.py
@@ -2691,13 +2691,20 @@ def create_api_app():
 
     @api_app.route('/api/hardware/runtime/diagnostics', methods=['GET'])
     def get_runtime_diagnostics():
-        """Return broad runtime diagnostics for leak triage."""
+        """Return runtime diagnostics for leak triage.
+
+        Default mode is intentionally lightweight so callers (including
+        web UI panels) do not stall the service under memory pressure.
+        Pass ``?verbose=1`` to include expensive heap breakdown fields.
+        """
         try:
             import os
             import resource
+            import ctypes
 
-            if not tracemalloc.is_tracing():
-                tracemalloc.start(25)
+            verbose = str(request.args.get('verbose', '0')).strip().lower() in {
+                '1', 'true', 'yes', 'on'
+            }
 
             rss_kb = None
             try:
@@ -2717,28 +2724,16 @@ def create_api_app():
                     'alive': bool(th.is_alive()),
                 })
 
-            top_types = []
+            # Cheap allocator probe to distinguish "retained heap" from
+            # glibc arena fragmentation. This call is fast and safe.
+            trim_released = None
             try:
-                objs = gc.get_objects()
-                counts = Counter(type(o).__name__ for o in objs)
-                for name, count in counts.most_common(20):
-                    top_types.append({'type': name, 'count': int(count)})
+                libc = ctypes.CDLL('libc.so.6')
+                libc.malloc_trim.argtypes = [ctypes.c_size_t]
+                libc.malloc_trim.restype = ctypes.c_int
+                trim_released = bool(libc.malloc_trim(0))
             except Exception:
-                top_types = []
-
-            alloc_top = []
-            try:
-                snapshot = tracemalloc.take_snapshot()
-                for stat in snapshot.statistics('lineno')[:20]:
-                    frame = stat.traceback[0]
-                    alloc_top.append({
-                        'file': str(frame.filename),
-                        'line': int(frame.lineno),
-                        'size_kb': round(stat.size / 1024.0, 2),
-                        'count': int(stat.count),
-                    })
-            except Exception:
-                alloc_top = []
+                trim_released = None
 
             payload = {
                 'pid': os.getpid(),
@@ -2747,11 +2742,41 @@ def create_api_app():
                 'rss_kb': rss_kb,
                 'maxrss_kb': resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
                 'gc_counts': gc.get_count(),
-                'top_object_types': top_types,
-                'alloc_top': alloc_top,
+                'malloc_trim_released': trim_released,
+                'verbose': verbose,
                 'gpio': None,
                 'gps': None,
             }
+
+            if verbose:
+                if not tracemalloc.is_tracing():
+                    tracemalloc.start(25)
+
+                top_types = []
+                try:
+                    objs = gc.get_objects()
+                    counts = Counter(type(o).__name__ for o in objs)
+                    for name, count in counts.most_common(20):
+                        top_types.append({'type': name, 'count': int(count)})
+                except Exception:
+                    top_types = []
+
+                alloc_top = []
+                try:
+                    snapshot = tracemalloc.take_snapshot()
+                    for stat in snapshot.statistics('lineno')[:20]:
+                        frame = stat.traceback[0]
+                        alloc_top.append({
+                            'file': str(frame.filename),
+                            'line': int(frame.lineno),
+                            'size_kb': round(stat.size / 1024.0, 2),
+                            'count': int(stat.count),
+                        })
+                except Exception:
+                    alloc_top = []
+
+                payload['top_object_types'] = top_types
+                payload['alloc_top'] = alloc_top
 
             if _gpio_controller is not None and hasattr(_gpio_controller, 'get_runtime_diagnostics'):
                 payload['gpio'] = _gpio_controller.get_runtime_diagnostics()

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -1294,16 +1294,6 @@
          Severity is communicated by the persistent status strip below,
          not by a handful of pills crammed into the header.
          ============================================================ -->
-    <section class="gps-card engineering-only" id="runtime-diag-card" aria-label="Hardware service runtime diagnostics" style="margin-bottom:12px;">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <h3 class="mb-0"><i class="fas fa-microchip me-1"></i> Hardware Service Runtime Diagnostics</h3>
-            <small class="text-muted">live process snapshot</small>
-        </div>
-        <div class="card-body">
-            <pre id="runtime-diag-pre" style="max-height:220px;overflow:auto;white-space:pre-wrap;margin:0"></pre>
-        </div>
-    </section>
-
     <div class="gps-dash-header" role="region" aria-label="GPS dashboard header">
         <span class="title">
             <i class="fas fa-satellite-dish"></i>
@@ -5169,17 +5159,6 @@
         lastSentences: []
     };
     
-    function renderRuntimeDiagnostics(snapshot) {
-        var pre = document.getElementById('runtime-diag-pre');
-        if (!pre) return;
-        var runtime = (snapshot && snapshot.runtime) || {};
-        try {
-            pre.textContent = JSON.stringify(runtime, null, 2);
-        } catch (e) {
-            pre.textContent = '{}';
-        }
-    }
-
     function renderNmeaInspector(sentences) {
         var pauseEl  = document.getElementById('ts-nmea-pause');
         var filterEl = document.getElementById('ts-nmea-filter');
@@ -5324,7 +5303,6 @@
         renderJammingTimeSeries();
         renderStaleness(gps);
         renderNmeaInspector(gps.recent_sentences || []);
-        renderRuntimeDiagnostics(snapshot);
     }
 
     // ── Polling.  Configurable interval; "0" means paused.

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -748,15 +748,6 @@ def gps_dashboard_data():
 
     chrony_payload = _collect_chrony_dashboard_data()
 
-    runtime_payload: Dict[str, Any] = {}
-    try:
-        runtime_payload = call_hardware_service('/api/hardware/runtime/diagnostics', method='GET') or {}
-        if not isinstance(runtime_payload, dict):
-            runtime_payload = {}
-    except Exception:
-        logger.warning('GPS dashboard: hardware runtime diagnostics call failed', exc_info=True)
-        runtime_payload = {'_error': 'hardware_runtime_unavailable'}
-
     host_info: Dict[str, Any] = {
         "hostname": socket.gethostname(),
         "now_utc": datetime.now(timezone.utc).isoformat(),
@@ -767,7 +758,6 @@ def gps_dashboard_data():
         "gps": gps_payload,
         "chrony": chrony_payload,
         "host": host_info,
-        "runtime": runtime_payload,
     })
 
 


### PR DESCRIPTION
### Motivation

- Reduce the chance that the dashboard or other callers stall the hardware service under memory pressure by avoiding expensive heap diagnostics on every request.
- Provide a cheap allocator probe to help distinguish retained heap vs. glibc arena fragmentation without heavy tracing.
- Remove automatic collection and rendering of runtime diagnostics from the GPS dashboard to avoid unnecessary overhead in normal operator workflows.

### Description

- Change `GET /api/hardware/runtime/diagnostics` to be lightweight by default and accept a `?verbose=1` flag to enable expensive heap breakdowns; the response now includes a `verbose` flag and a `malloc_trim_released` probe result.
- Add a fast allocator probe using `ctypes` to call `libc.malloc_trim(0)` and expose its boolean result as `malloc_trim_released` in the diagnostics payload, and defer `tracemalloc`/`gc` snapshots until `verbose` is requested.
- Remove the server-side call that populated `runtime` in the GPS dashboard payload (`webapp/admin/hardware.py`) and strip out the runtime diagnostics panel and the `renderRuntimeDiagnostics` call from the dashboard template/JS so the dashboard no longer polls or renders the runtime snapshot by default.

### Testing

- Ran the unit test suite with `pytest -q` and the tests completed successfully.
- Ran the style/lint checks with `flake8` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7f5167708320b63b924277d962ca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NMEA Sentence Inspector now supports message filtering and pause controls

* **Refactor**
  * GPS dashboard reorganized to emphasize operator-focused metrics: Leap-second countdown, Jamming & Spoofing status, Almanac & Ephemeris staleness tracking, and NMEA Sentence Inspector

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->