### PR TITLE
Enable NMEA in gpsd WATCH and fix ttyAMA device entries

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -452,7 +452,7 @@ class GPSManager:
             # Subscribe to JSON event stream — `pps:true` asks gpsd to
             # forward kernel PPS samples too, but it's harmless if the
             # gpsd build is too old to support it.
-            sock.sendall(b'?WATCH={"enable":true,"json":true,"pps":true}\n')
+            sock.sendall(b'?WATCH={"enable":true,"json":true,"nmea":true,"pps":true}\n')
             # Use a long read timeout in the steady state; reconnect logic
             # in the loop handles dropped connections.
             sock.settimeout(15.0)
@@ -1467,7 +1467,7 @@ class GPSManager:
     # ------------------------------------------------------------------
     #
     # Wire format: gpsd serves JSON-Lines over TCP. After we send
-    # ``?WATCH={"enable":true,"json":true,"pps":true}`` it streams events
+    # ``?WATCH={"enable":true,"json":true,"nmea":true,"pps":true}`` it streams events
     # of the form documented at https://gpsd.gitlab.io/gpsd/gpsd_json.html
     # — primarily TPV (time/position/velocity), SKY (satellite snapshot),
     # and GST (error estimates), interleaved with periodic VERSION /

--- a/bin/eas-station-hwsetup
+++ b/bin/eas-station-hwsetup
@@ -746,7 +746,7 @@ def _atomic_write_with_backup(
 # ---------------------------------------------------------------------------
 
 _GPSD_DEVICE_RE = re.compile(
-    r"^/dev/(serial[0-9]|ttyAMA[0-9]|ttyAMA1[0-9]?|ttyS[0-9]|"
+    r"^/dev/(serial[0-9]|ttyAMA[0-9]|ttyS[0-9]|"
     r"pps[0-9]|ttyUSB[0-9]|ttyACM[0-9])$"
 )
 # Tokens we accept inside GPSD_OPTIONS. Everything else is rejected so

--- a/systemd/eas-station-hardware.service
+++ b/systemd/eas-station-hardware.service
@@ -74,7 +74,7 @@ DeviceAllow=/dev/ttyUSB0 rw
 DeviceAllow=/dev/ttyACM0 rw
 # Serial UART for GPS HAT (/dev/serial0 symlink target varies by Pi model)
 DeviceAllow=/dev/ttyAMA0 rw
-DeviceAllow=/dev/ttyAMA10 rw
+DeviceAllow=/dev/ttyAMA1 rw
 DeviceAllow=/dev/ttyS0 rw
 
 # Resource limits


### PR DESCRIPTION
### Motivation
- Ensure the gpsd backend also receives raw NMEA sentences so parity with the serial reader is preserved and NMEA-dependent parsing is available.
- Correct the allowed GPS serial device patterns and the systemd service device allowance to match actual device names and remove a typo that referenced `/dev/ttyAMA10`.

### Description
- Add `"nmea":true` to the gpsd `?WATCH=` subscription in `app_core/gps/gps_manager.py` and update the inline comment to reflect the new flag.
- Simplify the allowed device regex in `bin/eas-station-hwsetup` to accept `/dev/ttyAMA[0-9]` and remove the earlier, incorrect `ttyAMA1[0-9]?` alternative.
- Fix the systemd unit `systemd/eas-station-hardware.service` to allow `/dev/ttyAMA1` instead of the mistyped `/dev/ttyAMA10`.

### Testing
- Ran the automated unit test suite with `pytest -q` and it completed successfully.
- Verified the systemd unit file parsing with `systemd-analyze verify` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf65a8c848320bb3df33c21788884)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPS system now receives and processes Pulse Per Second (PPS) timing events directly from the kernel, enabling high-precision time synchronization in addition to standard NMEA and JSON navigation data streams.

* **Chores**
  * Updated hardware serial device path configuration requirements for compatible GPS receivers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->