### PR TITLE
refactor(brand): restore SVG as canonical wordmark, PNG as raster com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="static/img/eas-system-wordmark.png" alt="EAS Station" width="192" height="48" style="vertical-align: middle;"> EAS Station™
+# <img src="static/img/eas-system-wordmark.svg" alt="EAS Station" width="192" height="48" style="vertical-align: middle;"> EAS Station™
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue?style=flat-square&logo=gnu&logoColor=white)](https://www.gnu.org/licenses/agpl-3.0)
 [![Commercial License](https://img.shields.io/badge/License-Commercial-green?style=flat-square)](LICENSE-COMMERCIAL)

--- a/app_utils/image_export.py
+++ b/app_utils/image_export.py
@@ -59,8 +59,9 @@ from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
 # ─── Canonical brand logo ──────────────────────────────────────────────────
 # Single source of truth for the EAS Station brand logo raster used inside
-# the share image.  Replace this PNG to refresh every consumer — favicons,
-# on-page <img> tags, this share-image renderer.
+# the share image.  Update both the SVG (static/img/eas-system-wordmark.svg)
+# and re-rasterize this PNG to refresh every consumer — favicons, on-page
+# <img> tags, this share-image renderer.
 _LOGO_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     'static', 'img', 'eas-system-wordmark.png',
@@ -1481,8 +1482,9 @@ def generate_alert_image(
 
     # Branding (top-right) — render the canonical EAS Station wordmark image
     # so updating the brand asset is just a matter of swapping the file at
-    # static/img/eas-system-wordmark.png.  Fall back to the legacy text mark
-    # only if the file is missing or fails to load.
+    # static/img/eas-system-wordmark.png (rasterized from the SVG).  Fall
+    # back to the legacy text mark only if the file is missing or fails to
+    # load.
     logo = _load_logo()
     brand_right = FB_WIDTH - 16
     if logo is not None:

--- a/docs/development/AGENTS.md
+++ b/docs/development/AGENTS.md
@@ -40,7 +40,7 @@ When discussing or investigating bugs:
   - `templates/about.html` – System overview and feature descriptions
   - Relevant Markdown files in `docs/` directory
   - This ensures users always have current information about system capabilities
-- **Brand Consistency** – Use `static/img/eas-system-wordmark.png` (the canonical brand wordmark) for hero sections, headers, and major UI cards when expanding documentation pages. The logo must remain accessible (include `alt` text). This is the single source of truth for every consumer — favicons, on-page `<img>` tags, and the Pillow-based share-image renderer in `app_utils/image_export.py` — so replacing the file refreshes everything at once.
+- **Brand Consistency** – Use `static/img/eas-system-wordmark.svg` (the canonical brand wordmark) for hero sections, headers, and major UI cards when expanding documentation pages. The logo must remain accessible (include `alt` text). A companion raster (`eas-system-wordmark.png`) exists for renderers that can not consume SVG (e.g. the Pillow-based share-image renderer in `app_utils/image_export.py`) — re-rasterize it whenever the SVG changes.
 - **Mermaid-Friendly Markdown** – GitHub-flavoured Mermaid diagrams are welcome in repository docs. Keep them accurate by naming real modules, packages, and endpoints.
 
 ### **🚨 MANDATORY: Frontend UI for Every Backend Feature**

--- a/docs/frontend/COMPONENT_LIBRARY.md
+++ b/docs/frontend/COMPONENT_LIBRARY.md
@@ -65,7 +65,7 @@ The primary navigation provides access to main application areas.
   <div class="container-fluid">
     <!-- Logo and Brand -->
     <a class="navbar-brand" href="/">
-      <img src="/static/img/eas-system-wordmark.png" alt="EAS Station" height="32">
+      <img src="/static/img/eas-system-wordmark.svg" alt="EAS Station" height="32">
       <span class="brand-text">EAS Station</span>
     </a>
 

--- a/static/js/logo-effects.js
+++ b/static/js/logo-effects.js
@@ -6,9 +6,9 @@
 
         logos.forEach(logo => {
             // The brand logo is an <img> referencing the canonical
-            // wordmark PNG — injecting SVG <defs> only makes sense on
-            // inline SVG elements.  Skip anything else so we don't
-            // throw on <img> tags.
+            // wordmark at static/img/eas-system-wordmark.svg — injecting
+            // SVG <defs> only makes sense on inline SVG elements.  Skip
+            // anything else so we don't throw on <img> tags.
             if (logo.tagName.toLowerCase() !== 'svg') return;
             if (logo.querySelector('defs')) return;
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,9 +20,11 @@
     {% block meta %}{% endblock %}
 
     <!-- Favicon — canonical EAS Station ™ wordmark -->
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
-    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}">
+    <link rel="alternate icon" type="image/png" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+    <link rel="mask-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}" color="#204885">
     <meta name="theme-color" content="#204885">
 
     <!-- Vendor CSS (Bootstrap) -->

--- a/templates/partials/common_head.html
+++ b/templates/partials/common_head.html
@@ -2,9 +2,11 @@
 <meta name="csrf-token" content="{{ csrf_token }}">
 
 <!-- Favicon — canonical EAS Station ™ wordmark -->
-<link rel="icon" type="image/png" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
-<link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+<link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}">
+<link rel="alternate icon" type="image/png" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+<link rel="shortcut icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}">
 <link rel="apple-touch-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}">
+<link rel="mask-icon" href="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}" color="#204885">
 <meta name="theme-color" content="#204885">
 
 <!-- Bootstrap CSS (local to avoid third-party blocking) -->

--- a/templates/partials/logo_wordmark.html
+++ b/templates/partials/logo_wordmark.html
@@ -3,16 +3,18 @@
 
    This renders the canonical brand wordmark:
 
-       static/img/eas-system-wordmark.png
+       static/img/eas-system-wordmark.svg
 
    The same wordmark is used by favicons, on-page brand placements (navbar,
-   hero, footer), and the alert share-image renderer.  To change the logo,
-   replace the PNG — no template edits required.
+   hero, footer), and the alert share-image renderer (which loads the
+   companion PNG at static/img/eas-system-wordmark.png because Pillow can
+   not read SVG).  To change the logo, update the SVG and re-rasterize
+   the PNG companion — no template edits required.
    ───────────────────────────────────────────────────────────────────────── #}
 {% set logo_classes = logo_classes | default('brand-logo') %}
 {% set logo_style = logo_style | default('') %}
 {% set logo_label = logo_label | default('EAS Station ™ logo') %}
 <img class="logo-wordmark{% if logo_classes %} {{ logo_classes }}{% endif %}"
-     src="{{ url_for('static', filename='img/eas-system-wordmark.png') }}?v={{ static_asset_version }}"
+     src="{{ url_for('static', filename='img/eas-system-wordmark.svg') }}?v={{ static_asset_version }}"
      alt="{{ logo_label }}"
      {% if logo_style %}style="{{ logo_style }}"{% endif %}>


### PR DESCRIPTION
…panion

The wordmark was migrated to PNG-only when we only had a PNG to ship. A redrawn SVG has since landed at static/img/eas-system-wordmark.svg, so restore the prior split: the SVG is the canonical source consumed by all HTML <img> tags and modern favicon links, while the PNG sits alongside as the raster companion for the Pillow-based share-image renderer (which cannot read SVG) and as the apple-touch-icon / alternate-icon fallback.

  * logo_wordmark.html, base.html, common_head.html: point favicon icon/shortcut/mask-icon links at the SVG, keep PNG for alternate-icon and apple-touch-icon.
  * Restore SVG-first guidance in image_export.py / logo-effects.js comments, AGENTS.md, COMPONENT_LIBRARY.md, and the README header.
  * Preserve the ?v={{ static_asset_version }} cache-bust on every reference so future version bumps invalidate the stale bitmap.

https://claude.ai/code/session_01HHmL1GDo6WW5N9bRC2jeNS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated brand guidelines to establish SVG as the canonical wordmark format for all placements.

* **Refactor**
  * Migrated wordmark references from PNG to SVG format throughout the codebase and documentation templates.
  * Updated favicon declarations to prioritize SVG with PNG fallback.
  * Enhanced inline documentation to clarify asset sourcing and maintenance procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->