### PR TITLE
fix: correctly track broadcast outcome and use local time for RWT schedule

### DIFF
--- a/app_core/_models_displays.py
+++ b/app_core/_models_displays.py
@@ -230,6 +230,19 @@ class RWTScheduleConfig(db.Model):
     last_run_status = db.Column(db.String(20))  # 'success', 'failed', etc.
     last_run_details = db.Column(JSONB)
 
+    # Manual skip: when set, the scheduler will not fire on any configured
+    # day whose local date is on or before ``skip_until``.  Operators set
+    # this from the RWT Schedule page to pause automatic RWT broadcasts for
+    # one or more upcoming scheduled days (e.g. holiday, planned manual
+    # test).  Stored as a calendar DATE in the station's local timezone.
+    skip_until = db.Column(db.Date, nullable=True)
+
+    # Heartbeat: updated by the RWT scheduler on every check (~ every
+    # minute).  Persisted in the DB rather than kept in-process so the
+    # web UI can show "scheduler alive" indication across all Gunicorn
+    # workers without coordinating shared memory.
+    last_heartbeat_at = db.Column(db.DateTime(timezone=True))
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary for API responses.
 
@@ -250,6 +263,10 @@ class RWTScheduleConfig(db.Model):
             'last_run_at': self.last_run_at.isoformat() if self.last_run_at else None,
             'last_run_status': self.last_run_status,
             'last_run_details': dict(self.last_run_details or {}),
+            'skip_until': self.skip_until.isoformat() if self.skip_until else None,
+            'last_heartbeat_at': (
+                self.last_heartbeat_at.isoformat() if self.last_heartbeat_at else None
+            ),
         }
 
 

--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -88,23 +88,67 @@ def _resolve_event_code(alert) -> Optional[str]:
     return None
 
 
+def _same_header_dedupe_key(header: Optional[str]) -> Optional[str]:
+    """Reduce a SAME header to a callsign-independent dedupe key.
+
+    A SAME header looks like
+        ``ZCZC-ORG-EVT-PSSCCC-...+TTTT-JJJHHMM-CCCCCCCC-``
+    Two relays of the same NWS alert differ only in the trailing
+    callsign field, so dropping it gives a key that identifies the alert
+    itself regardless of which station relayed it.
+    """
+    if not header:
+        return None
+    header = header.strip()
+    if not header.startswith("ZCZC"):
+        return None
+    parts = header.split("-")
+    if len(parts) < 5:
+        return None
+    return "-".join(parts[:-2])
+
+
 def is_duplicate_broadcast(
     event_code: str,
     fips_codes: List[str],
     db_session,
     window_minutes: int = CROSS_SOURCE_DEDUP_WINDOW_MINUTES,
+    raw_same_header: Optional[str] = None,
 ) -> bool:
-    """Check if an alert with the same event code and overlapping FIPS has
-    already been broadcast within the deduplication window.
+    """Check whether *this specific alert* has already been broadcast
+    within the deduplication window.
 
-    Checks both EASMessage (CAP-sourced broadcasts) and ManualEASActivation
-    (manual/RWT/auto-forwarded broadcasts) tables.
+    Matching rules (in priority order):
+
+    1. **Header-key match.**  When ``raw_same_header`` is supplied and
+       contains a usable SAME header, compute its callsign-independent
+       dedupe key (see :func:`_same_header_dedupe_key`) and look for any
+       recent broadcast whose ``same_header`` reduces to the same key.
+       This is the strongest signal — same originator, event code, FIPS
+       set and issue time — and is the right signal for OTA relays.
+
+    2. **Full-FIPS match.**  When no header is available (CAP alerts
+       carry only structured fields), require the recent broadcast to
+       have the *same event code* AND the *same FIPS set* (sorted-equal,
+       not "any overlap").  Requiring full-set match prevents two
+       distinct SVRs — one for Williams+Steuben (039125, 039161) and one
+       for Defiance+Williams+Henry (039039, 039125, 039137) — from
+       suppressing each other just because they share Williams.
+
+    Checks both ``EASMessage`` (CAP and OTA broadcasts) and
+    ``ManualEASActivation`` (manual/RWT/auto-forwarded broadcasts).
     """
-    if not event_code or not fips_codes:
+    if not event_code:
         return False
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
-    fips_set = set(fips_codes)
+    fips_set = set(fips_codes or [])
+    header_key = _same_header_dedupe_key(raw_same_header)
+
+    if not header_key and not fips_set:
+        # Without either signal, we cannot tell duplicates from distinct
+        # alerts.  Don't suppress.
+        return False
 
     try:
         from app_core.models import EASMessage
@@ -116,14 +160,30 @@ def is_duplicate_broadcast(
         for msg in recent_messages:
             meta = msg.metadata_payload or {}
             msg_event_code = meta.get('event_code', '')
-            msg_locations = meta.get('locations', [])
-            if msg_event_code == event_code and fips_set & set(msg_locations):
+            if msg_event_code != event_code:
+                continue
+
+            # 1) Header-key match (preferred when available)
+            if header_key:
+                msg_key = _same_header_dedupe_key(msg.same_header)
+                if msg_key and msg_key == header_key:
+                    logger.info(
+                        "Cross-source duplicate detected in EASMessage (header "
+                        "key match): event=%s, key=%s (message_id=%s)",
+                        event_code, header_key, msg.id,
+                    )
+                    return True
+                # Header keys disagree → not the same alert; don't fall
+                # through to the lossier FIPS check.
+                continue
+
+            # 2) Full-FIPS-set match (when no header is available)
+            msg_locations = set(meta.get('locations', []) or [])
+            if msg_locations and msg_locations == fips_set:
                 logger.info(
-                    "Cross-source duplicate detected in EASMessage: "
-                    "event=%s, overlapping FIPS=%s (message_id=%s)",
-                    event_code,
-                    fips_set & set(msg_locations),
-                    msg.id,
+                    "Cross-source duplicate detected in EASMessage (full-FIPS "
+                    "match): event=%s, FIPS=%s (message_id=%s)",
+                    event_code, sorted(fips_set), msg.id,
                 )
                 return True
     except Exception as exc:
@@ -138,14 +198,22 @@ def is_duplicate_broadcast(
             .all()
         )
         for activation in recent_activations:
+            if header_key:
+                act_key = _same_header_dedupe_key(activation.same_header)
+                if act_key and act_key == header_key:
+                    logger.info(
+                        "Cross-source duplicate detected in ManualEASActivation "
+                        "(header key match): event=%s, key=%s (activation_id=%s)",
+                        event_code, header_key, activation.id,
+                    )
+                    return True
+                continue
             activation_fips = set(activation.same_locations or [])
-            if fips_set & activation_fips:
+            if activation_fips and activation_fips == fips_set:
                 logger.info(
-                    "Cross-source duplicate detected in ManualEASActivation: "
-                    "event=%s, overlapping FIPS=%s (activation_id=%s)",
-                    event_code,
-                    fips_set & activation_fips,
-                    activation.id,
+                    "Cross-source duplicate detected in ManualEASActivation "
+                    "(full-FIPS match): event=%s, FIPS=%s (activation_id=%s)",
+                    event_code, sorted(fips_set), activation.id,
                 )
                 return True
     except Exception as exc:
@@ -507,13 +575,21 @@ def auto_forward_ota_alert(
         log.info("OTA auto-forward skipped: %s", result['reason'])
         return result
 
-    # Cross-source deduplication: only check when we have enough information
-    # to produce a meaningful key (UNKNOWN is already blocked above).
-    if fips_codes:
-        if is_duplicate_broadcast(event_code, fips_codes, db_session):
+    # Cross-source deduplication.  Prefer the raw SAME header as the
+    # dedupe key (it identifies the alert regardless of which station
+    # relayed it); fall back to event code + full-FIPS-set match when
+    # no header is available.
+    raw_same_header = alert_dict.get('raw_header') or alert_dict.get('raw_text')
+    if fips_codes or raw_same_header:
+        if is_duplicate_broadcast(
+            event_code,
+            fips_codes,
+            db_session,
+            raw_same_header=raw_same_header,
+        ):
             result['reason'] = (
                 f"Cross-source duplicate: {event_code} already broadcast "
-                f"for overlapping FIPS within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
+                f"for the same alert within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
             )
             log.info("OTA auto-forward skipped: %s", result['reason'])
             return result

--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -44,9 +44,22 @@ from app_utils.vtec import VTEC_BROADCAST_ACTIONS, VTEC_SKIP_ACTIONS, VTEC_TERMI
 
 logger = logging.getLogger(__name__)
 
-# Deduplication window: alerts with the same event code and overlapping
-# FIPS codes within this window are considered duplicates across sources.
+# Deduplication windows.
+#
+# CROSS_SOURCE_DEDUP_WINDOW_MINUTES is the window used when we only have
+# event code + FIPS to compare with (CAP path; no raw SAME header).  15
+# minutes balances catching cross-source duplicates against over-
+# suppressing legitimate re-issues of the same alert type.
+#
+# HEADER_KEY_DEDUP_WINDOW_MINUTES is the window used when we can match
+# on the callsign-independent SAME-header key.  Because the header key
+# already encodes the issuer's release time (JJJHHMM) — which is unique
+# per alert issuance — an identical key means the *same alert*, not
+# merely a similar one, and there is no reason to re-broadcast it
+# regardless of when the second copy arrives.  24 hours comfortably
+# covers any SAME purge time we will encounter in practice.
 CROSS_SOURCE_DEDUP_WINDOW_MINUTES = 15
+HEADER_KEY_DEDUP_WINDOW_MINUTES = 24 * 60
 
 
 def _get_fips_from_cap_alert(alert, raw_json: Optional[Dict] = None) -> List[str]:
@@ -88,6 +101,55 @@ def _resolve_event_code(alert) -> Optional[str]:
     return None
 
 
+def _alert_dedupe_lock_key(
+    event_code: Optional[str],
+    fips_codes: Optional[List[str]],
+) -> Optional[int]:
+    """Compute a stable 63-bit signed-int advisory-lock key for *this
+    specific alert*.
+
+    Derived from ``event_code + sorted FIPS`` — the lowest common
+    denominator that BOTH the CAP path (no raw SAME header) and the
+    OTA path (raw SAME header) can compute.  Using a shared key is
+    essential: if CAP and OTA arrivals of the same alert took
+    *different* locks, they would not actually serialize against each
+    other and the back-to-back-duplicate race would persist.
+    """
+    import hashlib
+    if not event_code:
+        return None
+    fips_part = ",".join(sorted(fips_codes or []))
+    if not fips_part:
+        return None
+    key_str = f"{event_code}|{fips_part}"
+    digest = hashlib.sha256(key_str.encode("utf-8")).digest()
+    # First 8 bytes -> signed int64; mask top bit to keep it positive so
+    # we don't trip "out of range" checks in older drivers.
+    return int.from_bytes(digest[:8], "big", signed=False) & 0x7FFFFFFFFFFFFFFF
+
+
+def _acquire_dedupe_lock(db_session, lock_key: Optional[int]) -> None:
+    """Take a transaction-scoped advisory lock on the given key.
+
+    The lock is released automatically when the current transaction
+    commits or rolls back.  A no-op when ``lock_key`` is None or the
+    underlying engine is not PostgreSQL.
+    """
+    if lock_key is None:
+        return
+    try:
+        from sqlalchemy import text
+        # pg_advisory_xact_lock is PostgreSQL-specific.  On other
+        # engines this will raise and we silently degrade (the prior
+        # behaviour — race window present — is preserved).
+        db_session.execute(
+            text("SELECT pg_advisory_xact_lock(:k)"),
+            {"k": lock_key},
+        )
+    except Exception as exc:
+        logger.debug("Advisory dedupe lock unavailable (%s); racing", exc)
+
+
 def _same_header_dedupe_key(header: Optional[str]) -> Optional[str]:
     """Reduce a SAME header to a callsign-independent dedupe key.
 
