### PR TITLE
Add diagnostic action and API to switch NMEA source to gpsd for chrony PPS discipline

### DIFF
--- a/app_utils/gps_hat.py
+++ b/app_utils/gps_hat.py
@@ -823,14 +823,48 @@ def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
             },
         })
 
-    # 8. GPS/PPS refclocks configured but never reaching chrony. This is
-    #    the port-contention symptom: gpsd is configured for /dev/serial0
-    #    (which resolves to /dev/ttyAMAN on Pi 5) but EAS Station's
-    #    hardware service has the same port open. gpsd never gets NMEA,
-    #    SHM 0 stays empty, the `lock GPS` constraint on PPS never fires,
-    #    and chrony falls back to internet NTP at stratum ≥ 2. There is
-    #    no one-click fix yet — properly resolving it needs Tier 3
-    #    (gpsd-as-NMEA-source mode in gps_manager.py).
+    # 8. GPS/PPS refclocks configured but not actually usable. chrony
+    #    needs two feeds: NMEA samples from gpsd's SHM 0 and the precise
+    #    PPS edge from /dev/pps0. If EAS Station is in direct-serial mode,
+    #    gpsd usually cannot own the GPS UART, so SHM 0 stays empty and
+    #    PPS cannot lock to GPS. In that case, direct operators to the
+    #    gpsd NMEA source mode instead of the old workaround of disabling
+    #    the live GPS receiver.
+    gps_source = str(report.get("expected_source") or "auto").strip().lower()
+    if gps_source == "serial" and chrony_cfg.get("has_pps_refclock"):
+        actions.append({
+            "id": "switch_gps_source_to_gpsd",
+            "severity": "warning",
+            "label": "Switch NMEA source to gpsd for PPS-disciplined chrony",
+            "reason": (
+                "EAS Station is configured to open the GPS serial port directly. "
+                "For chrony to discipline time from GPS + PPS, gpsd must own "
+                "the serial port, publish NMEA samples to SHM 0, and let chrony "
+                "lock /dev/pps0 to that GPS source. Change Admin → Hardware "
+                "Settings → GPS → NMEA Source to 'gpsd', save, then restart "
+                "gpsd, chrony, and the hardware service."
+            ),
+            "command": (
+                "# In the web UI: Admin → Hardware Settings → GPS → NMEA Source = gpsd; Save & Restart\n"
+                "sudo systemctl restart gpsd chrony eas-station-hardware"
+            ),
+            "runner": {
+                "endpoint": "/admin/hardware/gps-hat/source-mode",
+                "body": {"gps_source": "gpsd"},
+                "button_label": "Switch to gpsd",
+                "confirm": (
+                    "Set the GPS NMEA Source to gpsd now? This lets gpsd own "
+                    "the serial port so chrony can use gpsd SHM 0 plus /dev/pps0. "
+                    "The hardware service will be restarted afterward."
+                ),
+                "post_action": {
+                    "endpoint": "/admin/hardware/restart-services",
+                    "body": {},
+                    "label": "restart hardware service",
+                },
+            },
+        })
+
     unreached = chrony_run.get("refclocks_unreached") or []
     if unreached and serial.get("exists"):
         # Only surface when chrony itself is otherwise healthy — if chrony
@@ -852,11 +886,11 @@ def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
                     f"chrony has the {' / '.join(unreached)} refclock(s) configured "
                     "but Reach=0 — no samples have ever arrived. The most common "
                     "cause is gpsd not being able to open the GPS serial port "
