### PR TITLE
style(hero): frosted backplate behind hero wordmark for contrast

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -7561,7 +7561,17 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     gap: 1rem;
 }
 .eas-hero-logo,
-.about-hero-logo { max-width: 460px; width: 100%; }
+.about-hero-logo {
+    max-width: 460px;
+    width: 100%;
+    padding: 1rem 1.5rem;
+    border-radius: var(--radius-xl);
+    background: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.22),
+                0 0 0 1px rgba(255, 255, 255, 0.55) inset;
+}
 .eas-hero-title,
 .about-hero-title {
     font-size: clamp(1.9rem, 3.2vw, 2.6rem);


### PR DESCRIPTION
The wordmark uses light-gray glyphs for \"EAS\" and a thin gray equalizer, which wash out against the indigo→purple→pink hero gradient on the About page and other pages that use partials/hero.html.  Add a near-opaque white frosted panel behind .eas-hero-logo / .about-hero-logo with rounded corners, soft shadow and a subtle inner border so the artwork reads cleanly without changing the gradient or the wordmark itself.  Backdrop-filter blur keeps it from feeling pasted-on.

https://claude.ai/code/session_01HHmL1GDo6WW5N9bRC2jeNS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the about page hero logo styling with expanded padding, rounded corners, frosted glass background effect with backdrop blur, and enhanced shadow for a modern card-like appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->