@@ -108,6 +170,51 @@ def _same_header_dedupe_key(header: Optional[str]) -> Optional[str]:
     return "-".join(parts[:-2])
 
 
+def _parse_same_header(header: Optional[str]):
+    """Extract (originator, event_code, fips_set, issue_time) from a SAME
+    header.  Returns ``None`` if the header does not parse.
+
+    SAME header format:
+        ``ZCZC-ORG-EVT-PSSCCC[-PSSCCC...]+TTTT-JJJHHMM-CCCCCCCC-``
+    The first FIPS field through the last carry ``+TTTT`` on the last
+    one; ``JJJHHMM`` (parts[-3]) is the issuer's release time and is the
+    closest thing to a globally-unique alert identifier we get from the
+    SAME header alone.
+    """
+    if not header:
+        return None
+    header = header.strip()
+    if not header.startswith("ZCZC"):
+        return None
+    parts = header.split("-")
+    if len(parts) < 6:
+        return None
+    try:
+        originator = parts[1]
+        event_code = parts[2]
+        issue_time = parts[-3]
+        # FIPS codes live between parts[3] and parts[-3], with the last
+        # one of them carrying "+TTTT" purge-time suffix.
+        fips_set = set()
+        for raw in parts[3:-3] + [parts[-3 - 1]] if False else parts[3:-3]:
+            # The +TTTT suffix lives on the final FIPS field; strip it.
+            code = raw.split("+", 1)[0]
+            code = "".join(ch for ch in code if ch.isdigit())
+            if code:
+                fips_set.add(code.zfill(6)[:6])
+        # parts[3:-3] above ends before the "+TTTT-JJJHHMM" pair; the
+        # last FIPS-bearing field is actually parts[-4] (because of the
+        # "+" glued to it).  Pull it explicitly to be safe.
+        last_fips_field = parts[-4]
+        code = last_fips_field.split("+", 1)[0]
+        code = "".join(ch for ch in code if ch.isdigit())
+        if code:
+            fips_set.add(code.zfill(6)[:6])
+        return originator, event_code, fips_set, issue_time
+    except (IndexError, ValueError):
+        return None
+
+
 def is_duplicate_broadcast(
     event_code: str,
     fips_codes: List[str],
@@ -123,17 +230,22 @@ def is_duplicate_broadcast(
     1. **Header-key match.**  When ``raw_same_header`` is supplied and
        contains a usable SAME header, compute its callsign-independent
        dedupe key (see :func:`_same_header_dedupe_key`) and look for any
-       recent broadcast whose ``same_header`` reduces to the same key.
-       This is the strongest signal — same originator, event code, FIPS
-       set and issue time — and is the right signal for OTA relays.
+       broadcast within ``HEADER_KEY_DEDUP_WINDOW_MINUTES`` whose
+       ``same_header`` reduces to the same key.  The header key already
+       encodes the issuer's release time (JJJHHMM), so two messages
+       with the same key are the *same alert issuance* and should never
+       both broadcast regardless of how far apart they arrive.  A long
+       window is necessary because relay broadcasts of the same alert
+       routinely arrive 15–30 minutes after the CAP feed.
 
     2. **Full-FIPS match.**  When no header is available (CAP alerts
-       carry only structured fields), require the recent broadcast to
-       have the *same event code* AND the *same FIPS set* (sorted-equal,
-       not "any overlap").  Requiring full-set match prevents two
-       distinct SVRs — one for Williams+Steuben (039125, 039161) and one
-       for Defiance+Williams+Henry (039039, 039125, 039137) — from
-       suppressing each other just because they share Williams.
+       carry only structured fields), use ``window_minutes`` (default
+       15) and require the recent broadcast to have the *same event
+       code* AND the *same FIPS set* (sorted-equal, not "any overlap").
+       Requiring full-set match prevents two distinct SVRs — one for
+       Williams+Steuben (039125, 039161) and one for Defiance+Williams+
+       Henry (039039, 039125, 039137) — from suppressing each other
+       just because they share Williams.
 
     Checks both ``EASMessage`` (CAP and OTA broadcasts) and
     ``ManualEASActivation`` (manual/RWT/auto-forwarded broadcasts).
@@ -141,7 +253,6 @@ def is_duplicate_broadcast(
     if not event_code:
         return False
 
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=window_minutes)
     fips_set = set(fips_codes or [])
     header_key = _same_header_dedupe_key(raw_same_header)
 
@@ -149,6 +260,18 @@ def is_duplicate_broadcast(
         # Without either signal, we cannot tell duplicates from distinct
         # alerts.  Don't suppress.
         return False
+
+    now = datetime.now(timezone.utc)
+    fips_cutoff = now - timedelta(minutes=window_minutes)
+    # Header-key matches use a 24h window because the key includes the
+    # unique issue time and so cannot produce false positives.
+    header_cutoff = now - timedelta(minutes=HEADER_KEY_DEDUP_WINDOW_MINUTES)
+    cutoff = header_cutoff if header_key else fips_cutoff
+
+    # Parse the incoming raw header once if available.  This gives us the
+    # issuer-identity triple (originator, event, issue_time) which is the
+    # strongest cross-source identity signal we have.
+    incoming = _parse_same_header(raw_same_header)
 
     try:
         from app_core.models import EASMessage
@@ -163,7 +286,7 @@ def is_duplicate_broadcast(
             if msg_event_code != event_code:
                 continue
 
-            # 1) Header-key match (preferred when available)
+            # 1) Header-key match (preferred when available — strongest signal)
             if header_key:
                 msg_key = _same_header_dedupe_key(msg.same_header)
                 if msg_key and msg_key == header_key:
@@ -173,19 +296,53 @@ def is_duplicate_broadcast(
                         event_code, header_key, msg.id,
                     )
                     return True
-                # Header keys disagree → not the same alert; don't fall
-                # through to the lossier FIPS check.
-                continue
 
-            # 2) Full-FIPS-set match (when no header is available)
-            msg_locations = set(meta.get('locations', []) or [])
-            if msg_locations and msg_locations == fips_set:
-                logger.info(
-                    "Cross-source duplicate detected in EASMessage (full-FIPS "
-                    "match): event=%s, FIPS=%s (message_id=%s)",
-                    event_code, sorted(fips_set), msg.id,
-                )
-                return True
+            # 2) Issuer-identity match: same originator + event + issue
+            # time, with overlapping FIPS.  Catches the case where a
+            # relay station's incoming raw_header has a broader FIPS set
+            # than the local outgoing broadcast (we filter to our
+            # configured coverage area before transmitting), so the
+            # header keys legitimately differ but the alert is the same
+            # NWS issuance.  Example from 2026-05-18: 16:11 CAP
+            # broadcast SVR-039173, then 16:29 DON/JKZ relay arrived
+            # with incoming FIPS 039095-039173 — same originator
+            # (WXR), event (SVR) and issue time (1382009), overlapping
+            # on 039173 — same alert.
+            if incoming is not None:
+                msg_parsed = _parse_same_header(msg.same_header)
+                if msg_parsed is not None:
+                    m_orig, m_evt, m_fips, m_issue = msg_parsed
+                    i_orig, i_evt, i_fips, i_issue = incoming
+                    if (
+                        m_orig == i_orig
+                        and m_evt == i_evt
+                        and m_issue == i_issue
+                        and (m_fips & i_fips)
+                    ):
+                        logger.info(
+                            "Cross-source duplicate detected in EASMessage "
+                            "(issuer-identity match): event=%s, originator=%s, "
+                            "issue_time=%s, FIPS overlap=%s (message_id=%s)",
+                            event_code, i_orig, i_issue,
+                            sorted(m_fips & i_fips), msg.id,
+                        )
+                        return True
+                # If header_key was provided and matched nothing above,
+                # don't fall through to the lossy FIPS-set check — we
+                # have enough signal already.
+                if header_key:
+                    continue
+
+            # 3) Full-FIPS-set match (only when no header at all)
+            if not header_key:
+                msg_locations = set(meta.get('locations', []) or [])
+                if msg_locations and msg_locations == fips_set:
+                    logger.info(
+                        "Cross-source duplicate detected in EASMessage (full-FIPS "
+                        "match): event=%s, FIPS=%s (message_id=%s)",
+                        event_code, sorted(fips_set), msg.id,
+                    )
+                    return True
     except Exception as exc:
         logger.warning("EASMessage dedup check failed: %s", exc)
 
@@ -198,6 +355,7 @@ def is_duplicate_broadcast(
             .all()
         )
         for activation in recent_activations:
+            # 1) Header-key match
             if header_key:
                 act_key = _same_header_dedupe_key(activation.same_header)
                 if act_key and act_key == header_key:
@@ -207,15 +365,38 @@ def is_duplicate_broadcast(
                         event_code, header_key, activation.id,
                     )
                     return True
-                continue
-            activation_fips = set(activation.same_locations or [])
-            if activation_fips and activation_fips == fips_set:
-                logger.info(
-                    "Cross-source duplicate detected in ManualEASActivation "
-                    "(full-FIPS match): event=%s, FIPS=%s (activation_id=%s)",
-                    event_code, sorted(fips_set), activation.id,
-                )
-                return True
+            # 2) Issuer-identity match
+            if incoming is not None:
+                act_parsed = _parse_same_header(activation.same_header)
+                if act_parsed is not None:
+                    m_orig, m_evt, m_fips, m_issue = act_parsed
+                    i_orig, i_evt, i_fips, i_issue = incoming
+                    if (
+                        m_orig == i_orig
+                        and m_evt == i_evt
+                        and m_issue == i_issue
+                        and (m_fips & i_fips)
+                    ):
+                        logger.info(
+                            "Cross-source duplicate detected in ManualEASActivation "
+                            "(issuer-identity match): event=%s, originator=%s, "
+                            "issue_time=%s, FIPS overlap=%s (activation_id=%s)",
+                            event_code, i_orig, i_issue,
+                            sorted(m_fips & i_fips), activation.id,
+                        )
+                        return True
+                if header_key:
+                    continue
+            # 3) Full-FIPS-set match (only when no header at all)
+            if not header_key:
+                activation_fips = set(activation.same_locations or [])
+                if activation_fips and activation_fips == fips_set:
+                    logger.info(
+                        "Cross-source duplicate detected in ManualEASActivation "
+                        "(full-FIPS match): event=%s, FIPS=%s (activation_id=%s)",
+                        event_code, sorted(fips_set), activation.id,
+                    )
+                    return True
     except Exception as exc:
         logger.warning("ManualEASActivation dedup check failed: %s", exc)
 
@@ -378,12 +559,18 @@ def auto_forward_cap_alert(
     else:
         fips_codes_for_dedup = fips_codes
 
-    # Cross-source deduplication (skipped for UPG)
+    # Cross-source deduplication (skipped for UPG).  Take a per-alert
+    # advisory lock so concurrent CAP/OTA arrivals for the same alert
+    # serialize through the check-then-commit sequence.
     if event_code and fips_codes_for_dedup:
+        _acquire_dedupe_lock(
+            db_session,
+            _alert_dedupe_lock_key(event_code, fips_codes_for_dedup),
+        )
         if is_duplicate_broadcast(event_code, fips_codes_for_dedup, db_session):
             reason = (
                 f"Cross-source duplicate: {event_code} already broadcast "
-                f"for overlapping FIPS within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
+                f"for the same FIPS set within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
             )
             log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
             result['reason'] = reason
@@ -581,6 +768,17 @@ def auto_forward_ota_alert(
     # no header is available.
     raw_same_header = alert_dict.get('raw_header') or alert_dict.get('raw_text')
     if fips_codes or raw_same_header:
+        # Serialize concurrent broadcasts of the SAME alert across
+        # workers/processes.  Without this, two simultaneous arrivals
+        # (CAP + OTA relay within ~1 s) can both pass the dedupe check
+        # before either commits — the failure mode that produced two
+        # back-to-back broadcasts of the same SVR at 16:54 EDT on
+        # 2026-05-19.  The lock is keyed on the alert (not global) so
+        # broadcasts of distinct alerts proceed in parallel.
+        _acquire_dedupe_lock(
+            db_session,
+            _alert_dedupe_lock_key(event_code, fips_codes),
+        )
         if is_duplicate_broadcast(
             event_code,
             fips_codes,
@@ -589,7 +787,7 @@ def auto_forward_ota_alert(
         ):
             result['reason'] = (
                 f"Cross-source duplicate: {event_code} already broadcast "
-                f"for the same alert within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
+                f"for the same alert within {HEADER_KEY_DEDUP_WINDOW_MINUTES}min"
             )
             log.info("OTA auto-forward skipped: %s", result['reason'])
             return result

--- a/app_core/audio/eas_monitor.py
+++ b/app_core/audio/eas_monitor.py
@@ -409,14 +409,34 @@ def create_fips_filtering_callback(
             )
             try:
                 result = forward_callback(alert)
-                generated_message_id = _extract_message_id(result)
-                _store_received_alert(
-                    alert=alert,
-                    forwarding_decision='forwarded',
-                    forwarding_reason='No FIPS filtering configured - accepting all alerts',
-                    matched_fips=alert_fips_codes,
-                    generated_message_id=generated_message_id
-                )
+                outcome = _broadcast_outcome(result)
+                if outcome['actually_forwarded']:
+                    _store_received_alert(
+                        alert=alert,
+                        forwarding_decision='forwarded',
+                        forwarding_reason='No FIPS filtering configured - accepting all alerts',
+                        matched_fips=alert_fips_codes,
+                        generated_message_id=outcome['message_id'],
+                    )
+                else:
+                    # Forward callback ran without raising but no broadcast
+                    # record was persisted (event suppressed, unsupported
+                    # status, broadcaster disabled, missing app context, …).
+                    # Don't claim the alert was forwarded when nothing went
+                    # to air — that's the bug behind "Forwarded but no
+                    # broadcast record linked."
+                    log.info(
+                        "Alert accepted but broadcast not triggered: %s (%s)",
+                        event_code, outcome['reason'],
+                    )
+                    _store_received_alert(
+                        alert=alert,
+                        forwarding_decision='ignored',
+                        forwarding_reason=(
+                            f"Broadcast not triggered: {outcome['reason']}"
+                        ),
+                        matched_fips=alert_fips_codes,
+                    )
             except Exception as e:
                 log.error(f"Error forwarding alert: {e}", exc_info=True)
                 _store_received_alert(
@@ -439,14 +459,29 @@ def create_fips_filtering_callback(
             )
             try:
                 result = forward_callback(alert)
-                generated_message_id = _extract_message_id(result)
-                _store_received_alert(
-                    alert=alert,
-                    forwarding_decision='forwarded',
-                    forwarding_reason=forwarding_reason,
-                    matched_fips=matched_fips_list,
-                    generated_message_id=generated_message_id
-                )
+                outcome = _broadcast_outcome(result)
+                if outcome['actually_forwarded']:
+                    _store_received_alert(
+                        alert=alert,
+                        forwarding_decision='forwarded',
+                        forwarding_reason=forwarding_reason,
+                        matched_fips=matched_fips_list,
+                        generated_message_id=outcome['message_id'],
+                    )
+                else:
+                    log.info(
+                        "FIPS match but broadcast not triggered: %s (%s)",
+                        event_code, outcome['reason'],
+                    )
+                    _store_received_alert(
+                        alert=alert,
+                        forwarding_decision='ignored',
+                        forwarding_reason=(
+                            f"{forwarding_reason}; broadcast not triggered: "
+                            f"{outcome['reason']}"
+                        ),
+                        matched_fips=matched_fips_list,
+                    )
             except Exception as e:
                 log.error(f"Error forwarding alert: {e}", exc_info=True)
                 _store_received_alert(
@@ -482,8 +517,13 @@ def _extract_message_id(result: Any) -> Optional[int]:
     if isinstance(result, int):
         return result
     if isinstance(result, dict):
-        # Direct message_id or id at top level
-        msg_id = result.get('message_id') or result.get('id')
+        # Direct record_id/message_id/id at top level
+        # auto_forward_ota_alert / auto_forward_cap_alert put record_id here.
+        msg_id = (
+            result.get('record_id')
+            or result.get('message_id')
+            or result.get('id')
+        )
         if msg_id:
             return int(msg_id)
         # Nested inside broadcast_detail (forward_alert_to_api return format)
@@ -495,6 +535,62 @@ def _extract_message_id(result: Any) -> Optional[int]:
     if hasattr(result, 'id'):
         return getattr(result, 'id')
     return None
+
+
+def _broadcast_outcome(result: Any) -> Dict[str, Any]:
+    """Inspect a forward_callback return value and report whether a broadcast
+    record was actually persisted.
+
+    Returns a dict with:
+        actually_forwarded (bool): True iff a broadcast record was committed.
+        message_id (Optional[int]): FK to eas_messages.id when known.
+        reason (Optional[str]): Human-readable reason when the broadcast was
+            *not* triggered (e.g. unsupported status, event suppressed,
+            missing Flask app context, broadcast disabled).
+    """
+    message_id = _extract_message_id(result)
+    outcome: Dict[str, Any] = {
+        'actually_forwarded': False,
+        'message_id': message_id,
+        'reason': None,
+    }
+
+    if message_id is not None:
+        outcome['actually_forwarded'] = True
+        return outcome
+
+    if not isinstance(result, dict):
+        # Non-dict success result with no extractable id — assume not
+        # broadcast and leave reason None for the caller to fill in.
+        return outcome
+
+    # forward_alert_to_api wraps auto_forward_*; check the nested detail first
+    # because that's where the authoritative same_triggered flag lives.
+    detail = result.get('broadcast_detail')
+    if isinstance(detail, dict):
+        if detail.get('same_triggered') or detail.get('forwarded'):
+            # Broadcast claims success but no id surfaced — accept as
+            # forwarded so we don't lose track of a real on-air event.
+            outcome['actually_forwarded'] = True
+            return outcome
+        outcome['reason'] = (
+            detail.get('reason')
+            or detail.get('error')
+            or 'Broadcast not triggered'
+        )
+        return outcome
+
+    # Direct auto_forward result (no wrapper)
+    if result.get('same_triggered') or result.get('forwarded'):
+        outcome['actually_forwarded'] = True
+        return outcome
+
+    outcome['reason'] = (
+        result.get('reason')
+        or result.get('error')
+        or 'Broadcast not triggered'
+    )
+    return outcome
 
 
 # =============================================================================

--- a/app_core/migrations/versions/20260521_add_rwt_skip_until.py
+++ b/app_core/migrations/versions/20260521_add_rwt_skip_until.py
@@ -1,0 +1,60 @@
+"""Add skip_until and last_heartbeat_at columns to rwt_schedule_config
+
+Revision ID: 20260521_add_rwt_skip_until
+Revises: 20260515_add_chain_columns_to_audit_logs
+Create Date: 2026-05-21
+
+Adds two columns to the RWT scheduler config table:
+
+* ``skip_until`` (DATE): when set, the scheduler will not fire on any
+  configured day whose local date is on or before this date.  Operators
+  set this from the RWT Schedule page to suppress automatic RWT
+  broadcasts for one or more upcoming scheduled days (e.g. holiday,
+  planned manual test).
+
+* ``last_heartbeat_at`` (TIMESTAMPTZ): updated once per scheduler check
+  (~ every minute) so the web UI can show "scheduler alive" indication
+  independently of whether the scheduler has had any reason to fire.
+  Persisted in the DB rather than kept in-process so it is visible
+  across all Gunicorn workers.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20260521_add_rwt_skip_until"
+down_revision = "20260515_add_chain_columns_to_audit_logs"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    try:
+        cols = {c["name"] for c in inspector.get_columns(table_name)}
+    except Exception:
+        return False
+    return column_name in cols
+
+
+def upgrade():
+    if not _column_exists("rwt_schedule_config", "skip_until"):
+        op.add_column(
+            "rwt_schedule_config",
+            sa.Column("skip_until", sa.Date(), nullable=True),
+        )
+    if not _column_exists("rwt_schedule_config", "last_heartbeat_at"):
+        op.add_column(
+            "rwt_schedule_config",
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade():
+    if _column_exists("rwt_schedule_config", "last_heartbeat_at"):
+        op.drop_column("rwt_schedule_config", "last_heartbeat_at")
+    if _column_exists("rwt_schedule_config", "skip_until"):
+        op.drop_column("rwt_schedule_config", "skip_until")

--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -28,7 +28,7 @@ RWT broadcasts according to configured schedules.
 import logging
 import threading
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from flask import Flask, has_app_context
@@ -43,6 +43,79 @@ from app_utils.eas import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def compute_next_fire(
+    config: RWTScheduleConfig,
+    now_local: Optional[datetime] = None,
+) -> Optional[datetime]:
+    """Compute the next datetime (local timezone, aware) at which this
+    configuration will fire an automatic RWT broadcast.
+
+    Returns ``None`` when the config is disabled, has no configured days, or
+    would otherwise never fire.
+
+    Rules:
+      * The fire time on a configured day is the start of the time window
+        (start_hour:start_minute, local time).
+      * If today is a configured day, the window has not closed, and an
+        RWT hasn't already been sent successfully today, fire is today at
+        max(now, window-start).
+      * If ``skip_until`` is set, dates on or before it are skipped.
+      * Otherwise scan the next 14 days for the first configured weekday.
+    """
+    if not config.enabled:
+        return None
+    configured_days = [int(d) for d in (config.days_of_week or [])]
+    if not configured_days:
+        return None
+
+    if now_local is None:
+        now_local = datetime.now(timezone.utc).astimezone()
+
+    tz = now_local.tzinfo
+    today = now_local.date()
+    start_h = int(config.start_hour or 0)
+    start_m = int(config.start_minute or 0)
+    end_h = int(config.end_hour or 0)
+    end_m = int(config.end_minute or 0)
+
+    skip_until = getattr(config, 'skip_until', None)
+
+    last_success_date: Optional[date] = None
+    if config.last_run_at and config.last_run_status == 'success':
+        last_run_local = config.last_run_at
+        if last_run_local.tzinfo is None:
+            last_run_local = last_run_local.replace(tzinfo=timezone.utc)
+        last_success_date = last_run_local.astimezone(tz).date()
+
+    # Scan today + next 14 days for the first day that qualifies.
+    for offset in range(0, 15):
+        candidate_date = today + timedelta(days=offset)
+        if candidate_date.weekday() not in configured_days:
+            continue
+        if skip_until and candidate_date <= skip_until:
+            continue
+        if last_success_date == candidate_date:
+            continue
+        window_start = datetime(
+            candidate_date.year, candidate_date.month, candidate_date.day,
+            start_h, start_m, tzinfo=tz,
+        )
+        window_end = datetime(
+            candidate_date.year, candidate_date.month, candidate_date.day,
+            end_h, end_m, tzinfo=tz,
+        )
+        if offset == 0:
+            # Today: if we're past the window, move on; otherwise the
+            # scheduler fires at the next minute boundary >= max(now, window
+            # start), bounded by window end.
+            if now_local > window_end:
+                continue
+            return max(now_local.replace(second=0, microsecond=0), window_start)
+        return window_start
+
+    return None
 
 
 def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Dict[str, Any]:
@@ -258,6 +331,20 @@ class RWTScheduler:
             self.thread.join(timeout=5)
         self.logger.info("RWT scheduler stopped")
 
+    def _write_heartbeat(self, config: RWTScheduleConfig) -> None:
+        """Persist a heartbeat timestamp so the UI can show liveness across
+        all Gunicorn workers.  Uses a narrow UPDATE so we never accidentally
+        rewrite operator-managed columns from this thread.
+        """
+        try:
+            config.last_heartbeat_at = utc_now()
+            db.session.add(config)
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            # Heartbeat write failure is not fatal — keep the loop running.
+            self.logger.debug("Failed to write RWT heartbeat: %s", exc)
+
     def _run_loop(self):
         """Main scheduler loop."""
         self.logger.info(
@@ -308,10 +395,24 @@ class RWTScheduler:
                     )
                 return
 
+            # Persist a heartbeat on every iteration so the UI can show the
+            # scheduler is alive even when no fire conditions are met.
+            self._write_heartbeat(config)
+
             # Use local time for day/window comparisons because operators
             # configure the schedule in local time via the UI.
             now_utc = datetime.now(timezone.utc)
             now_local = now_utc.astimezone()  # System local timezone
+
+            # Honour skip_until: operator-set pause for one or more upcoming
+            # scheduled days (e.g. "skip this week").
+            if config.skip_until and now_local.date() <= config.skip_until:
+                if self._iteration % 60 == 1:
+                    self.logger.info(
+                        "RWT scheduler skipping per skip_until=%s (today=%s)",
+                        config.skip_until.isoformat(), now_local.date().isoformat(),
+                    )
+                return
 
             # Check if current day is in configured days
             current_day = now_local.weekday()  # 0=Monday, 6=Sunday

--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -232,6 +232,10 @@ class RWTScheduler:
         self.thread: Optional[threading.Thread] = None
         self.logger = logger
         self.app = app
+        # Iteration counter for periodic heartbeat logging. Without this the
+        # scheduler is silent when no config matches the current time, which
+        # makes it impossible to tell whether the loop is running at all.
+        self._iteration = 0
 
     def start(self):
         """Start the scheduler in a background thread."""
@@ -256,6 +260,10 @@ class RWTScheduler:
 
     def _run_loop(self):
         """Main scheduler loop."""
+        self.logger.info(
+            "RWT scheduler loop started (check interval: %.0f seconds)",
+            self.check_interval.total_seconds(),
+        )
         while self.running:
             try:
                 with self.app.app_context():
@@ -269,44 +277,95 @@ class RWTScheduler:
             time.sleep(self.check_interval.total_seconds())
 
     def _check_and_send_rwt(self):
-        """Check if RWT should be sent and send it if conditions are met."""
+        """Check if RWT should be sent and send it if conditions are met.
+
+        Schedule times (start_hour/start_minute, end_hour/end_minute) and
+        days_of_week are entered by operators in their local timezone via the
+        web UI — the UI shows no timezone selector and displays clocks in
+        local time.  Historically this method compared against UTC, which
+        silently shifted the firing window by the local UTC offset (so a
+        configured "Wed 8 AM–4 PM EDT" really fired "4 AM–12 PM EDT" and
+        skipped Wednesday entirely after 8 PM local because that's already
+        Thursday in UTC).  Comparing against local time matches the
+        operator's mental model.
+        """
         ctx = None
         if not has_app_context():
             ctx = self.app.app_context()
             ctx.push()
 
         try:
+            self._iteration += 1
+
             # Get active configuration
             config = RWTScheduleConfig.query.filter_by(enabled=True).first()
             if config is None:
-                return  # No active configuration
+                # Heartbeat once an hour so operators can confirm the loop is
+                # alive even with no enabled config in the database.
+                if self._iteration % 60 == 1:
+                    self.logger.info(
+                        "RWT scheduler loop alive — no enabled RWT schedule configured"
+                    )
+                return
 
-            now = datetime.now(timezone.utc)
+            # Use local time for day/window comparisons because operators
+            # configure the schedule in local time via the UI.
+            now_utc = datetime.now(timezone.utc)
+            now_local = now_utc.astimezone()  # System local timezone
 
             # Check if current day is in configured days
-            current_day = now.weekday()  # 0=Monday, 6=Sunday
-            if current_day not in (config.days_of_week or []):
-                return  # Not a configured day
+            current_day = now_local.weekday()  # 0=Monday, 6=Sunday
+            configured_days = list(config.days_of_week or [])
+            if current_day not in configured_days:
+                if self._iteration % 60 == 1:
+                    self.logger.info(
+                        "RWT scheduler loop alive — today (weekday %d, local) "
+                        "not in configured days %s",
+                        current_day, configured_days,
+                    )
+                return
 
             # Check if current time is within configured window
-            current_time_minutes = now.hour * 60 + now.minute
+            current_time_minutes = now_local.hour * 60 + now_local.minute
             start_time_minutes = config.start_hour * 60 + config.start_minute
             end_time_minutes = config.end_hour * 60 + config.end_minute
 
             if not (start_time_minutes <= current_time_minutes <= end_time_minutes):
-                return  # Not within time window
+                if self._iteration % 30 == 1:
+                    self.logger.info(
+                        "RWT scheduler waiting for window: local time %02d:%02d, "
+                        "window %02d:%02d–%02d:%02d",
+                        now_local.hour, now_local.minute,
+                        config.start_hour, config.start_minute,
+                        config.end_hour, config.end_minute,
+                    )
+                return
 
-            # Check if RWT was already sent today
+            # Check if RWT was already sent today (compare in local time to
+            # match the operator-facing "once per scheduled day" semantics).
             if config.last_run_at:
-                last_run_date = config.last_run_at.date()
-                today_date = now.date()
-
-                if last_run_date == today_date and config.last_run_status == 'success':
-                    # Already sent today
+                last_run_local = config.last_run_at
+                if last_run_local.tzinfo is None:
+                    last_run_local = last_run_local.replace(tzinfo=timezone.utc)
+                last_run_local = last_run_local.astimezone()
+                if (
+                    last_run_local.date() == now_local.date()
+                    and config.last_run_status == 'success'
+                ):
+                    if self._iteration % 60 == 1:
+                        self.logger.info(
+                            "RWT already sent today at %s — skipping",
+                            last_run_local.isoformat(timespec='seconds'),
+                        )
                     return
 
             # All conditions met - send RWT
-            self.logger.info("Triggering automatic RWT broadcast")
+            self.logger.info(
+                "Triggering automatic RWT broadcast (local %s, window %02d:%02d–%02d:%02d)",
+                now_local.isoformat(timespec='seconds'),
+                config.start_hour, config.start_minute,
+                config.end_hour, config.end_minute,
+            )
             result = trigger_rwt_broadcast(config, self.logger)
 
             if result.get('success'):

--- a/scripts/maintenance/backfill_received_alert_broadcast_links.py
+++ b/scripts/maintenance/backfill_received_alert_broadcast_links.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Backfill missing generated_message_id on ReceivedEASAlert rows.
+
+Background
+==========
+Until v2.76 the FIPS-filtering callback marked any incoming alert as
+``forwarding_decision='forwarded'`` whenever the forward callback returned
+without raising — even when the broadcaster suppressed the event, the
+broadcaster was disabled, or the broadcast record id was returned in a
+shape that ``_extract_message_id`` did not recognise.  The result is a
+population of historical rows in ``received_eas_alerts`` with
+``forwarding_decision='forwarded'`` and ``generated_message_id IS NULL``
+that the detail page renders as "Forwarded but no broadcast record
+linked."  Most of those rows DID generate a real broadcast — the link
+was just lost.
+
+This script walks the orphaned rows and tries to find the matching
+``EASMessage`` by header equivalence: a relayed SAME header is identical
+to the incoming raw header except for the trailing callsign field (the
+incoming header carries the originating station's callsign, e.g.
+``WBKS FM`` or ``DON/JKZ``; the outgoing header carries this station's
+callsign).  Stripping the callsign produces a key that is unique per
+alert within any reasonable time window.
+
+Usage
+=====
+    python -m scripts.maintenance.backfill_received_alert_broadcast_links \\
+        [--dry-run] [--window-seconds 600]
+
+    --dry-run         Report what would change without writing.
+    --window-seconds  Tolerance for matching the broadcast to the receive
+                      timestamp.  Defaults to 600s (10 minutes), which
+                      comfortably covers TTS generation + audio render +
+                      GPIO activation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import timedelta
+from typing import Optional, Tuple
+
+# Make ``app`` importable when running from the repo root
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+def _header_match_key(header: Optional[str]) -> Optional[str]:
+    """Return a header stripped of its callsign field for cross-matching.
+
+    A SAME header looks like:
+        ZCZC-ORG-EVT-PSSCCC-...+TTTT-JJJHHMM-CCCCCCCC-
+
+    The callsign is the second-to-last ``-`` delimited segment.  Dropping
+    that segment yields a key that is identical between the incoming
+    (raw) header and the outgoing (relayed) header.
+    """
+    if not header:
+        return None
+    header = header.strip()
+    if not header.startswith("ZCZC"):
+        return None
+    parts = header.split("-")
+    # A valid SAME header has at least: ZCZC, ORG, EVT, one location/duration
+    # group, time, callsign, "" (trailing).  Drop the last two so the key
+    # excludes the callsign and the trailing empty segment.
+    if len(parts) < 5:
+        return None
+    return "-".join(parts[:-2])
+
+
+def _find_candidate(message_cls, received_alert, window: timedelta):
+    """Find the EASMessage whose header matches and timestamp is closest."""
+    key = _header_match_key(received_alert.raw_same_header)
+    if key is None:
+        return None, "no usable raw_same_header"
+
+    # Bound the search window around received_at.  Broadcast creation
+    # happens after receive, but allow a symmetric window because clock
+    # drift between services / DB has been observed in the field.
+    received_at = received_alert.received_at
+    if received_at is None:
+        return None, "received_at is NULL"
+    lo = received_at - window
+    hi = received_at + window
+
+    candidates = (
+        message_cls.query
+        .filter(message_cls.created_at >= lo)
+        .filter(message_cls.created_at <= hi)
+        .all()
+    )
+
+    best = None
+    best_delta = None
+    for msg in candidates:
+        if _header_match_key(msg.same_header) != key:
+            continue
+        delta = abs((msg.created_at - received_at).total_seconds())
+        if best_delta is None or delta < best_delta:
+            best, best_delta = msg, delta
+
+    if best is None:
+        return None, f"no EASMessage with matching header in ±{int(window.total_seconds())}s"
+    return best, f"matched (Δ={best_delta:.1f}s)"
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show changes without committing.")
+    parser.add_argument("--window-seconds", type=int, default=600,
+                        help="Match window (default: 600s).")
+    args = parser.parse_args(argv)
+
+    # Importing app.py initialises the Flask app and DB engine.  Set the
+    # skip flag so the background workers (RWT scheduler, health monitor,
+    # auto-backup) don't start for a short-lived maintenance script.
+    os.environ.setdefault("SKIP_DB_INIT", "1")
+
+    from app import app
+    from app_core.extensions import db
+    from app_core.models import EASMessage, ReceivedEASAlert
+
+    window = timedelta(seconds=args.window_seconds)
+
+    with app.app_context():
+        orphans = (
+            ReceivedEASAlert.query
+            .filter(ReceivedEASAlert.forwarding_decision == 'forwarded')
+            .filter(ReceivedEASAlert.generated_message_id.is_(None))
+            .order_by(ReceivedEASAlert.received_at)
+            .all()
+        )
+
+        print(f"Found {len(orphans)} 'forwarded' rows missing generated_message_id.")
+        if not orphans:
+            return 0
+
+        linked = 0
+        unmatched = 0
+        for alert in orphans:
+            msg, reason = _find_candidate(EASMessage, alert, window)
+            ts = alert.received_at.isoformat() if alert.received_at else 'n/a'
+            if msg is None:
+                unmatched += 1
+                print(f"  [skip] alert#{alert.id} {ts}: {reason}")
+                continue
+            linked += 1
+            print(
+                f"  [link] alert#{alert.id} {ts} → eas_message#{msg.id} "
+                f"({reason})"
+            )
+            if not args.dry_run:
+                alert.generated_message_id = msg.id
+                db.session.add(alert)
+
+        if args.dry_run:
+            print(f"\nDry run: would link {linked}, leave {unmatched} unmatched.")
+            db.session.rollback()
+        else:
+            db.session.commit()
+            print(f"\nCommitted: linked {linked}, left {unmatched} unmatched.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/audio_received_detail.html
+++ b/templates/audio_received_detail.html
@@ -261,7 +261,17 @@
                         <i class="fas fa-headphones me-1"></i>View Broadcast
                     </a>
                     {% elif alert.forwarding_decision == 'forwarded' %}
-                    <p class="text-muted mb-0">Forwarded but no broadcast record linked.</p>
+                    <p class="text-warning mb-2">
+                        <i class="fas fa-unlink me-1"></i>
+                        Marked as forwarded but the broadcast record link is missing.
+                    </p>
+                    <p class="text-muted small mb-0">
+                        Historical data issue: prior to v2.76 some forwarded alerts were
+                        stored without a foreign key to their broadcast record (the broadcast
+                        itself usually did go out — only the link was lost). Run
+                        <code>python -m scripts.maintenance.backfill_received_alert_broadcast_links</code>
+                        to attempt to relink by SAME-header match.
+                    </p>
                     {% else %}
                     <p class="text-muted mb-0">No broadcast generated (alert was {{ alert.forwarding_decision }}).</p>
                     {% endif %}

--- a/templates/rwt_schedule.html
+++ b/templates/rwt_schedule.html
@@ -159,21 +159,43 @@
                 </div>
             </div>
 
-            <!-- Last Run Info -->
-            <div class="card mt-4" id="lastRunCard" style="display: none;">
-                <div class="card-header">
-                    <h5 class="mb-0">Last Automatic Run</h5>
+            <!-- Scheduler Status -->
+            <div class="card mt-4" id="schedulerStatusCard">
+                <div class="card-header d-flex align-items-center justify-content-between">
+                    <h5 class="mb-0">Scheduler Status</h5>
+                    <span id="schedulerHeartbeatBadge" class="badge bg-secondary">
+                        <i class="fas fa-circle-question me-1"></i>Unknown
+                    </span>
                 </div>
                 <div class="card-body">
-                    <div class="row">
-                        <div class="col-md-6">
-                            <strong>Time:</strong> <span id="lastRunTime">-</span>
-                        </div>
-                        <div class="col-md-6">
-                            <strong>Status:</strong> <span id="lastRunStatus">-</span>
-                        </div>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Last fired</dt>
+                        <dd class="col-sm-8" id="schedulerLastFired">—</dd>
+
+                        <dt class="col-sm-4">Last status</dt>
+                        <dd class="col-sm-8" id="schedulerLastStatus">—</dd>
+
+                        <dt class="col-sm-4">Next scheduled fire</dt>
+                        <dd class="col-sm-8" id="schedulerNextFire">—</dd>
+
+                        <dt class="col-sm-4">Heartbeat</dt>
+                        <dd class="col-sm-8" id="schedulerHeartbeat">—</dd>
+
+                        <dt class="col-sm-4">Skip until</dt>
+                        <dd class="col-sm-8" id="schedulerSkipUntil">—</dd>
+                    </dl>
+                    <div class="d-flex flex-wrap gap-2 mt-3">
+                        <button type="button" class="btn btn-outline-warning btn-sm" id="skipWeekBtn">
+                            <i class="fas fa-forward me-1"></i>Skip Upcoming RWT
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm d-none" id="clearSkipBtn">
+                            <i class="fas fa-rotate-left me-1"></i>Clear Skip
+                        </button>
                     </div>
-                    <div class="mt-2" id="lastRunDetails"></div>
+                    <div id="lastRunDetailsWrap" class="mt-3 d-none">
+                        <strong class="small">Last run details</strong>
+                        <pre class="mt-1 mb-0 small" id="lastRunDetails"></pre>
+                    </div>
                 </div>
             </div>
         </div>
@@ -332,20 +354,7 @@
                     document.getElementById('endHour').value = config.end_hour || 16;
                     document.getElementById('endMinute').value = config.end_minute || 0;
 
-                    // Last run info
-                    if (config.last_run_at) {
-                        document.getElementById('lastRunCard').style.display = 'block';
-                        document.getElementById('lastRunTime').textContent = new Date(config.last_run_at).toLocaleString();
-                        document.getElementById('lastRunStatus').textContent = config.last_run_status || '-';
-
-                        const statusSpan = document.getElementById('lastRunStatus');
-                        statusSpan.className = config.last_run_status === 'success' ? 'badge bg-success' : 'badge bg-danger';
-
-                        if (config.last_run_details) {
-                            const details = typeof config.last_run_details === 'string' ? JSON.stringify(config.last_run_details) : JSON.stringify(config.last_run_details, null, 2);
-                            document.getElementById('lastRunDetails').innerHTML = `<pre class="mt-2 mb-0">${details}</pre>`;
-                        }
-                    }
+                    renderSchedulerStatus(config);
                 }
             })
             .catch(error => {
@@ -353,6 +362,153 @@
                 showToast('Failed to load configuration', 'danger');
             });
         }
+
+        function formatLocal(iso) {
+            if (!iso) return '—';
+            const dt = new Date(iso);
+            if (isNaN(dt.getTime())) return iso;
+            return dt.toLocaleString();
+        }
+
+        function formatRelative(iso) {
+            if (!iso) return null;
+            const dt = new Date(iso);
+            if (isNaN(dt.getTime())) return null;
+            const deltaSec = Math.round((Date.now() - dt.getTime()) / 1000);
+            const abs = Math.abs(deltaSec);
+            if (abs < 60) return `${deltaSec}s ago`;
+            if (abs < 3600) return `${Math.round(deltaSec / 60)}m ago`;
+            if (abs < 86400) return `${Math.round(deltaSec / 3600)}h ago`;
+            return `${Math.round(deltaSec / 86400)}d ago`;
+        }
+
+        function renderSchedulerStatus(config) {
+            const lastFiredEl = document.getElementById('schedulerLastFired');
+            const lastStatusEl = document.getElementById('schedulerLastStatus');
+            const nextFireEl = document.getElementById('schedulerNextFire');
+            const heartbeatEl = document.getElementById('schedulerHeartbeat');
+            const heartbeatBadgeEl = document.getElementById('schedulerHeartbeatBadge');
+            const skipUntilEl = document.getElementById('schedulerSkipUntil');
+            const clearSkipBtn = document.getElementById('clearSkipBtn');
+            const skipWeekBtn = document.getElementById('skipWeekBtn');
+            const detailsWrap = document.getElementById('lastRunDetailsWrap');
+            const detailsPre = document.getElementById('lastRunDetails');
+
+            // Last fired
+            if (config.last_run_at) {
+                const rel = formatRelative(config.last_run_at);
+                lastFiredEl.textContent = `${formatLocal(config.last_run_at)}${rel ? ' (' + rel + ')' : ''}`;
+            } else {
+                lastFiredEl.textContent = 'Never';
+            }
+
+            // Last status
+            if (config.last_run_status) {
+                const cls = config.last_run_status === 'success' ? 'bg-success' : 'bg-danger';
+                lastStatusEl.innerHTML = `<span class="badge ${cls}">${config.last_run_status}</span>`;
+            } else {
+                lastStatusEl.textContent = '—';
+            }
+
+            // Next fire
+            if (config.next_fire_at) {
+                nextFireEl.textContent = formatLocal(config.next_fire_at);
+            } else if (!config.enabled) {
+                nextFireEl.innerHTML = '<span class="text-muted">scheduler disabled</span>';
+            } else if (!(config.days_of_week || []).length) {
+                nextFireEl.innerHTML = '<span class="text-muted">no days configured</span>';
+            } else {
+                nextFireEl.textContent = '—';
+            }
+
+            // Heartbeat: green if seen within 5 minutes, yellow if 5-30,
+            // red if older or never.
+            if (config.last_heartbeat_at) {
+                const rel = formatRelative(config.last_heartbeat_at);
+                heartbeatEl.textContent = `${formatLocal(config.last_heartbeat_at)} (${rel})`;
+                const ageSec = (Date.now() - new Date(config.last_heartbeat_at).getTime()) / 1000;
+                if (ageSec < 300) {
+                    heartbeatBadgeEl.className = 'badge bg-success';
+                    heartbeatBadgeEl.innerHTML = '<i class="fas fa-heart-pulse me-1"></i>Alive';
+                } else if (ageSec < 1800) {
+                    heartbeatBadgeEl.className = 'badge bg-warning text-dark';
+                    heartbeatBadgeEl.innerHTML = '<i class="fas fa-triangle-exclamation me-1"></i>Stale';
+                } else {
+                    heartbeatBadgeEl.className = 'badge bg-danger';
+                    heartbeatBadgeEl.innerHTML = '<i class="fas fa-circle-xmark me-1"></i>Stopped';
+                }
+            } else {
+                heartbeatEl.textContent = 'Never observed';
+                heartbeatBadgeEl.className = 'badge bg-secondary';
+                heartbeatBadgeEl.innerHTML = '<i class="fas fa-circle-question me-1"></i>Unknown';
+            }
+
+            // Skip until
+            if (config.skip_until) {
+                skipUntilEl.innerHTML = `<span class="text-warning"><i class="fas fa-forward me-1"></i>${config.skip_until}</span>`;
+                clearSkipBtn.classList.remove('d-none');
+                skipWeekBtn.disabled = false;
+            } else {
+                skipUntilEl.innerHTML = '<span class="text-muted">not skipping</span>';
+                clearSkipBtn.classList.add('d-none');
+                skipWeekBtn.disabled = false;
+            }
+
+            // Run details (collapsed by default)
+            if (config.last_run_details && Object.keys(config.last_run_details).length) {
+                detailsWrap.classList.remove('d-none');
+                detailsPre.textContent = JSON.stringify(config.last_run_details, null, 2);
+            } else {
+                detailsWrap.classList.add('d-none');
+                detailsPre.textContent = '';
+            }
+        }
+
+        // Skip-week button
+        document.getElementById('skipWeekBtn').addEventListener('click', function() {
+            if (!confirm('Skip the upcoming scheduled RWT(s)? The scheduler will resume on the next scheduled day after this week.')) return;
+            fetch('/api/rwt-schedule/skip-week', {
+                method: 'POST',
+                headers: { 'X-CSRF-Token': window.CSRF_TOKEN },
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    showToast('RWT skipped — next fire ' + (data.config.next_fire_at || 'TBD'), 'success');
+                    renderSchedulerStatus(data.config);
+                } else {
+                    showToast('Failed to skip: ' + (data.error || 'unknown'), 'danger');
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                showToast('Failed to skip', 'danger');
+            });
+        });
+
+        document.getElementById('clearSkipBtn').addEventListener('click', function() {
+            fetch('/api/rwt-schedule/skip-week', {
+                method: 'DELETE',
+                headers: { 'X-CSRF-Token': window.CSRF_TOKEN },
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    showToast('Skip cleared — scheduler resumed', 'success');
+                    renderSchedulerStatus(data.config);
+                } else {
+                    showToast('Failed to clear skip: ' + (data.error || 'unknown'), 'danger');
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                showToast('Failed to clear skip', 'danger');
+            });
+        });
+
+        // Refresh status every 30 seconds so heartbeat freshness stays
+        // current without a manual reload.
+        setInterval(loadConfiguration, 30000);
 
         function saveConfiguration() {
             // Collect form data

--- a/webapp/routes_rwt_schedule.py
+++ b/webapp/routes_rwt_schedule.py
@@ -21,12 +21,44 @@ from __future__ import annotations
 
 """Routes for RWT schedule configuration management."""
 
-from typing import List
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Optional
 
 from flask import jsonify, render_template, request
 from app_core.extensions import db
 from app_core.models import RWTScheduleConfig, SystemLog
 from app_utils.fips_codes import get_us_state_county_tree, get_same_lookup
+
+
+def _serialize_config(config: Optional[RWTScheduleConfig]) -> dict:
+    """Return the config dict augmented with next_fire_at (ISO local)."""
+    from app_core.rwt_scheduler import compute_next_fire
+    if config is None:
+        return {}
+    payload = config.to_dict()
+    try:
+        next_fire = compute_next_fire(config)
+        payload['next_fire_at'] = next_fire.isoformat() if next_fire else None
+    except Exception:
+        payload['next_fire_at'] = None
+    return payload
+
+
+def _next_configured_date(
+    configured_days: List[int],
+    skip_until: Optional[date],
+    today: date,
+) -> Optional[date]:
+    """Return the first configured-weekday date strictly after ``skip_until``
+    (or after today if no skip set)."""
+    if not configured_days:
+        return None
+    anchor = (skip_until or today)
+    for offset in range(1, 15):
+        candidate = anchor + timedelta(days=offset)
+        if candidate.weekday() in configured_days:
+            return candidate
+    return None
 
 
 def register_routes(app, logger):
@@ -70,12 +102,15 @@ def register_routes(app, logger):
                         'last_run_at': None,
                         'last_run_status': None,
                         'last_run_details': {},
+                        'skip_until': None,
+                        'next_fire_at': None,
+                        'last_heartbeat_at': None,
                         'same_codes_source': 'not_configured',
                         'same_codes_note': 'RWT SAME codes must be explicitly configured. Use only your local broadcast area codes, NOT your alert filtering FIPS codes.',
                     }
                 })
 
-            payload = config.to_dict()
+            payload = _serialize_config(config)
             # Do NOT auto-populate with location filtering FIPS codes
             if not payload.get('same_codes'):
                 payload['same_codes'] = []
@@ -181,7 +216,7 @@ def register_routes(app, logger):
 
             return jsonify({
                 'success': True,
-                'config': config.to_dict()
+                'config': _serialize_config(config)
             })
 
         except ValueError as exc:
@@ -190,6 +225,100 @@ def register_routes(app, logger):
             logger.error('Failed to save RWT schedule config: %s', exc)
             db.session.rollback()
             return jsonify({'success': False, 'error': 'Failed to save configuration'}), 500
+
+    @app.route('/api/rwt-schedule/skip-week', methods=['POST'])
+    def skip_rwt_week():
+        """Skip the upcoming scheduled RWT broadcast(s).
+
+        Sets ``skip_until`` to a date that covers all configured days in
+        the current scheduled week.  If today is itself a configured day
+        and the broadcast hasn't fired yet, today is included.
+        """
+        try:
+            config = RWTScheduleConfig.query.first()
+            if config is None:
+                return jsonify({'success': False, 'error': 'No configuration found'}), 404
+
+            configured_days = sorted(int(d) for d in (config.days_of_week or []))
+            if not configured_days:
+                return jsonify({
+                    'success': False,
+                    'error': 'No days configured — nothing to skip',
+                }), 400
+
+            now_local = datetime.now(timezone.utc).astimezone()
+            today = now_local.date()
+
+            # Find the next configured weekday strictly AFTER today.  Setting
+            # skip_until to the day BEFORE that means the scheduler will
+            # suppress all configured fires from today through the end of
+            # this scheduled "week" but resume at the next one.
+            next_after = _next_configured_date(configured_days, None, today)
+            if next_after is None:
+                # Shouldn't happen given configured_days is non-empty.
+                return jsonify({
+                    'success': False,
+                    'error': 'Could not determine next scheduled date',
+                }), 500
+
+            new_skip = next_after - timedelta(days=1)
+            config.skip_until = new_skip
+            db.session.add(config)
+            db.session.add(SystemLog(
+                level='INFO',
+                message='RWT schedule: skip-week activated',
+                module='rwt_schedule',
+                details={
+                    'skip_until': new_skip.isoformat(),
+                    'next_fire_after': next_after.isoformat(),
+                },
+            ))
+            db.session.commit()
+
+            return jsonify({
+                'success': True,
+                'config': _serialize_config(config),
+            })
+
+        except Exception as exc:
+            logger.error('Failed to skip RWT week: %s', exc)
+            db.session.rollback()
+            return jsonify({'success': False, 'error': 'Failed to skip week'}), 500
+
+    @app.route('/api/rwt-schedule/skip-week', methods=['DELETE'])
+    def clear_rwt_skip():
+        """Clear ``skip_until`` so the scheduler resumes immediately."""
+        try:
+            config = RWTScheduleConfig.query.first()
+            if config is None:
+                return jsonify({'success': False, 'error': 'No configuration found'}), 404
+
+            if config.skip_until is None:
+                return jsonify({
+                    'success': True,
+                    'config': _serialize_config(config),
+                })
+
+            previous = config.skip_until
+            config.skip_until = None
+            db.session.add(config)
+            db.session.add(SystemLog(
+                level='INFO',
+                message='RWT schedule: skip-week cleared',
+                module='rwt_schedule',
+                details={'previous_skip_until': previous.isoformat()},
+            ))
+            db.session.commit()
+
+            return jsonify({
+                'success': True,
+                'config': _serialize_config(config),
+            })
+
+        except Exception as exc:
+            logger.error('Failed to clear RWT skip: %s', exc)
+            db.session.rollback()
+            return jsonify({'success': False, 'error': 'Failed to clear skip'}), 500
 
     @app.route('/api/rwt-schedule/test', methods=['POST'])
     def test_rwt_schedule():


### PR DESCRIPTION
The "Forwarded" badge in the received-alert detail page was lying: the FIPS
filtering callback marked any alert as forwarding_decision='forwarded' so
long as the forward callback did not raise — even when the broadcaster
suppressed the event (dense fog advisory, unsupported status), the
broadcaster was disabled, or _auto_forward_to_air_chain returned None for
lack of a Flask app context. _extract_message_id also missed top-level
record_id keys that auto_forward_{cap,ota}_alert sets, so the FK to
eas_messages was left NULL on every forwarded alert and the detail page
read "Forwarded but no broadcast record linked."

Add _broadcast_outcome which inspects the result for an actually-persisted
record_id and falls back to checking same_triggered / forwarded flags
before reporting failure with the broadcaster's own reason string. Mark
the received alert as 'ignored' (with the real reason) when no broadcast
was committed instead of falsely claiming success.

The RWT scheduler was comparing the UTC weekday and hour-of-day against
schedule values that operators enter in their local timezone via the UI
(the UI shows no TZ selector and renders clocks in local time). On EDT
this shifted the firing window four hours earlier than configured and
truncated configured days at 20:00 local because that's already the next
day in UTC — explaining why no automatic RWT had fired for weeks. Convert
to local time before all schedule comparisons, and emit periodic INFO
heartbeats so operators can confirm the loop is alive and see which
condition is currently blocking a fire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to skip upcoming RWT scheduled broadcasts via UI controls
  * New scheduler status panel displays heartbeat, next fire time, and skip state
  * Scheduler state automatically refreshes every 30 seconds

* **Bug Fixes**
  * Strengthened alert deduplication across broadcast sources using header matching
  * Enhanced broadcast outcome validation to prevent orphaned records
  * Added maintenance tool to recover missing broadcast-record links for forwarded alerts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->