-                    "because EAS Station's hardware service holds it. Until the "
-                    "gpsd-as-NMEA-source feature lands, the workaround is to "
-                    "uncheck 'Enable GPS Receiver' under Admin → Hardware "
-                    "Settings → GPS, save, and let gpsd own the port. You'll "
-                    "lose the live GPS card but gain stratum-1 PPS time."
+                    "because another process owns it. Set Admin → Hardware "
+                    "Settings → GPS → NMEA Source to 'gpsd' so gpsd is the "
+                    "single serial-port owner; EAS Station will read the same "
+                    "receiver from gpsd's localhost JSON stream while chrony "
+                    "uses gpsd SHM 0 plus /dev/pps0."
                 ),
                 "command": (
                     "# Check who owns the serial port:\n"
@@ -874,6 +908,7 @@ def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
 def collect_gps_hat_diagnostics(
     expected_pps_pin: int = 18,
     expected_baud: int = 9600,
+    expected_source: str = "auto",
     logger: Optional[logging.Logger] = None,
 ) -> Dict[str, Any]:
     """Top-level probe. Returns a JSON-serialisable diagnostic report.
@@ -883,6 +918,9 @@ def collect_gps_hat_diagnostics(
             (passed in by the caller from settings).
         expected_baud: Baud rate EAS Station has configured for the GPS
             serial port (passed in by the caller from settings).
+        expected_source: NMEA source mode EAS Station is configured to use
+            (``auto``, ``serial``, or ``gpsd``); used to flag port-sharing
+            setups that cannot let chrony consume GPS+PPS.
         logger: Optional logger; defaults to module logger.
     """
     log = logger or _logger
@@ -890,6 +928,7 @@ def collect_gps_hat_diagnostics(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "expected_pps_pin": expected_pps_pin,
         "expected_baud": expected_baud,
+        "expected_source": (expected_source or "auto"),
     }
 
     try:

--- a/docs/hardware/GPS_HAT_SETUP.md
+++ b/docs/hardware/GPS_HAT_SETUP.md
@@ -96,6 +96,52 @@ In the GPS form under *Hardware Settings → GPS*:
 - **Anywhere you want stratum-1 PPS time**: switch to **gpsd**. Run the GPS HAT Setup Status panel's Run buttons until everything is green; you get sub-microsecond UTC discipline for free.
 - **Custom NMEA source / non-standard pinout / debugging**: switch to **serial**. The HAT runs on whatever path you point it at, no gpsd dependency.
 
+### How to let chrony discipline time from GPS + PPS
+
+Chrony needs **both** parts of the GPS time source:
+
+1. **Coarse time / sentence validity from gpsd** — gpsd reads the UART NMEA stream and publishes it to chrony's SHM segment 0.
+2. **Precise second edge from kernel PPS** — the `pps-gpio` overlay exposes the HAT's PPS pin as `/dev/pps0`, and chrony locks that PPS edge to the GPS sentences with `lock GPS`.
+
+Do this from the UI whenever possible:
+
+1. Go to **Admin → Hardware Settings → GPS**.
+2. Set **NMEA Source** to **gpsd (share GPS with chrony for PPS)**, then **Save & Restart**. If the diagnostic panel detects that you're still in **Serial port** mode while chrony has GPS/PPS refclocks configured, it also offers a **Switch to gpsd** Run button that applies this setting and restarts the hardware service for you. This makes gpsd the only process that opens the serial port; EAS Station reads the same receiver through gpsd instead of fighting gpsd for `/dev/serial0`.
+3. In **GPS HAT Setup Status**, run any remaining action cards for:
+   - installing `chrony`, `gpsd`, `gpsd-clients`, and `pps-tools`;
+   - adding `dtoverlay=pps-gpio,gpiopin=<your PPS pin>` to `config.txt` and rebooting;
+   - writing `/etc/default/gpsd`;
+   - configuring chrony's `SHM 0` + `PPS /dev/pps0 lock GPS` refclocks;
+   - enabling and starting `gpsd` and `chrony`.
+4. Verify **GPS & Time Dashboard** shows the hardware service source as `gpsd`, PPS backend as `kernel`, and chrony selecting a local `#` refclock (`GPS`/`PPS`) at stratum 1.
+
+The managed chrony block should look like this:
+
+```conf
+# >>> eas-station-hwsetup — managed block (do not edit between markers)
+rtcsync
+refclock SHM 0 refid GPS precision 1e-1 offset 0.0 delay 0.2 noselect
+refclock PPS /dev/pps0 lock GPS refid PPS
+# <<< eas-station-hwsetup — managed block
+```
+
+The gpsd default file should include the GPS UART and PPS device and force gpsd to start reading immediately:
+
+```sh
+DEVICES="/dev/serial0 /dev/pps0"
+GPSD_OPTIONS="-n -b -s 9600"
+START_DAEMON="true"
+USBAUTO="false"
+```
+
+After changing these by hand, restart the services in this order:
+
+```sh
+sudo systemctl restart gpsd chrony eas-station-hardware
+```
+
+If `chronyc sources -v` shows `#? GPS` or `#? PPS` with `Reach=0`, chrony is configured but not receiving samples. The usual cause is port ownership: switch **NMEA Source** from **Serial port** to **gpsd**, then restart the services above.
+
 ### Verifying gpsd mode is actually active
 
 Hardware service log line on startup should read:

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -6811,17 +6811,22 @@
         var chrony = (snapshot && snapshot.chrony) || {};
         var t      = chrony.tracking || {};
 
-        // Reference Lock — has GPS lock + 3D fix.
-        var locked = gps.has_fix && !gps.holdover_s;
-        var fixMode = gps.fix_mode || (gps.has_fix ? '3D' : 'No fix');
+        // Reference Lock — has GPS lock + 3D fix.  gps.fix_mode is the
+        // NMEA/gpsd numeric mode (1=no fix, 2=2D, 3=3D), so normalise it
+        // before composing operator-facing copy.  Otherwise a healthy 3D
+        // solution renders as the confusing text "3 fix (no altitude)".
+        var fixMode = gps.fix_mode;
+        var fixModeLabel = (fixMode === 3) ? '3D' : ((fixMode === 2) ? '2D' : (gps.has_fix ? 'GNSS' : 'No'));
         var refLev, refDet;
         if (gps.holdover_s > 0) {
             refLev = (gps.holdover_s > 300 ? 'bad' : 'watch');
             refDet = 'Holdover ' + fmtDuration(gps.holdover_s) + ' — no live GNSS lock';
-        } else if (gps.has_fix && /3D/i.test(String(fixMode))) {
+        } else if (gps.has_fix && fixMode === 3) {
             refLev = 'excellent'; refDet = '3D fix locked';
+        } else if (gps.has_fix && fixMode === 2) {
+            refLev = 'acceptable'; refDet = '2D fix — altitude not available';
         } else if (gps.has_fix) {
-            refLev = 'acceptable'; refDet = fixMode + ' fix (no altitude)';
+            refLev = 'acceptable'; refDet = fixModeLabel + ' fix — dimensionality unknown';
         } else {
             refLev = 'bad'; refDet = 'No GNSS lock';
         }

--- a/templates/admin/hardware_settings.html
+++ b/templates/admin/hardware_settings.html
@@ -2605,7 +2605,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             if (postJson.stdout) appendOutput(postJson.stdout);
                             if (postJson.stderr) appendOutput(postJson.stderr);
                             appendOutput(JSON.stringify(postJson, null, 2) + '\n');
-                            if (!postJson.ok) {
+                            var postOk = !!(postJson.ok || postJson.success);
+                            if (!postOk) {
                                 setModalStatus(
                                     '<i class="fas fa-exclamation-triangle text-warning me-1"></i>'
                                     + 'Main action succeeded but follow-up '

--- a/tests/test_gps_hat_actions.py
+++ b/tests/test_gps_hat_actions.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_gps_hat_module():
+    spec = importlib.util.spec_from_file_location(
+        "gps_hat_under_test",
+        Path(__file__).resolve().parents[1] / "app_utils" / "gps_hat.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_build_actions = _load_gps_hat_module()._build_actions
+
+
+def _base_report(**overrides):
+    report = {
+        "rtc": {
+            "detected_chip": None,
+            "expected_overlay": None,
+            "chip_label": None,
+            "porf_set": None,
+        },
+        "pps": {"gpio_device": {"name": "pps0"}},
+        "serial": {"exists": True},
+        "packages": {"items": [], "missing_required": []},
+        "services": {"items": []},
+        "gpsd_config": {"exists": True, "has_n_flag": True, "baud_flag": 9600},
+        "chrony_config": {
+            "exists": True,
+            "rtcsync_enabled": True,
+            "has_pps_refclock": True,
+            "has_shm_refclock": True,
+            "pool_lines": [],
+        },
+        "chrony_runtime": {"tracking_ok": True, "refclocks_unreached": []},
+        "config_txt": {
+            "path": "/boot/firmware/config.txt",
+            "exists": True,
+            "pps_gpio_overlay_line": "dtoverlay=pps-gpio,gpiopin=18",
+            "pps_pin_match": True,
+        },
+        "expected_pps_pin": 18,
+        "expected_baud": 9600,
+        "expected_source": "auto",
+    }
+    report.update(overrides)
+    return report
+
+
+def test_serial_source_warns_to_switch_to_gpsd_for_chrony_pps():
+    actions = _build_actions(_base_report(expected_source="serial"))
+
+    switch_actions = [a for a in actions if a["id"] == "switch_gps_source_to_gpsd"]
+    assert len(switch_actions) == 1
+    assert "NMEA Source to 'gpsd'" in switch_actions[0]["reason"]
+    assert "systemctl restart gpsd chrony eas-station-hardware" in switch_actions[0]["command"]
+    assert switch_actions[0]["runner"]["endpoint"] == "/admin/hardware/gps-hat/source-mode"
+    assert switch_actions[0]["runner"]["body"] == {"gps_source": "gpsd"}
+    assert switch_actions[0]["runner"]["post_action"]["endpoint"] == "/admin/hardware/restart-services"
+
+
+def test_gpsd_source_does_not_warn_to_switch_to_gpsd():
+    actions = _build_actions(_base_report(expected_source="gpsd"))
+
+    assert "switch_gps_source_to_gpsd" not in {a["id"] for a in actions}

--- a/webapp/admin/hardware.py
+++ b/webapp/admin/hardware.py
@@ -95,6 +95,7 @@ def gps_hat_diagnostics():
         report = collect_gps_hat_diagnostics(
             expected_pps_pin=int(gps_settings.get('pps_gpio_pin', 18) or 18),
             expected_baud=int(gps_settings.get('baudrate', 9600) or 9600),
+            expected_source=str(gps_settings.get('gps_source', 'auto') or 'auto'),
             logger=logger,
         )
         # Surface helper availability so the UI can show "Run" buttons (when
@@ -460,6 +461,44 @@ def gps_hat_config_txt_overlay():
     except Exception as exc:
         logger.exception("hwsetup config_txt_set_overlay failed")
         return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@hardware_bp.route('/hardware/gps-hat/source-mode', methods=['POST'])
+@require_permission('system.configure')
+def gps_hat_source_mode():
+    """Set the GPS NMEA source mode from a GPS HAT diagnostic action.
+
+    Body: ``{"gps_source": "auto"|"serial"|"gpsd"}``
+
+    This is intentionally narrow: the full hardware settings form can update
+    every hardware field, but the diagnostic panel only needs a one-click way
+    to move off direct-serial mode so gpsd can own the UART for chrony's
+    SHM+PPS refclock chain. Restarting the hardware service is handled by the
+    action runner's follow-up step.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            raise BadRequest("body must be a JSON object")
+        src = str(body.get('gps_source', 'gpsd') or 'gpsd').strip().lower()
+        if src not in ('auto', 'serial', 'gpsd'):
+            raise BadRequest("gps_source must be one of: auto, serial, gpsd")
+
+        settings = update_hardware_settings({'gps_source': src})
+        invalidate_hardware_settings_cache()
+        return jsonify({
+            "ok": True,
+            "success": True,
+            "gps_source": settings.gps_source,
+            "stdout": f"GPS NMEA source set to {settings.gps_source}.\n",
+            "requires_restart": True,
+        })
+    except BadRequest:
+        raise
+    except Exception as exc:
+        logger.exception("gps_hat_source_mode failed")
+        db.session.rollback()
+        return jsonify({"ok": False, "success": False, "error": str(exc)}), 500
 
 
 @hardware_bp.route('/hardware/update', methods=['POST'])


### PR DESCRIPTION
### Motivation

- Provide operators a clear, one-click path to resolve serial-port contention that prevents chrony from using GPS+PPS by switching NMEA source to `gpsd` so gpsd can own the UART and chrony can use SHM 0 + `/dev/pps0`.

### Description

- Add a new diagnostic action `switch_gps_source_to_gpsd` in `_build_actions` that warns when the station is configured for direct-serial (`expected_source == "serial"`) while chrony has a PPS refclock configured, and supply a runner that posts to `/admin/hardware/gps-hat/source-mode` to change the setting and restart services.
- Extend `collect_gps_hat_diagnostics` to accept and include an `expected_source` parameter in the report so diagnostics can reason about port-sharing modes.
- Add a new admin route `POST /hardware/gps-hat/source-mode` to update the hardware setting `gps_source` and return a restart-required response, with input validation and transactional error handling.
- Update user-facing artifacts: expand `docs/hardware/GPS_HAT_SETUP.md` with a new section explaining how to let chrony discipline time from GPS+PPS and include managed `chrony`/`gpsd` config examples; adjust the dashboard UI logic in `templates/admin/gps_dashboard.html` to normalise `gps.fix_mode` labels; and make the hardware settings runner UI in `templates/admin/hardware_settings.html` accept either `ok` or `success` in follow-up POST responses.
- Add unit tests in `tests/test_gps_hat_actions.py` that exercise the new action generation for `serial` vs `gpsd` `expected_source` values.

### Testing

- Ran the new unit tests with `pytest tests/test_gps_hat_actions.py`, which passed.
- Exercised the diagnostic action generator by loading the module and asserting the presence or absence of the `switch_gps_source_to_gpsd` action based on `expected_source` values, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8d60ba448320aa6a164710d28f61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPS NMEA source mode configuration (serial or gpsd)
  * New warning when PPS refclock is configured but system uses serial GPS access, with guided switch to gpsd mode
  * Improved GPS timing health status indicators with better fix-type clarity

* **Documentation**
  * Added comprehensive guide for GPS + PPS time discipline setup with chrony, including step-by-step UI instructions and configuration examples

* **Bug Fixes**
  * Fixed action-runner response validation for GPS configuration updates

* **Tests**
  * Added test coverage for GPS source mode warning logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->