### PR TITLE
Thread alert correlation IDs through every log line

### DIFF
--- a/app.py
+++ b/app.py
@@ -220,6 +220,11 @@ from app_core.datetime.parsing import parse_nws_datetime
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Install correlation-ID filter on the root logger so every log line carries
+# the current alert identifier (rendered as "-" when no alert is bound).
+from app_core.logging_context import install_alert_filter as _install_alert_filter  # noqa: E402
+_install_alert_filter()
+
 
 def _load_or_generate_secret_key(key_file: str) -> str:
     """Load the Flask secret key from *key_file*, or generate and persist a new one.
@@ -267,9 +272,11 @@ try:
         backupCount=5,
     )
     _file_handler.setFormatter(logging.Formatter(
-        '%(asctime)s [%(process)d] [%(levelname)s] %(name)s: %(message)s',
+        '%(asctime)s [%(process)d] [%(levelname)s] [alert=%(alert_id)s] %(name)s: %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S',
     ))
+    # Make sure the file handler also stamps records with the current alert ID.
+    _install_alert_filter(logging.getLogger())
     # Set WARNING as the floor level for the file handler so that DB log_level
     # overrides (applied later in _load_db_settings_into_config) cannot silence
     # notification warnings and email error messages.

--- a/app_core/_models_admin.py
+++ b/app_core/_models_admin.py
@@ -43,6 +43,10 @@ class SystemLog(db.Model):
     message = db.Column(db.Text, nullable=False)
     module = db.Column(db.String(100))
     details = db.Column(db.JSON)
+    # Correlation ID tying this row to the alert lifecycle it belongs to.
+    # Auto-populated from the logging_context ContextVar when a row is
+    # inserted while an alert is being processed; left NULL otherwise.
+    alert_identifier = db.Column(db.String(255), nullable=True, index=True)
 
 
 class AdminUser(db.Model):

--- a/app_core/_models_alerts.py
+++ b/app_core/_models_alerts.py
@@ -146,6 +146,9 @@ class EASMessage(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     cap_alert_id = db.Column(db.Integer, db.ForeignKey("cap_alerts.id", ondelete="SET NULL"), index=True)
+    # Correlation ID (CAP identifier or OTA-derived hash) tying this message
+    # to the alert lifecycle.  Auto-populated from logging_context.
+    alert_identifier = db.Column(db.String(255), nullable=True, index=True)
     same_header = db.Column(db.String(255), nullable=False)
     audio_filename = db.Column(db.String(255), nullable=False)
     text_filename = db.Column(db.String(255), nullable=False)
@@ -170,6 +173,7 @@ class EASMessage(db.Model):
         return {
             "id": self.id,
             "cap_alert_id": self.cap_alert_id,
+            "alert_identifier": self.alert_identifier,
             "same_header": self.same_header,
             "audio_filename": self.audio_filename,
             "text_filename": self.text_filename,

--- a/app_core/_models_audio.py
+++ b/app_core/_models_audio.py
@@ -96,7 +96,10 @@ class AudioAlert(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     source_name = db.Column(db.String(100), nullable=False, index=True)
-    
+    # Correlation ID tying this row to the alert lifecycle it belongs to.
+    # Auto-populated from logging_context when set during the write.
+    alert_identifier = db.Column(db.String(255), nullable=True, index=True)
+
     # Alert classification
     alert_level = db.Column(db.String(20), nullable=False)  # 'info', 'warning', 'error', 'critical'
     alert_type = db.Column(db.String(50), nullable=False)   # 'silence', 'clipping', 'disconnect', etc.

--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -430,259 +430,270 @@ def auto_forward_cap_alert(
     Returns:
         Dict with forwarding result (same_triggered, event_code, reason, etc.).
     """
+    from app_core.logging_context import push_alert, pop_alert
+
     log = logger_instance or logger
 
-    result: Dict[str, Any] = {
-        'forwarded': False,
-        'source': getattr(cap_alert, 'source', 'CAP'),
-        'identifier': getattr(cap_alert, 'identifier', 'unknown'),
-    }
+    # Bind the CAP identifier as the correlation ID for the duration of this
+    # call so every log line emitted by EASBroadcaster, the SAME encoder, and
+    # downstream notification dispatch carries the same alert identifier.
+    # When the caller already bound it (e.g. cap_poller.save_cap_alert), the
+    # token-based reset below restores their value on return.
+    _alert_token = push_alert(getattr(cap_alert, 'identifier', None))
+    try:
+        result: Dict[str, Any] = {
+            'forwarded': False,
+            'source': getattr(cap_alert, 'source', 'CAP'),
+            'identifier': getattr(cap_alert, 'identifier', 'unknown'),
+        }
 
-    if not eas_config.get('enabled'):
-        reason = "EAS broadcasting disabled"
-        log.debug("Auto-forward skipped for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
-
-    # ── ECIG §3.1: status=Actual required for any on-air broadcast ────────
-    alert_status = getattr(cap_alert, 'status', None) or alert_data.get('status', '')
-    if str(alert_status).strip().lower() != 'actual':
-        reason = f"Alert status '{alert_status}' is not 'Actual' — broadcast suppressed (ECIG §3.1)"
-        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
-
-    # ── ECIG §3.2: scope=Public required for broadcast ────────────────────
-    alert_scope = getattr(cap_alert, 'scope', None) or alert_data.get('scope', '')
-    if str(alert_scope).strip().lower() != 'public':
-        reason = f"Alert scope '{alert_scope}' is not 'Public' — broadcast suppressed (ECIG §3.2)"
-        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
-
-    # ── ECIG §3.3: expired alerts shall not be broadcast ─────────────────
-    sent_dt = getattr(cap_alert, 'sent', None) or alert_data.get('sent')
-    expires_dt = getattr(cap_alert, 'expires', None) or alert_data.get('expires')
-    if isinstance(expires_dt, datetime) and isinstance(sent_dt, datetime):
-        if expires_dt <= sent_dt:
-            reason = "Alert expires ≤ sent — alert is already expired (ECIG §3.3)"
-            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+        if not eas_config.get('enabled'):
+            reason = "EAS broadcasting disabled"
+            log.debug("Auto-forward skipped for %s: %s", result['identifier'], reason)
             result['reason'] = reason
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
-    now_utc = datetime.now(timezone.utc)
-    if isinstance(expires_dt, datetime):
-        exp = expires_dt if expires_dt.tzinfo else expires_dt.replace(tzinfo=timezone.utc)
-        if exp <= now_utc:
-            reason = f"Alert already expired at {expires_dt} — broadcast suppressed (ECIG §3.3)"
+
+        # ── ECIG §3.1: status=Actual required for any on-air broadcast ────────
+        alert_status = getattr(cap_alert, 'status', None) or alert_data.get('status', '')
+        if str(alert_status).strip().lower() != 'actual':
+            reason = f"Alert status '{alert_status}' is not 'Actual' — broadcast suppressed (ECIG §3.1)"
             log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
             result['reason'] = reason
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
-    # Extract FIPS codes for cross-source dedup
-    raw_json = alert_data.get('raw_json', {})
-    fips_codes = _get_fips_from_cap_alert(cap_alert, raw_json)
-    event_code = _resolve_event_code(cap_alert)
+        # ── ECIG §3.2: scope=Public required for broadcast ────────────────────
+        alert_scope = getattr(cap_alert, 'scope', None) or alert_data.get('scope', '')
+        if str(alert_scope).strip().lower() != 'public':
+            reason = f"Alert scope '{alert_scope}' is not 'Public' — broadcast suppressed (ECIG §3.2)"
+            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            return result
 
-    # Event code filtering: forward only events the operator has selected.
-    # An empty allowlist means "forward all event types" — except RWT, which is
-    # always suppressed unless the operator explicitly opts in by adding 'RWT'
-    # to forwarded_event_codes.  This keeps the CAP path consistent with the
-    # OTA path (auto_forward_ota_alert) so test activations are not silently
-    # rebroadcast just because the allowlist is empty.
-    forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
-    allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
-    event_code_upper = event_code.upper() if event_code else ''
+        # ── ECIG §3.3: expired alerts shall not be broadcast ─────────────────
+        sent_dt = getattr(cap_alert, 'sent', None) or alert_data.get('sent')
+        expires_dt = getattr(cap_alert, 'expires', None) or alert_data.get('expires')
+        if isinstance(expires_dt, datetime) and isinstance(sent_dt, datetime):
+            if expires_dt <= sent_dt:
+                reason = "Alert expires ≤ sent — alert is already expired (ECIG §3.3)"
+                log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+                result['reason'] = reason
+                _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+                return result
+        now_utc = datetime.now(timezone.utc)
+        if isinstance(expires_dt, datetime):
+            exp = expires_dt if expires_dt.tzinfo else expires_dt.replace(tzinfo=timezone.utc)
+            if exp <= now_utc:
+                reason = f"Alert already expired at {expires_dt} — broadcast suppressed (ECIG §3.3)"
+                log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+                result['reason'] = reason
+                _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+                return result
 
-    if event_code_upper == 'RWT' and 'RWT' not in allowed:
-        reason = (
-            "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
-        )
-        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
+        # Extract FIPS codes for cross-source dedup
+        raw_json = alert_data.get('raw_json', {})
+        fips_codes = _get_fips_from_cap_alert(cap_alert, raw_json)
+        event_code = _resolve_event_code(cap_alert)
 
-    if allowed and event_code_upper not in allowed:
-        # An unresolved event code (event_code_upper == '') with a configured
-        # allowlist must also be rejected: we cannot prove the alert is on the
-        # allowlist, so refuse to forward rather than silently bypassing the
-        # operator's filter.
-        reason = (
-            f"Event '{event_code or 'UNKNOWN'}' is not in the configured forwarding allowlist"
-        )
-        log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
+        # Event code filtering: forward only events the operator has selected.
+        # An empty allowlist means "forward all event types" — except RWT, which is
+        # always suppressed unless the operator explicitly opts in by adding 'RWT'
+        # to forwarded_event_codes.  This keeps the CAP path consistent with the
+        # OTA path (auto_forward_ota_alert) so test activations are not silently
+        # rebroadcast just because the allowlist is empty.
+        forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
+        allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
+        event_code_upper = event_code.upper() if event_code else ''
 
-    # VTEC-aware action gating — only applies when VTEC was parsed at ingest
-    vtec_action: Optional[str] = getattr(cap_alert, 'vtec_action', None)
-    if vtec_action:
-        if vtec_action in VTEC_SKIP_ACTIONS:
-            # CON / ROU / COR: event is already on air, this is a non-VTEC text
-            # update or routine placeholder — no new broadcast needed
+        if event_code_upper == 'RWT' and 'RWT' not in allowed:
             reason = (
-                f"VTEC action '{vtec_action}' is a non-broadcast update "
-                "— rebroadcast suppressed"
+                "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
             )
             log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
             result['reason'] = reason
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
-        if vtec_action in VTEC_TERMINAL_ACTIONS:
-            # CAN / EXP: event is over; cancellation tones are not auto-generated
+        if allowed and event_code_upper not in allowed:
+            # An unresolved event code (event_code_upper == '') with a configured
+            # allowlist must also be rejected: we cannot prove the alert is on the
+            # allowlist, so refuse to forward rather than silently bypassing the
+            # operator's filter.
             reason = (
-                f"VTEC action '{vtec_action}' indicates event termination "
-                "— no broadcast triggered"
+                f"Event '{event_code or 'UNKNOWN'}' is not in the configured forwarding allowlist"
             )
             log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
             result['reason'] = reason
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
-        if vtec_action in VTEC_BROADCAST_ACTIONS and vtec_action == 'UPG':
-            # UPG: upgraded severity — always rebroadcast, skip dedup window
-            log.info(
-                "Auto-forward forced for %s: VTEC action 'UPG' bypasses dedup window",
-                result['identifier'],
-            )
-            # Fall through directly to broadcaster — skip the FIPS dedup check below
-            fips_codes_for_dedup: List[str] = []
+        # VTEC-aware action gating — only applies when VTEC was parsed at ingest
+        vtec_action: Optional[str] = getattr(cap_alert, 'vtec_action', None)
+        if vtec_action:
+            if vtec_action in VTEC_SKIP_ACTIONS:
+                # CON / ROU / COR: event is already on air, this is a non-VTEC text
+                # update or routine placeholder — no new broadcast needed
+                reason = (
+                    f"VTEC action '{vtec_action}' is a non-broadcast update "
+                    "— rebroadcast suppressed"
+                )
+                log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+                result['reason'] = reason
+                _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+                return result
+
+            if vtec_action in VTEC_TERMINAL_ACTIONS:
+                # CAN / EXP: event is over; cancellation tones are not auto-generated
+                reason = (
+                    f"VTEC action '{vtec_action}' indicates event termination "
+                    "— no broadcast triggered"
+                )
+                log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+                result['reason'] = reason
+                _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+                return result
+
+            if vtec_action in VTEC_BROADCAST_ACTIONS and vtec_action == 'UPG':
+                # UPG: upgraded severity — always rebroadcast, skip dedup window
+                log.info(
+                    "Auto-forward forced for %s: VTEC action 'UPG' bypasses dedup window",
+                    result['identifier'],
+                )
+                # Fall through directly to broadcaster — skip the FIPS dedup check below
+                fips_codes_for_dedup: List[str] = []
+            else:
+                fips_codes_for_dedup = fips_codes
         else:
             fips_codes_for_dedup = fips_codes
-    else:
-        fips_codes_for_dedup = fips_codes
 
-    # Cross-source deduplication (skipped for UPG).  Take a per-alert
-    # advisory lock so concurrent CAP/OTA arrivals for the same alert
-    # serialize through the check-then-commit sequence.
-    if event_code and fips_codes_for_dedup:
-        _acquire_dedupe_lock(
-            db_session,
-            _alert_dedupe_lock_key(event_code, fips_codes_for_dedup),
-        )
-        if is_duplicate_broadcast(event_code, fips_codes_for_dedup, db_session):
-            reason = (
-                f"Cross-source duplicate: {event_code} already broadcast "
-                f"for the same FIPS set within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
+        # Cross-source deduplication (skipped for UPG).  Take a per-alert
+        # advisory lock so concurrent CAP/OTA arrivals for the same alert
+        # serialize through the check-then-commit sequence.
+        if event_code and fips_codes_for_dedup:
+            _acquire_dedupe_lock(
+                db_session,
+                _alert_dedupe_lock_key(event_code, fips_codes_for_dedup),
             )
-            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+            if is_duplicate_broadcast(event_code, fips_codes_for_dedup, db_session):
+                reason = (
+                    f"Cross-source duplicate: {event_code} already broadcast "
+                    f"for the same FIPS set within {CROSS_SOURCE_DEDUP_WINDOW_MINUTES}min"
+                )
+                log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+                result['reason'] = reason
+                _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+                return result
+
+        # Use EASBroadcaster for the full broadcast pipeline
+        from app_utils.eas import EASBroadcaster
+
+        try:
+            broadcaster = EASBroadcaster(
+                db_session=db_session,
+                model_cls=eas_message_cls,
+                config=eas_config,
+                logger=log,
+                location_settings=location_settings,
+            )
+        except Exception as exc:
+            reason = f"Failed to initialize EASBroadcaster: {exc}"
+            log.error("Auto-forward failed for %s: %s", result['identifier'], reason)
             result['reason'] = reason
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
-    # Use EASBroadcaster for the full broadcast pipeline
-    from app_utils.eas import EASBroadcaster
+        # Build payload for EASBroadcaster.handle_alert()
+        payload = dict(alert_data)
+        if 'raw_json' not in payload:
+            payload['raw_json'] = raw_json
 
-    try:
-        broadcaster = EASBroadcaster(
-            db_session=db_session,
-            model_cls=eas_message_cls,
-            config=eas_config,
-            logger=log,
-            location_settings=location_settings,
+        # Preserve key fields the broadcaster expects
+        for field in ('event', 'status', 'message_type', 'sent', 'expires'):
+            if field not in payload:
+                payload[field] = getattr(cap_alert, field, None)
+
+        # Mark as forwarded in payload so GPIO behavior triggers forwarding mode
+        payload['forwarding_decision'] = 'forwarded'
+        payload['forwarded'] = True
+
+        # Push the alert text onto every active Icecast stream while the broadcast
+        # is on the air; clear it once handle_alert() returns so normal source
+        # metadata (song titles, etc.) resumes.
+        from app_core.audio.alert_metadata import (
+            clear_alert_metadata,
+            set_alert_metadata,
         )
-    except Exception as exc:
-        reason = f"Failed to initialize EASBroadcaster: {exc}"
-        log.error("Auto-forward failed for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
 
-    # Build payload for EASBroadcaster.handle_alert()
-    payload = dict(alert_data)
-    if 'raw_json' not in payload:
-        payload['raw_json'] = raw_json
+        alert_title = (getattr(cap_alert, 'headline', '') or '').strip()
+        if not alert_title:
+            alert_title = (getattr(cap_alert, 'event', '') or '').strip()
+        if alert_title:
+            set_alert_metadata(alert_title)
 
-    # Preserve key fields the broadcaster expects
-    for field in ('event', 'status', 'message_type', 'sent', 'expires'):
-        if field not in payload:
-            payload[field] = getattr(cap_alert, field, None)
-
-    # Mark as forwarded in payload so GPIO behavior triggers forwarding mode
-    payload['forwarding_decision'] = 'forwarded'
-    payload['forwarded'] = True
-
-    # Push the alert text onto every active Icecast stream while the broadcast
-    # is on the air; clear it once handle_alert() returns so normal source
-    # metadata (song titles, etc.) resumes.
-    from app_core.audio.alert_metadata import (
-        clear_alert_metadata,
-        set_alert_metadata,
-    )
-
-    alert_title = (getattr(cap_alert, 'headline', '') or '').strip()
-    if not alert_title:
-        alert_title = (getattr(cap_alert, 'event', '') or '').strip()
-    if alert_title:
-        set_alert_metadata(alert_title)
-
-    try:
         try:
-            broadcast_result = broadcaster.handle_alert(cap_alert, payload)
-        finally:
-            if alert_title:
-                clear_alert_metadata()
-    except Exception as exc:
-        reason = f"EASBroadcaster.handle_alert() failed: {exc}"
-        log.error("Auto-forward failed for %s: %s", result['identifier'], reason, exc_info=True)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
-        return result
+            try:
+                broadcast_result = broadcaster.handle_alert(cap_alert, payload)
+            finally:
+                if alert_title:
+                    clear_alert_metadata()
+        except Exception as exc:
+            reason = f"EASBroadcaster.handle_alert() failed: {exc}"
+            log.error("Auto-forward failed for %s: %s", result['identifier'], reason, exc_info=True)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            return result
 
-    if broadcast_result.get('same_triggered'):
-        reason = f"Auto-forwarded: SAME {broadcast_result.get('same_header', '')}"
-        log.info(
-            "Auto-forwarded CAP alert %s to air chain: event=%s, header=%s",
-            result['identifier'],
-            broadcast_result.get('event_code'),
-            broadcast_result.get('same_header'),
-        )
-        result['forwarded'] = True
-        result['same_header'] = broadcast_result.get('same_header')
-        result['event_code'] = broadcast_result.get('event_code')
-        result['record_id'] = broadcast_result.get('record_id')
-        _update_cap_forwarding_status(
-            cap_alert, db_session, True, reason, log,
-            audio_url=broadcast_result.get('audio_path'),
-        )
-
-        # Send email/SMS notifications for this broadcast
-        try:
-            from app_core.notifications import send_alert_notifications
-
-            alert_info = {
-                'event_code': broadcast_result.get('event_code') or event_code or '',
-                'headline': getattr(cap_alert, 'headline', '') or '',
-                'same_header': broadcast_result.get('same_header', ''),
-                'location_codes': fips_codes,
-                'source': getattr(cap_alert, 'source', 'CAP') or 'CAP',
-                'timestamp': (
-                    getattr(cap_alert, 'sent', None) or datetime.now(timezone.utc)
-                ).isoformat(),
-            }
-            send_alert_notifications(
-                record_id=broadcast_result.get('record_id'),
-                alert_info=alert_info,
-                db_session=db_session,
-                logger_instance=log,
+        if broadcast_result.get('same_triggered'):
+            reason = f"Auto-forwarded: SAME {broadcast_result.get('same_header', '')}"
+            log.info(
+                "Auto-forwarded CAP alert %s to air chain: event=%s, header=%s",
+                result['identifier'],
+                broadcast_result.get('event_code'),
+                broadcast_result.get('same_header'),
             )
-        except Exception as _notif_exc:
-            log.warning("Notification dispatch failed (non-fatal): %s", _notif_exc)
+            result['forwarded'] = True
+            result['same_header'] = broadcast_result.get('same_header')
+            result['event_code'] = broadcast_result.get('event_code')
+            result['record_id'] = broadcast_result.get('record_id')
+            _update_cap_forwarding_status(
+                cap_alert, db_session, True, reason, log,
+                audio_url=broadcast_result.get('audio_path'),
+            )
 
-    else:
-        reason = broadcast_result.get('reason', 'Broadcast not triggered')
-        log.info("Auto-forward did not trigger broadcast for %s: %s", result['identifier'], reason)
-        result['reason'] = reason
-        _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            # Send email/SMS notifications for this broadcast
+            try:
+                from app_core.notifications import send_alert_notifications
 
-    return result
+                alert_info = {
+                    'event_code': broadcast_result.get('event_code') or event_code or '',
+                    'headline': getattr(cap_alert, 'headline', '') or '',
+                    'same_header': broadcast_result.get('same_header', ''),
+                    'location_codes': fips_codes,
+                    'source': getattr(cap_alert, 'source', 'CAP') or 'CAP',
+                    'timestamp': (
+                        getattr(cap_alert, 'sent', None) or datetime.now(timezone.utc)
+                    ).isoformat(),
+                }
+                send_alert_notifications(
+                    record_id=broadcast_result.get('record_id'),
+                    alert_info=alert_info,
+                    db_session=db_session,
+                    logger_instance=log,
+                )
+            except Exception as _notif_exc:
+                log.warning("Notification dispatch failed (non-fatal): %s", _notif_exc)
+
+        else:
+            reason = broadcast_result.get('reason', 'Broadcast not triggered')
+            log.info("Auto-forward did not trigger broadcast for %s: %s", result['identifier'], reason)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+
+        return result
+    finally:
+        pop_alert(_alert_token)
 
 
 def auto_forward_ota_alert(
@@ -710,6 +721,8 @@ def auto_forward_ota_alert(
     Returns:
         Dict with forwarding result.
     """
+    from app_core.logging_context import push_alert, pop_alert
+
     log = logger_instance or logger
 
     event_code = alert_dict.get('event_code', 'UNKNOWN')
@@ -719,243 +732,259 @@ def auto_forward_ota_alert(
     relay_tone_profile = alert_dict.get('relay_tone_profile', 'attention')  # 853+960 Hz EAS dual-tone
     relay_tone_duration = alert_dict.get('relay_tone_duration', 8.0)         # always 8 s
 
-    result: Dict[str, Any] = {
-        'forwarded': False,
-        'source': source_name,
-        'event_code': event_code,
-    }
+    # OTA alerts have no CAP identifier; derive a stable correlation ID from
+    # the raw SAME header (or raw_text) so all log lines for this on-air
+    # decode share a key.  Same hashing approach the dedup layer already uses.
+    _ota_id = alert_dict.get('identifier')
+    if not _ota_id:
+        _ota_seed = alert_dict.get('raw_header') or alert_dict.get('raw_text') or ''
+        if _ota_seed:
+            import hashlib as _hashlib
+            _ota_id = f"OTA-{event_code}-{_hashlib.sha1(_ota_seed.encode('utf-8', 'ignore')).hexdigest()[:8]}"
+        else:
+            _ota_id = f"OTA-{source_name}-{event_code}"
+    _alert_token = push_alert(_ota_id)
+    try:
+        result: Dict[str, Any] = {
+            'forwarded': False,
+            'source': source_name,
+            'event_code': event_code,
+            'identifier': _ota_id,
+        }
 
-    if not eas_config.get('enabled'):
-        result['reason'] = "EAS broadcasting disabled"
-        return result
+        if not eas_config.get('enabled'):
+            result['reason'] = "EAS broadcasting disabled"
+            return result
 
-    # Refuse to rebroadcast an alert whose event code could not be decoded.
-    # An UNKNOWN code means the SAME header was either garbled or from an event
-    # type not in the registry; broadcasting it would produce an illegal/
-    # nonsensical SAME header.
-    if not event_code or event_code == 'UNKNOWN':
-        result['reason'] = "OTA alert has unresolvable event code; skipping rebroadcast"
-        log.info(
-            "OTA auto-forward skipped for source '%s': %s",
-            source_name, result['reason'],
-        )
-        return result
+        # Refuse to rebroadcast an alert whose event code could not be decoded.
+        # An UNKNOWN code means the SAME header was either garbled or from an event
+        # type not in the registry; broadcasting it would produce an illegal/
+        # nonsensical SAME header.
+        if not event_code or event_code == 'UNKNOWN':
+            result['reason'] = "OTA alert has unresolvable event code; skipping rebroadcast"
+            log.info(
+                "OTA auto-forward skipped for source '%s': %s",
+                source_name, result['reason'],
+            )
+            return result
 
-    # Event code filtering.
-    forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
-    allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
+        # Event code filtering.
+        forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
+        allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
 
-    # RWT is suppressed by default even when no allowlist is configured.
-    # Operators must explicitly add 'RWT' to forwarded_event_codes to relay tests.
-    if event_code.upper() == 'RWT' and 'RWT' not in allowed:
-        result['reason'] = (
-            "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
-        )
-        log.info("OTA auto-forward skipped: %s", result['reason'])
-        return result
-
-    # General allowlist: when configured, reject anything not on the list.
-    if allowed and event_code.upper() not in allowed:
-        result['reason'] = (
-            f"Event '{event_code}' is not in the configured forwarding allowlist"
-        )
-        log.info("OTA auto-forward skipped: %s", result['reason'])
-        return result
-
-    # Cross-source deduplication.  Prefer the raw SAME header as the
-    # dedupe key (it identifies the alert regardless of which station
-    # relayed it); fall back to event code + full-FIPS-set match when
-    # no header is available.
-    raw_same_header = alert_dict.get('raw_header') or alert_dict.get('raw_text')
-    if fips_codes or raw_same_header:
-        # Serialize concurrent broadcasts of the SAME alert across
-        # workers/processes.  Without this, two simultaneous arrivals
-        # (CAP + OTA relay within ~1 s) can both pass the dedupe check
-        # before either commits — the failure mode that produced two
-        # back-to-back broadcasts of the same SVR at 16:54 EDT on
-        # 2026-05-19.  The lock is keyed on the alert (not global) so
-        # broadcasts of distinct alerts proceed in parallel.
-        _acquire_dedupe_lock(
-            db_session,
-            _alert_dedupe_lock_key(event_code, fips_codes),
-        )
-        if is_duplicate_broadcast(
-            event_code,
-            fips_codes,
-            db_session,
-            raw_same_header=raw_same_header,
-        ):
+        # RWT is suppressed by default even when no allowlist is configured.
+        # Operators must explicitly add 'RWT' to forwarded_event_codes to relay tests.
+        if event_code.upper() == 'RWT' and 'RWT' not in allowed:
             result['reason'] = (
-                f"Cross-source duplicate: {event_code} already broadcast "
-                f"for the same alert within {HEADER_KEY_DEDUP_WINDOW_MINUTES}min"
+                "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
             )
             log.info("OTA auto-forward skipped: %s", result['reason'])
             return result
 
-    # Build a CAPAlert-like object from OTA alert data
-    now = datetime.now(timezone.utc)
-    issue_time = alert_dict.get('issue_time')
-    purge_time = alert_dict.get('purge_time')
-    sent_dt = (
-        datetime.fromisoformat(issue_time) if isinstance(issue_time, str) else issue_time
-    ) if issue_time else now
-    expires_dt = (
-        datetime.fromisoformat(purge_time) if isinstance(purge_time, str) else purge_time
-    ) if purge_time else now + timedelta(hours=1)
-
-    from app_utils.event_codes import EVENT_CODE_REGISTRY
-    event_info = EVENT_CODE_REGISTRY.get(event_code, {})
-    event_name = event_info.get('name', event_code) if isinstance(event_info, dict) else event_code
-
-    alert_object = SimpleNamespace(
-        id=None,
-        identifier=f"OTA-{source_name}-{now.strftime('%Y%m%d%H%M%S')}",
-        event=event_name,
-        headline=f"{event_name} — {source_name}",
-        description='',
-        instruction=None,
-        sent=sent_dt,
-        expires=expires_dt,
-        status='Actual',
-        message_type='Alert',
-        severity=event_info.get('severity', 'Unknown') if isinstance(event_info, dict) else 'Unknown',
-        urgency=event_info.get('urgency', 'Unknown') if isinstance(event_info, dict) else 'Unknown',
-        certainty='Observed',
-        raw_json=None,
-    )
-
-    # Build human-readable area description from FIPS codes for TTS narration
-    try:
-        from app_utils.fips_codes import US_FIPS_LOOKUP as _FIPS_NAMES
-        _area_parts = [
-            _FIPS_NAMES[c] for c in fips_codes if c in _FIPS_NAMES
-        ]
-        area_desc = '; '.join(_area_parts) if _area_parts else 'the affected area'
-    except Exception:
-        area_desc = 'the affected area'
-
-    # Originator code from the received SAME header (e.g. WXR, EAS, CIV, PEP)
-    originator_code = (alert_dict.get('originator') or 'WXR').strip().upper()
-
-    # Build payload with SAME geocode from OTA FIPS codes
-    payload = {
-        'identifier': alert_object.identifier,
-        'event': event_name,
-        'status': 'Actual',
-        'message_type': 'Alert',
-        'sent': sent_dt,
-        'expires': expires_dt,
-        'raw_json': {
-            'properties': {
-                'event': event_name,
-                'areaDesc': area_desc,
-                'geocode': {
-                    'SAME': list(fips_codes),
-                },
-                'parameters': {
-                    'EAS-ORG': originator_code,
-                },
-            }
-        },
-        'forwarding_decision': 'forwarded',
-        'forwarded': True,
-    }
-
-    # RWT must never carry an EBS attention tone — FCC §11.61 prohibits it.
-    # When an RWT is forwarded, the relay is header × 3 + EOM only.
-    if event_code.upper() == 'RWT':
-        payload['relay_tone_profile'] = 'none'
-        payload['relay_tone_duration'] = 0.0
-        # Do NOT attach relay_audio_wav_bytes — no narration on RWT
-    else:
-        # Attach OTA narration audio captured between attention tone and EOM so
-        # build_files() can relay it instead of synthesising new TTS.
-        # Alerts with a 1050 Hz or EBS attention tone will always have narration.
-        if relay_audio_wav:
-            payload['relay_audio_wav_bytes'] = relay_audio_wav
-
-        # Relay always uses the EAS dual-tone (853+960 Hz, 8 s).  Both the NOAA
-        # 1050 Hz tone and any EBS dual-tone from the originating station are
-        # stripped from the captured ring-buffer audio by _find_narration_start();
-        # the broadcaster generates a fresh 8-second attention signal.
-        payload['relay_tone_profile'] = relay_tone_profile
-        payload['relay_tone_duration'] = relay_tone_duration
-
-    from app_utils.eas import EASBroadcaster
-
-    try:
-        broadcaster = EASBroadcaster(
-            db_session=db_session,
-            model_cls=eas_message_cls,
-            config=eas_config,
-            logger=log,
-            location_settings=location_settings,
-        )
-    except Exception as exc:
-        result['reason'] = f"Failed to initialize EASBroadcaster: {exc}"
-        log.error("OTA auto-forward failed: %s", result['reason'])
-        return result
-
-    # Push the alert text onto every active Icecast stream while the broadcast
-    # is on the air; clear it once handle_alert() returns so normal source
-    # metadata resumes.
-    from app_core.audio.alert_metadata import (
-        clear_alert_metadata,
-        set_alert_metadata,
-    )
-
-    alert_title = (alert_object.headline or '').strip()
-    if alert_title:
-        set_alert_metadata(alert_title)
-
-    try:
-        try:
-            broadcast_result = broadcaster.handle_alert(alert_object, payload)
-        finally:
-            if alert_title:
-                clear_alert_metadata()
-    except Exception as exc:
-        result['reason'] = f"EASBroadcaster.handle_alert() failed: {exc}"
-        log.error("OTA auto-forward failed: %s", result['reason'], exc_info=True)
-        return result
-
-    if broadcast_result.get('same_triggered'):
-        log.info(
-            "Auto-forwarded OTA alert to air chain: source=%s, event=%s, header=%s",
-            source_name,
-            broadcast_result.get('event_code'),
-            broadcast_result.get('same_header'),
-        )
-        result['forwarded'] = True
-        result['same_header'] = broadcast_result.get('same_header')
-        result['record_id'] = broadcast_result.get('record_id')
-
-        # Send email/SMS notifications for this broadcast
-        try:
-            from app_core.notifications import send_alert_notifications
-
-            alert_info = {
-                'event_code': event_code,
-                'headline': alert_object.headline,
-                'same_header': broadcast_result.get('same_header', ''),
-                'location_codes': list(fips_codes),
-                'source': source_name,
-                'timestamp': datetime.now(timezone.utc).isoformat(),
-            }
-            send_alert_notifications(
-                record_id=broadcast_result.get('record_id'),
-                alert_info=alert_info,
-                db_session=db_session,
-                logger_instance=log,
+        # General allowlist: when configured, reject anything not on the list.
+        if allowed and event_code.upper() not in allowed:
+            result['reason'] = (
+                f"Event '{event_code}' is not in the configured forwarding allowlist"
             )
-        except Exception as _notif_exc:
-            log.warning("Notification dispatch failed (non-fatal): %s", _notif_exc)
+            log.info("OTA auto-forward skipped: %s", result['reason'])
+            return result
 
-    else:
-        result['reason'] = broadcast_result.get('reason', 'Broadcast not triggered')
-        log.info("OTA auto-forward did not trigger broadcast: %s", result['reason'])
+        # Cross-source deduplication.  Prefer the raw SAME header as the
+        # dedupe key (it identifies the alert regardless of which station
+        # relayed it); fall back to event code + full-FIPS-set match when
+        # no header is available.
+        raw_same_header = alert_dict.get('raw_header') or alert_dict.get('raw_text')
+        if fips_codes or raw_same_header:
+            # Serialize concurrent broadcasts of the SAME alert across
+            # workers/processes.  Without this, two simultaneous arrivals
+            # (CAP + OTA relay within ~1 s) can both pass the dedupe check
+            # before either commits — the failure mode that produced two
+            # back-to-back broadcasts of the same SVR at 16:54 EDT on
+            # 2026-05-19.  The lock is keyed on the alert (not global) so
+            # broadcasts of distinct alerts proceed in parallel.
+            _acquire_dedupe_lock(
+                db_session,
+                _alert_dedupe_lock_key(event_code, fips_codes),
+            )
+            if is_duplicate_broadcast(
+                event_code,
+                fips_codes,
+                db_session,
+                raw_same_header=raw_same_header,
+            ):
+                result['reason'] = (
+                    f"Cross-source duplicate: {event_code} already broadcast "
+                    f"for the same alert within {HEADER_KEY_DEDUP_WINDOW_MINUTES}min"
+                )
+                log.info("OTA auto-forward skipped: %s", result['reason'])
+                return result
 
-    return result
+        # Build a CAPAlert-like object from OTA alert data
+        now = datetime.now(timezone.utc)
+        issue_time = alert_dict.get('issue_time')
+        purge_time = alert_dict.get('purge_time')
+        sent_dt = (
+            datetime.fromisoformat(issue_time) if isinstance(issue_time, str) else issue_time
+        ) if issue_time else now
+        expires_dt = (
+            datetime.fromisoformat(purge_time) if isinstance(purge_time, str) else purge_time
+        ) if purge_time else now + timedelta(hours=1)
+
+        from app_utils.event_codes import EVENT_CODE_REGISTRY
+        event_info = EVENT_CODE_REGISTRY.get(event_code, {})
+        event_name = event_info.get('name', event_code) if isinstance(event_info, dict) else event_code
+
+        alert_object = SimpleNamespace(
+            id=None,
+            identifier=f"OTA-{source_name}-{now.strftime('%Y%m%d%H%M%S')}",
+            event=event_name,
+            headline=f"{event_name} — {source_name}",
+            description='',
+            instruction=None,
+            sent=sent_dt,
+            expires=expires_dt,
+            status='Actual',
+            message_type='Alert',
+            severity=event_info.get('severity', 'Unknown') if isinstance(event_info, dict) else 'Unknown',
+            urgency=event_info.get('urgency', 'Unknown') if isinstance(event_info, dict) else 'Unknown',
+            certainty='Observed',
+            raw_json=None,
+        )
+
+        # Build human-readable area description from FIPS codes for TTS narration
+        try:
+            from app_utils.fips_codes import US_FIPS_LOOKUP as _FIPS_NAMES
+            _area_parts = [
+                _FIPS_NAMES[c] for c in fips_codes if c in _FIPS_NAMES
+            ]
+            area_desc = '; '.join(_area_parts) if _area_parts else 'the affected area'
+        except Exception:
+            area_desc = 'the affected area'
+
+        # Originator code from the received SAME header (e.g. WXR, EAS, CIV, PEP)
+        originator_code = (alert_dict.get('originator') or 'WXR').strip().upper()
+
+        # Build payload with SAME geocode from OTA FIPS codes
+        payload = {
+            'identifier': alert_object.identifier,
+            'event': event_name,
+            'status': 'Actual',
+            'message_type': 'Alert',
+            'sent': sent_dt,
+            'expires': expires_dt,
+            'raw_json': {
+                'properties': {
+                    'event': event_name,
+                    'areaDesc': area_desc,
+                    'geocode': {
+                        'SAME': list(fips_codes),
+                    },
+                    'parameters': {
+                        'EAS-ORG': originator_code,
+                    },
+                }
+            },
+            'forwarding_decision': 'forwarded',
+            'forwarded': True,
+        }
+
+        # RWT must never carry an EBS attention tone — FCC §11.61 prohibits it.
+        # When an RWT is forwarded, the relay is header × 3 + EOM only.
+        if event_code.upper() == 'RWT':
+            payload['relay_tone_profile'] = 'none'
+            payload['relay_tone_duration'] = 0.0
+            # Do NOT attach relay_audio_wav_bytes — no narration on RWT
+        else:
+            # Attach OTA narration audio captured between attention tone and EOM so
+            # build_files() can relay it instead of synthesising new TTS.
+            # Alerts with a 1050 Hz or EBS attention tone will always have narration.
+            if relay_audio_wav:
+                payload['relay_audio_wav_bytes'] = relay_audio_wav
+
+            # Relay always uses the EAS dual-tone (853+960 Hz, 8 s).  Both the NOAA
+            # 1050 Hz tone and any EBS dual-tone from the originating station are
+            # stripped from the captured ring-buffer audio by _find_narration_start();
+            # the broadcaster generates a fresh 8-second attention signal.
+            payload['relay_tone_profile'] = relay_tone_profile
+            payload['relay_tone_duration'] = relay_tone_duration
+
+        from app_utils.eas import EASBroadcaster
+
+        try:
+            broadcaster = EASBroadcaster(
+                db_session=db_session,
+                model_cls=eas_message_cls,
+                config=eas_config,
+                logger=log,
+                location_settings=location_settings,
+            )
+        except Exception as exc:
+            result['reason'] = f"Failed to initialize EASBroadcaster: {exc}"
+            log.error("OTA auto-forward failed: %s", result['reason'])
+            return result
+
+        # Push the alert text onto every active Icecast stream while the broadcast
+        # is on the air; clear it once handle_alert() returns so normal source
+        # metadata resumes.
+        from app_core.audio.alert_metadata import (
+            clear_alert_metadata,
+            set_alert_metadata,
+        )
+
+        alert_title = (alert_object.headline or '').strip()
+        if alert_title:
+            set_alert_metadata(alert_title)
+
+        try:
+            try:
+                broadcast_result = broadcaster.handle_alert(alert_object, payload)
+            finally:
+                if alert_title:
+                    clear_alert_metadata()
+        except Exception as exc:
+            result['reason'] = f"EASBroadcaster.handle_alert() failed: {exc}"
+            log.error("OTA auto-forward failed: %s", result['reason'], exc_info=True)
+            return result
+
+        if broadcast_result.get('same_triggered'):
+            log.info(
+                "Auto-forwarded OTA alert to air chain: source=%s, event=%s, header=%s",
+                source_name,
+                broadcast_result.get('event_code'),
+                broadcast_result.get('same_header'),
+            )
+            result['forwarded'] = True
+            result['same_header'] = broadcast_result.get('same_header')
+            result['record_id'] = broadcast_result.get('record_id')
+
+            # Send email/SMS notifications for this broadcast
+            try:
+                from app_core.notifications import send_alert_notifications
+
+                alert_info = {
+                    'event_code': event_code,
+                    'headline': alert_object.headline,
+                    'same_header': broadcast_result.get('same_header', ''),
+                    'location_codes': list(fips_codes),
+                    'source': source_name,
+                    'timestamp': datetime.now(timezone.utc).isoformat(),
+                }
+                send_alert_notifications(
+                    record_id=broadcast_result.get('record_id'),
+                    alert_info=alert_info,
+                    db_session=db_session,
+                    logger_instance=log,
+                )
+            except Exception as _notif_exc:
+                log.warning("Notification dispatch failed (non-fatal): %s", _notif_exc)
+
+        else:
+            result['reason'] = broadcast_result.get('reason', 'Broadcast not triggered')
+            log.info("OTA auto-forward did not trigger broadcast: %s", result['reason'])
+
+        return result
+    finally:
+        pop_alert(_alert_token)
 
 
 def _update_cap_forwarding_status(

--- a/app_core/audio/eas_monitor.py
+++ b/app_core/audio/eas_monitor.py
@@ -878,6 +878,8 @@ class EASMonitor:
 
     def _handle_alert(self, alert_data) -> None:
         """Handle detected alert."""
+        from app_core.logging_context import push_alert, pop_alert
+
         self._alerts_detected += 1
 
         # The streaming decoder emits StreamingSAMEAlert objects; convert to dict.
@@ -896,16 +898,34 @@ class EASMonitor:
                 pass
         alert_data['source_name'] = active_source or self.source_name
 
-        logger.info(
-            f"EAS Alert detected on '{alert_data['source_name']}': "
-            f"{alert_data.get('event_code', 'UNKNOWN')}"
-        )
+        # Derive a correlation ID from the raw SAME header so detection,
+        # forwarding, and downstream broadcast log lines share a key.
+        _corr_id = alert_data.get('identifier')
+        if not _corr_id:
+            seed = alert_data.get('raw_header') or alert_data.get('raw_text') or ''
+            if seed:
+                _corr_id = (
+                    f"OTA-{alert_data.get('event_code', 'UNK')}-"
+                    f"{hashlib.sha1(seed.encode('utf-8', 'ignore')).hexdigest()[:8]}"
+                )
+            else:
+                _corr_id = f"OTA-{alert_data['source_name']}-{alert_data.get('event_code', 'UNK')}"
+            alert_data['identifier'] = _corr_id
 
-        if self.alert_callback:
-            try:
-                self.alert_callback(alert_data)
-            except Exception as e:
-                logger.error(f"Error in alert callback: {e}", exc_info=True)
+        _token = push_alert(_corr_id)
+        try:
+            logger.info(
+                f"EAS Alert detected on '{alert_data['source_name']}': "
+                f"{alert_data.get('event_code', 'UNKNOWN')}"
+            )
+
+            if self.alert_callback:
+                try:
+                    self.alert_callback(alert_data)
+                except Exception as e:
+                    logger.error(f"Error in alert callback: {e}", exc_info=True)
+        finally:
+            pop_alert(_token)
 
     def _handle_alert_detected(
         self,

--- a/app_core/audio/eas_monitor_v3.py
+++ b/app_core/audio/eas_monitor_v3.py
@@ -800,19 +800,39 @@ class UnifiedEASMonitorService:
             except Exception as _exc:
                 logger.warning("Could not encode OTA narration audio: %s", _exc)
 
-        logger.warning(
-            "🚨 EOM from '%s' — forwarding %s alert",
-            source_name, alert_data.get('event_code', 'UNKNOWN'),
-        )
+        # Derive a correlation ID from the raw SAME header so detection and
+        # forwarding log lines share a key.
+        from app_core.logging_context import push_alert, pop_alert
+        import hashlib as _hashlib
+        _corr_id = alert_data.get('identifier')
+        if not _corr_id:
+            seed = alert_data.get('raw_header') or alert_data.get('raw_text') or ''
+            if seed:
+                _corr_id = (
+                    f"OTA-{alert_data.get('event_code', 'UNK')}-"
+                    f"{_hashlib.sha1(seed.encode('utf-8', 'ignore')).hexdigest()[:8]}"
+                )
+            else:
+                _corr_id = f"OTA-{source_name}-{alert_data.get('event_code', 'UNK')}"
+            alert_data['identifier'] = _corr_id
 
-        self._total_alerts_dispatched += 1
-        self._last_alert_dispatch_time = time.time()
+        _token = push_alert(_corr_id)
+        try:
+            logger.warning(
+                "🚨 EOM from '%s' — forwarding %s alert",
+                source_name, alert_data.get('event_code', 'UNKNOWN'),
+            )
 
-        if self.alert_callback:
-            try:
-                self.alert_callback(alert_data)
-            except Exception as e:
-                logger.error("Error in alert callback: %s", e, exc_info=True)
+            self._total_alerts_dispatched += 1
+            self._last_alert_dispatch_time = time.time()
+
+            if self.alert_callback:
+                try:
+                    self.alert_callback(alert_data)
+                except Exception as e:
+                    logger.error("Error in alert callback: %s", e, exc_info=True)
+        finally:
+            pop_alert(_token)
 
     def _monitor_loop(self) -> None:
         """

--- a/app_core/logging_context.py
+++ b/app_core/logging_context.py
@@ -1,0 +1,147 @@
+"""Correlation-ID logging context for the EAS Station alert pipeline.
+
+A single alert (CAP identifier or OTA-derived ID) is bound to a
+``contextvars.ContextVar`` while it flows through ingestion, forwarding,
+SAME encoding, broadcast, and archiving.  Every ``logging.LogRecord``
+produced inside that scope picks up the bound ID through
+``AlertContextFilter``, so a coherent trail can be reconstructed with::
+
+    grep 'alert=NWS-IPAWS-...' /var/log/eas-station/*.log
+
+When no alert is bound the field renders as ``-`` so format strings stay
+fixed-width and don't blow up on idle log lines (audio streaming,
+hardware health, etc.).
+
+Usage at an entry point::
+
+    from app_core.logging_context import bind_alert
+
+    with bind_alert(cap_alert.identifier):
+        run_pipeline(cap_alert)
+
+Usage from a Redis subscriber where there is no natural ``with`` block::
+
+    from app_core.logging_context import set_alert, clear_alert
+
+    set_alert(payload.get('identifier'))
+    try:
+        handle(payload)
+    finally:
+        clear_alert()
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+# Sentinel rendered when no alert is bound.  Kept short so log lines stay
+# aligned and greppable.
+_UNBOUND = '-'
+
+_alert_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    'eas_alert_id', default=None,
+)
+
+# Format string services should adopt so the alert ID appears in every line.
+LOG_FORMAT_WITH_ALERT = (
+    '%(asctime)s [%(levelname)s] [alert=%(alert_id)s] [%(name)s] %(message)s'
+)
+
+
+class AlertContextFilter(logging.Filter):
+    """Inject the current alert ID into every ``LogRecord``.
+
+    Adding this filter to a handler (or the root logger) guarantees that
+    ``%(alert_id)s`` is always populated, even for records produced
+    outside an active ``bind_alert`` scope.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        if not hasattr(record, 'alert_id') or not record.alert_id:
+            record.alert_id = _alert_id_var.get() or _UNBOUND
+        return True
+
+
+def install_alert_filter(logger: Optional[logging.Logger] = None) -> AlertContextFilter:
+    """Attach :class:`AlertContextFilter` to *logger* and all of its handlers.
+
+    Defaults to the root logger so every downstream logger inherits the
+    filter.  Safe to call multiple times — the filter is idempotent and
+    we de-dupe by type so repeated calls during reload don't stack copies.
+    """
+    target = logger if logger is not None else logging.getLogger()
+    flt: Optional[AlertContextFilter] = None
+    for existing in target.filters:
+        if isinstance(existing, AlertContextFilter):
+            flt = existing
+            break
+    if flt is None:
+        flt = AlertContextFilter()
+        target.addFilter(flt)
+    for handler in target.handlers:
+        if not any(isinstance(f, AlertContextFilter) for f in handler.filters):
+            handler.addFilter(flt)
+    return flt
+
+
+@contextmanager
+def bind_alert(identifier: Optional[str]) -> Iterator[Optional[str]]:
+    """Bind *identifier* as the current correlation ID for the calling task.
+
+    No-op (yields ``None``) when *identifier* is falsy so callers don't
+    have to guard the ``with`` site themselves.
+    """
+    if not identifier:
+        yield None
+        return
+    token = _alert_id_var.set(str(identifier))
+    try:
+        yield str(identifier)
+    finally:
+        _alert_id_var.reset(token)
+
+
+def set_alert(identifier: Optional[str]) -> None:
+    """Set the current alert ID without scoping.
+
+    Use when a context manager is awkward — e.g. inside a long-lived
+    Redis subscriber loop where ``bind_alert`` would have to wrap each
+    iteration manually.  Pair every ``set_alert`` with ``clear_alert``
+    in a ``finally`` block.
+    """
+    _alert_id_var.set(str(identifier) if identifier else None)
+
+
+def clear_alert() -> None:
+    """Drop the current binding.  Counterpart to :func:`set_alert`."""
+    _alert_id_var.set(None)
+
+
+def push_alert(identifier: Optional[str]) -> Optional[contextvars.Token]:
+    """Bind *identifier* and return a token that can be passed to :func:`pop_alert`.
+
+    Useful for ``try/finally`` patterns inside long functions where
+    re-indenting the whole body to fit under a ``with bind_alert(...):``
+    block would be churn.  Returns ``None`` when *identifier* is falsy
+    (in which case :func:`pop_alert` is also a no-op).
+    """
+    if not identifier:
+        return None
+    return _alert_id_var.set(str(identifier))
+
+
+def pop_alert(token: Optional[contextvars.Token]) -> None:
+    """Restore the binding that was in effect before :func:`push_alert`.
+
+    Tolerates a ``None`` token so callers don't have to special-case
+    "nothing was bound" at the call site.
+    """
+    if token is not None:
+        _alert_id_var.reset(token)
+
+
+def current_alert() -> Optional[str]:
+    """Return the alert ID currently bound to this task, or ``None``."""
+    return _alert_id_var.get()

--- a/app_core/logging_context.py
+++ b/app_core/logging_context.py
@@ -145,3 +145,40 @@ def pop_alert(token: Optional[contextvars.Token]) -> None:
 def current_alert() -> Optional[str]:
     """Return the alert ID currently bound to this task, or ``None``."""
     return _alert_id_var.get()
+
+
+def attach_alert_id_autopopulate(*models, attr: str = 'alert_identifier') -> None:
+    """Register a ``before_insert`` listener on each model that stamps the
+    current correlation ID onto *attr* when the column is unset.
+
+    This is the glue that lets ``SystemLog(message=...)`` writes scattered
+    across ~40 call sites automatically inherit the alert context bound by
+    ``bind_alert``/``push_alert`` — without each call site having to know
+    the field exists.  Explicit overrides at the call site still win
+    because we only fill the column when it is ``None``.
+
+    Args:
+        *models: SQLAlchemy declarative classes to attach the listener to.
+        attr: Column name on each model to populate.  Defaults to
+            ``alert_identifier``; pass ``alert_id`` for legacy tables
+            (e.g. ``GPIOActivationLog``) that already shipped with a
+            differently-named column.
+    """
+    from sqlalchemy import event  # Imported lazily so logging_context stays
+    # importable in environments without SQLAlchemy (tests, CLI tools).
+
+    def _before_insert(mapper, connection, target):  # noqa: ARG001
+        try:
+            if getattr(target, attr, None):
+                return  # Caller set it explicitly; respect that.
+            cid = _alert_id_var.get()
+            if cid:
+                setattr(target, attr, cid)
+        except Exception:
+            # Listeners must never break a write.  Silently skip on any
+            # unexpected error (e.g. detached instance, missing attr).
+            pass
+
+    for model in models:
+        # Use propagate=True so subclasses (if any) inherit the behaviour.
+        event.listen(model, 'before_insert', _before_insert, propagate=True)

--- a/app_core/migrations/versions/20260521_add_alert_identifier_columns.py
+++ b/app_core/migrations/versions/20260521_add_alert_identifier_columns.py
@@ -1,0 +1,79 @@
+"""Add alert_identifier correlation-ID columns to log-shaped tables
+
+Revision ID: 20260521_add_alert_identifier_columns
+Revises: 20260521_add_rwt_skip_until
+Create Date: 2026-05-21
+
+Adds a nullable, indexed ``alert_identifier`` column to three log-shaped
+tables so rows written during an alert's lifecycle can be traced back to
+the originating CAP identifier (or OTA-derived correlation ID).  A
+SQLAlchemy ``before_insert`` listener in ``app_core.logging_context``
+populates the column from the ContextVar set by ``bind_alert`` /
+``push_alert`` whenever a write happens inside an alert scope.
+
+Affected tables:
+
+* ``system_log``        — general application logs (44+ write sites)
+* ``audio_alerts``      — audio subsystem warnings/errors
+* ``eas_messages``      — generated EAS broadcasts
+
+``gpio_activation_logs`` already carries a similarly-shaped ``alert_id``
+column (added with the table) and is not touched by this migration; the
+auto-populate listener is wired to that field separately.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20260521_add_alert_identifier_columns"
+down_revision = "20260521_add_rwt_skip_until"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    try:
+        cols = {c["name"] for c in inspector.get_columns(table_name)}
+    except Exception:
+        return False
+    return column_name in cols
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    try:
+        idx_names = {i["name"] for i in inspector.get_indexes(table_name)}
+    except Exception:
+        return False
+    return index_name in idx_names
+
+
+_TARGETS = (
+    ("system_log", "ix_system_log_alert_identifier"),
+    ("audio_alerts", "ix_audio_alerts_alert_identifier"),
+    ("eas_messages", "ix_eas_messages_alert_identifier"),
+)
+
+
+def upgrade():
+    for table, index_name in _TARGETS:
+        if not _column_exists(table, "alert_identifier"):
+            op.add_column(
+                table,
+                sa.Column("alert_identifier", sa.String(length=255), nullable=True),
+            )
+        if not _index_exists(table, index_name):
+            op.create_index(index_name, table, ["alert_identifier"])
+
+
+def downgrade():
+    for table, index_name in _TARGETS:
+        if _index_exists(table, index_name):
+            op.drop_index(index_name, table_name=table)
+        if _column_exists(table, "alert_identifier"):
+            op.drop_column(table, "alert_identifier")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -121,6 +121,17 @@ from ._models_displays import (
     ScreenRotation,
 )
 
+# Wire the alert-correlation-ID auto-populate hook onto log-shaped tables.
+# Every INSERT to one of these tables made while a logging_context alert
+# is bound will record the identifier without the call site having to know
+# about it.  GPIOActivationLog uses its legacy ``alert_id`` column; the
+# rest carry the canonical ``alert_identifier`` column added in migration
+# 20260521_add_alert_identifier_columns.
+from .logging_context import attach_alert_id_autopopulate as _attach_alert_autop
+_attach_alert_autop(SystemLog, AudioAlert, EASMessage)
+_attach_alert_autop(GPIOActivationLog, attr='alert_id')
+del _attach_alert_autop
+
 
 __all__ = [
     "db",

--- a/eas_monitoring_service.py
+++ b/eas_monitoring_service.py
@@ -55,13 +55,18 @@ from typing import Optional, Any, Dict
 from dotenv import load_dotenv
 
 # Configure logging early
+from app_core.logging_context import (
+    LOG_FORMAT_WITH_ALERT,
+    install_alert_filter,
+)
 logging.basicConfig(
     level=logging.DEBUG,  # Changed from INFO to DEBUG to show diagnostic logs
-    format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
+    format=LOG_FORMAT_WITH_ALERT,
     handlers=[
         logging.StreamHandler(sys.stdout)
     ]
 )
+install_alert_filter()
 
 logger = logging.getLogger(__name__)
 

--- a/eas_service.py
+++ b/eas_service.py
@@ -62,13 +62,18 @@ from typing import Optional, Any, Dict
 from dotenv import load_dotenv
 
 # Configure logging early
+from app_core.logging_context import (
+    LOG_FORMAT_WITH_ALERT,
+    install_alert_filter,
+)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
+    format=LOG_FORMAT_WITH_ALERT,
     handlers=[
         logging.StreamHandler(sys.stdout)
     ]
 )
+install_alert_filter()
 
 logger = logging.getLogger(__name__)
 

--- a/hardware_service.py
+++ b/hardware_service.py
@@ -80,13 +80,18 @@ from app_utils.memdiag import install_memdiag_handlers
 from app_utils.glibc_tuning import apply_glibc_tuning, start_malloc_trim_thread
 
 # Configure logging early
+from app_core.logging_context import (
+    LOG_FORMAT_WITH_ALERT,
+    install_alert_filter,
+)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
+    format=LOG_FORMAT_WITH_ALERT,
     handlers=[
         logging.StreamHandler(sys.stdout)
     ]
 )
+install_alert_filter()
 
 logger = logging.getLogger(__name__)
 

--- a/poller/cap_poller.py
+++ b/poller/cap_poller.py
@@ -2510,53 +2510,59 @@ class CAPPoller:
             raise  # Re-raise so caller knows intersection calculation failed
 
     def save_cap_alert(self, alert_data: Dict) -> Tuple[bool, Optional[CAPAlert], Optional[Dict[str, Any]]]:
-        try:
-            payload = dict(alert_data)
-            geometry_data = payload.pop('_geometry_data', None)
-            existing = self.db_session.query(CAPAlert).filter_by(
-                identifier=payload['identifier']
-            ).first()
+        from app_core.logging_context import bind_alert
 
-            if existing:
-                return self._update_existing_alert(existing, payload, geometry_data)
-
-            return self._insert_new_alert(payload, geometry_data, alert_data)
-
-        except IntegrityError as e:
-            # Race condition: another process inserted the same alert between our
-            # SELECT and INSERT. Rollback and retry as an UPDATE.
-            self.logger.warning(
-                f"IntegrityError saving alert {payload.get('identifier', 'unknown')}, "
-                f"retrying as update: {e}"
-            )
-            self.db_session.rollback()
-
-            # Re-fetch the existing alert and update it
+        # Bind the CAP identifier as the correlation ID for every log line
+        # produced while this alert moves through dedup, DB write, geometry
+        # processing, Redis publish, auto-forward, and IntegrityError retries.
+        with bind_alert(alert_data.get('identifier')):
             try:
+                payload = dict(alert_data)
+                geometry_data = payload.pop('_geometry_data', None)
                 existing = self.db_session.query(CAPAlert).filter_by(
                     identifier=payload['identifier']
                 ).first()
+
                 if existing:
                     return self._update_existing_alert(existing, payload, geometry_data)
-                else:
-                    # Alert was deleted between our attempts - this is very rare
-                    self.logger.error(
-                        f"Alert {payload.get('identifier')} not found after IntegrityError"
-                    )
+
+                return self._insert_new_alert(payload, geometry_data, alert_data)
+
+            except IntegrityError as e:
+                # Race condition: another process inserted the same alert between our
+                # SELECT and INSERT. Rollback and retry as an UPDATE.
+                self.logger.warning(
+                    f"IntegrityError saving alert {payload.get('identifier', 'unknown')}, "
+                    f"retrying as update: {e}"
+                )
+                self.db_session.rollback()
+
+                # Re-fetch the existing alert and update it
+                try:
+                    existing = self.db_session.query(CAPAlert).filter_by(
+                        identifier=payload['identifier']
+                    ).first()
+                    if existing:
+                        return self._update_existing_alert(existing, payload, geometry_data)
+                    else:
+                        # Alert was deleted between our attempts - this is very rare
+                        self.logger.error(
+                            f"Alert {payload.get('identifier')} not found after IntegrityError"
+                        )
+                        return False, None, None
+                except Exception as retry_err:
+                    self.logger.error(f"Failed to update alert after IntegrityError: {retry_err}")
+                    self.db_session.rollback()
                     return False, None, None
-            except Exception as retry_err:
-                self.logger.error(f"Failed to update alert after IntegrityError: {retry_err}")
+
+            except SQLAlchemyError as e:
+                self.logger.error(f"Database error saving alert: {e}")
                 self.db_session.rollback()
                 return False, None, None
-
-        except SQLAlchemyError as e:
-            self.logger.error(f"Database error saving alert: {e}")
-            self.db_session.rollback()
-            return False, None, None
-        except Exception as e:
-            self.logger.error(f"Error saving CAP alert: {e}")
-            self.db_session.rollback()
-            return False, None, None
+            except Exception as e:
+                self.logger.error(f"Error saving CAP alert: {e}")
+                self.db_session.rollback()
+                return False, None, None
 
     def _update_existing_alert(
         self,
@@ -3631,11 +3637,13 @@ def main():
     args = parser.parse_args()
 
     # Logging to stdout for service management and systemd
+    from app_core.logging_context import install_alert_filter
     logging.basicConfig(
         level=getattr(logging, args.log_level),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        format='%(asctime)s - %(name)s - %(levelname)s - [alert=%(alert_id)s] %(message)s',
         handlers=[logging.StreamHandler(sys.stdout)]
     )
+    install_alert_filter()
     logger = logging.getLogger(__name__)
 
     startup_utc = utc_now()

--- a/sdr_hardware_service.py
+++ b/sdr_hardware_service.py
@@ -79,13 +79,18 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 # Configure logging early
+from app_core.logging_context import (
+    LOG_FORMAT_WITH_ALERT,
+    install_alert_filter,
+)
 logging.basicConfig(
     level=logging.DEBUG,  # Changed from INFO to DEBUG to show diagnostic logs
-    format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
+    format=LOG_FORMAT_WITH_ALERT,
     handlers=[
         logging.StreamHandler(sys.stdout)
     ]
 )
+install_alert_filter()
 
 logger = logging.getLogger(__name__)
 

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -223,8 +223,26 @@
                                 </div>
                             </div>
 
+                            <!-- Active alert-correlation-ID filter chip -->
+                            {% if alert_filter %}
+                            <div class="row mt-2">
+                                <div class="col-12">
+                                    <span class="badge bg-info text-dark">
+                                        <i class="fas fa-link"></i>
+                                        Filtered to alert
+                                        <code class="ms-1">{{ alert_filter }}</code>
+                                        <a class="ms-2 text-dark"
+                                           href="?type={{ log_type }}&limit={{ limit }}{% if search_query %}&search={{ search_query }}{% endif %}{% if log_level_filter %}&level={{ log_level_filter }}{% endif %}{% if date_from %}&date_from={{ date_from }}{% endif %}{% if date_to %}&date_to={{ date_to }}{% endif %}{% if service_filter %}&service={{ service_filter }}{% endif %}"
+                                           title="Remove alert filter">
+                                            <i class="fas fa-times-circle"></i>
+                                        </a>
+                                    </span>
+                                </div>
+                            </div>
+                            {% endif %}
+
                             <!-- Clear Filters Button -->
-                            {% if search_query or log_level_filter or date_from or date_to or service_filter %}
+                            {% if search_query or log_level_filter or date_from or date_to or service_filter or alert_filter %}
                             <div class="row mt-2">
                                 <div class="col-12">
                                     <a href="?type={{ log_type }}&limit={{ limit }}" class="btn btn-sm btn-outline-secondary">
@@ -305,6 +323,7 @@
                                                         <th style="width: 180px;"><i class="fas fa-clock"></i> Timestamp</th>
                                                         <th style="width: 100px;"><i class="fas fa-tag"></i> Level</th>
                                                         <th style="width: 200px;"><i class="fas fa-cube"></i> Module</th>
+                                                        <th style="width: 180px;"><i class="fas fa-link"></i> Alert</th>
                                                         <th><i class="fas fa-comment"></i> Message</th>
                                                         <th style="width: 80px;"><i class="fas fa-info"></i> Details</th>
                                                     </tr>
@@ -325,6 +344,17 @@
                                                             </span>
                                                         </td>
                                                         <td><small class="text-muted">{{ log.module }}</small></td>
+                                                        <td>
+                                                            {% if log.alert_identifier %}
+                                                            <a href="?type={{ log_type }}&limit={{ limit }}&alert={{ log.alert_identifier }}"
+                                                               class="badge bg-info text-dark text-decoration-none"
+                                                               title="Filter to this alert's lifecycle">
+                                                                <code class="text-dark">{{ log.alert_identifier }}</code>
+                                                            </a>
+                                                            {% else %}
+                                                            <span class="text-muted">—</span>
+                                                            {% endif %}
+                                                        </td>
                                                         <td><span class="log-message">{{ log.message }}</span></td>
                                                         <td class="text-center">
                                                             {% if log.details %}
@@ -341,7 +371,7 @@
                                                     </tr>
                                                     {% if log.details %}
                                                     <tr class="collapse" id="details-{{ category|replace(' ', '') }}-{{ loop.index }}">
-                                                        <td colspan="5">
+                                                        <td colspan="6">
                                                             <div class="card card-body bg-light">
                                                                 <h6><i class="fas fa-info-circle"></i> Detailed Information:</h6>
                                                                 <pre class="mb-0" style="font-size: 0.85rem; max-height: 400px; overflow-y: auto;">{{ log.details | tojson(indent=2) }}</pre>
@@ -406,6 +436,17 @@
                                         </span>
                                     </td>
                                     <td><small class="text-muted">{{ log.module }}</small></td>
+                                    <td>
+                                        {% if log.alert_identifier %}
+                                        <a href="?type={{ log_type }}&limit={{ limit }}&alert={{ log.alert_identifier }}"
+                                           class="badge bg-info text-dark text-decoration-none"
+                                           title="Filter to this alert's lifecycle">
+                                            <code class="text-dark">{{ log.alert_identifier }}</code>
+                                        </a>
+                                        {% else %}
+                                        <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
                                     <td><span class="log-message">{{ log.message }}</span></td>
                                     <td class="text-center">
                                         {% if log.details %}
@@ -422,7 +463,7 @@
                                 </tr>
                                 {% if log.details %}
                                 <tr class="collapse" id="details-{{ loop.index }}">
-                                    <td colspan="5">
+                                    <td colspan="6">
                                         <div class="card card-body bg-light">
                                             <h6><i class="fas fa-info-circle"></i> Detailed Information:</h6>
                                             <pre class="mb-0" style="font-size: 0.85rem; max-height: 400px; overflow-y: auto;">{{ log.details | tojson(indent=2) }}</pre>

--- a/tests/test_logging_context.py
+++ b/tests/test_logging_context.py
@@ -145,3 +145,93 @@ def test_alert_id_field_is_always_present(configured_logger):
     log.info("capture")
     assert hasattr(record_holder["record"], "alert_id")
     assert record_holder["record"].alert_id == "-"
+
+
+class TestAttachAlertIdAutopopulate:
+    """The SQLAlchemy ``before_insert`` listener must stamp the bound alert ID
+    onto rows that don't carry one, and leave explicit values alone."""
+
+    def _build_session(self):
+        """Build a tiny in-process SQLAlchemy setup with a single model that
+        mimics the shape of SystemLog (id + alert_identifier).  This keeps
+        the test free of Flask/PostGIS/etc. while still exercising the real
+        ``event.listen`` machinery used by the production code."""
+        from sqlalchemy import Column, Integer, String, create_engine
+        from sqlalchemy.orm import declarative_base, sessionmaker
+
+        Base = declarative_base()
+
+        class FakeLog(Base):
+            __tablename__ = "fake_log"
+            id = Column(Integer, primary_key=True)
+            message = Column(String(200))
+            alert_identifier = Column(String(255))
+
+        from app_core.logging_context import attach_alert_id_autopopulate
+        attach_alert_id_autopopulate(FakeLog)
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine)(), FakeLog
+
+    def test_listener_stamps_bound_alert_id(self):
+        session, FakeLog = self._build_session()
+        try:
+            with bind_alert("NWS-XYZ-2026-007"):
+                row = FakeLog(message="hello")
+                session.add(row)
+                session.commit()
+            assert row.alert_identifier == "NWS-XYZ-2026-007"
+        finally:
+            session.close()
+
+    def test_listener_skips_when_no_alert_bound(self):
+        session, FakeLog = self._build_session()
+        try:
+            row = FakeLog(message="idle")
+            session.add(row)
+            session.commit()
+            assert row.alert_identifier is None
+        finally:
+            session.close()
+
+    def test_listener_respects_explicit_value(self):
+        """When the caller set the column explicitly, the listener must not
+        clobber it with the context value."""
+        session, FakeLog = self._build_session()
+        try:
+            with bind_alert("ctx-id"):
+                row = FakeLog(message="explicit", alert_identifier="caller-id")
+                session.add(row)
+                session.commit()
+            assert row.alert_identifier == "caller-id"
+        finally:
+            session.close()
+
+    def test_listener_supports_custom_attribute_name(self):
+        """``GPIOActivationLog`` uses ``alert_id`` rather than
+        ``alert_identifier``; the helper must accept an override."""
+        from sqlalchemy import Column, Integer, String, create_engine
+        from sqlalchemy.orm import declarative_base, sessionmaker
+        from app_core.logging_context import attach_alert_id_autopopulate
+
+        Base = declarative_base()
+
+        class LegacyLog(Base):
+            __tablename__ = "legacy_log"
+            id = Column(Integer, primary_key=True)
+            alert_id = Column(String(255))
+
+        attach_alert_id_autopopulate(LegacyLog, attr="alert_id")
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        try:
+            with bind_alert("legacy-style"):
+                row = LegacyLog()
+                session.add(row)
+                session.commit()
+            assert row.alert_id == "legacy-style"
+        finally:
+            session.close()

--- a/tests/test_logging_context.py
+++ b/tests/test_logging_context.py
@@ -1,0 +1,147 @@
+"""Tests for the alert correlation-ID logging context.
+
+Verifies that ``app_core.logging_context`` correctly threads alert
+identifiers through ``logging.LogRecord`` instances so a grep on
+``alert=<identifier>`` reconstructs the alert lifecycle.
+"""
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from app_core.logging_context import (
+    LOG_FORMAT_WITH_ALERT,
+    AlertContextFilter,
+    bind_alert,
+    clear_alert,
+    current_alert,
+    install_alert_filter,
+    pop_alert,
+    push_alert,
+    set_alert,
+)
+
+
+@pytest.fixture
+def configured_logger():
+    """Wire a fresh handler into a unique logger so tests don't leak state."""
+    buf = io.StringIO()
+    logger = logging.getLogger(f"test_logging_context_{id(buf)}")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    # Strip any handlers a previous test installed onto this logger.
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT_WITH_ALERT))
+    logger.addHandler(handler)
+    install_alert_filter(logger)
+    # Reset any context leaked by an earlier test.
+    clear_alert()
+    yield logger, buf
+    clear_alert()
+
+
+def test_unbound_alert_renders_as_dash(configured_logger):
+    log, buf = configured_logger
+    log.info("idle")
+    assert "[alert=-]" in buf.getvalue()
+
+
+def test_bind_alert_sets_and_restores(configured_logger):
+    log, buf = configured_logger
+    with bind_alert("NWS-XYZ-2026-001"):
+        log.info("inside")
+    log.info("outside")
+    lines = buf.getvalue().strip().splitlines()
+    assert "[alert=NWS-XYZ-2026-001]" in lines[0]
+    assert "[alert=-]" in lines[1]
+
+
+def test_bind_alert_with_none_is_noop(configured_logger):
+    log, buf = configured_logger
+    with bind_alert(None):
+        log.info("none-bound")
+    assert "[alert=-]" in buf.getvalue()
+
+
+def test_bind_alert_nests_and_restores_outer(configured_logger):
+    log, buf = configured_logger
+    with bind_alert("outer"):
+        log.info("o1")
+        with bind_alert("inner"):
+            log.info("i")
+        log.info("o2")
+    lines = buf.getvalue().strip().splitlines()
+    assert "[alert=outer]" in lines[0]
+    assert "[alert=inner]" in lines[1]
+    assert "[alert=outer]" in lines[2]
+
+
+def test_push_pop_alert_roundtrip(configured_logger):
+    log, buf = configured_logger
+    token = push_alert("OTA-RWT-deadbeef")
+    log.info("pushed")
+    pop_alert(token)
+    log.info("popped")
+    lines = buf.getvalue().strip().splitlines()
+    assert "[alert=OTA-RWT-deadbeef]" in lines[0]
+    assert "[alert=-]" in lines[1]
+
+
+def test_push_alert_with_none_returns_none_token(configured_logger):
+    log, buf = configured_logger
+    token = push_alert(None)
+    assert token is None
+    pop_alert(token)  # must not raise
+    log.info("still-unbound")
+    assert "[alert=-]" in buf.getvalue()
+
+
+def test_set_and_clear_alert(configured_logger):
+    log, buf = configured_logger
+    set_alert("manual-id")
+    assert current_alert() == "manual-id"
+    log.info("set")
+    clear_alert()
+    assert current_alert() is None
+    log.info("cleared")
+    lines = buf.getvalue().strip().splitlines()
+    assert "[alert=manual-id]" in lines[0]
+    assert "[alert=-]" in lines[1]
+
+
+def test_install_alert_filter_is_idempotent():
+    """Calling install_alert_filter twice must not stack duplicate filters."""
+    test_logger = logging.getLogger("test_idempotent_filter")
+    for h in list(test_logger.handlers):
+        test_logger.removeHandler(h)
+    handler = logging.StreamHandler(io.StringIO())
+    test_logger.addHandler(handler)
+
+    install_alert_filter(test_logger)
+    install_alert_filter(test_logger)
+
+    handler_filters = [f for f in handler.filters if isinstance(f, AlertContextFilter)]
+    logger_filters = [f for f in test_logger.filters if isinstance(f, AlertContextFilter)]
+    assert len(handler_filters) == 1
+    assert len(logger_filters) == 1
+
+
+def test_alert_id_field_is_always_present(configured_logger):
+    """Records created outside any bind must still have an alert_id attribute."""
+    log, buf = configured_logger
+    record_holder: dict = {}
+
+    class CaptureHandler(logging.Handler):
+        def emit(self, record):
+            record_holder["record"] = record
+
+    capture = CaptureHandler()
+    log.addHandler(capture)
+    install_alert_filter(log)
+    log.info("capture")
+    assert hasattr(record_holder["record"], "alert_id")
+    assert record_holder["record"].alert_id == "-"

--- a/webapp/routes_logs.py
+++ b/webapp/routes_logs.py
@@ -287,6 +287,7 @@ def get_recent_logs():
                 'module': log.module or 'system',
                 'message': log.message,
                 'category': 'system',
+                'alert_identifier': log.alert_identifier,
                 'details': log.details,
             })
 
@@ -299,6 +300,7 @@ def get_recent_logs():
                 'module': f'audio:{log.source_name}' if log.source_name else 'audio',
                 'message': log.message,
                 'category': 'audio',
+                'alert_identifier': log.alert_identifier,
                 'details': {
                     'alert_type': log.alert_type,
                     'acknowledged': log.acknowledged,
@@ -314,6 +316,9 @@ def get_recent_logs():
                 'module': f'gpio:pin{log.pin}',
                 'message': f"{log.activation_type} - Duration: {log.duration_seconds or 'active'}s",
                 'category': 'gpio',
+                # GPIOActivationLog stores the correlation ID in its legacy
+                # ``alert_id`` column rather than ``alert_identifier``.
+                'alert_identifier': log.alert_id,
                 'details': {
                     'pin': log.pin,
                     'activation_type': log.activation_type,
@@ -330,6 +335,7 @@ def get_recent_logs():
                 'module': 'eas_generator',
                 'message': f"SAME: {log.same_header}" if log.same_header else "EAS message generated",
                 'category': 'eas',
+                'alert_identifier': log.alert_identifier,
                 'details': {
                     'same_header': log.same_header,
                     'audio_filename': log.audio_filename,

--- a/webapp/routes_public.py
+++ b/webapp/routes_public.py
@@ -1705,6 +1705,7 @@ def register(app: Flask, logger) -> None:
                     'level': log.level,
                     'module': log.module or 'system',
                     'message': log.message,
+                    'alert_identifier': log.alert_identifier,
                     'details': log.details,
                 }
                 for log in logs_result
@@ -1827,6 +1828,7 @@ def register(app: Flask, logger) -> None:
                     'level': log.alert_level.upper(),
                     'module': f'Audio Alert: {log.source_name}',
                     'message': log.message,
+                    'alert_identifier': log.alert_identifier,
                     'details': {
                         'alert_type': log.alert_type,
                         'acknowledged': log.acknowledged,
@@ -1924,6 +1926,9 @@ def register(app: Flask, logger) -> None:
                         f"Type: {log.activation_type} | Operator: {log.operator or 'System'} | "
                         f"Duration: {log.duration_seconds or 'Active'}s"
                     ),
+                    # GPIOActivationLog uses the legacy ``alert_id`` field
+                    # but the UI shows it under the canonical name.
+                    'alert_identifier': log.alert_id,
                     'details': {
                         'pin': log.pin,
                         'activation_type': log.activation_type,
@@ -1959,9 +1964,11 @@ def register(app: Flask, logger) -> None:
                         f"TTS Provider: {log.tts_provider or 'None'} | "
                         f"Audio: {log.audio_filename}"
                     ),
+                    'alert_identifier': log.alert_identifier,
                     'details': {
                         'id': log.id,
                         'cap_alert_id': log.cap_alert_id,
+                        'alert_identifier': log.alert_identifier,
                         'same_header': log.same_header,
                         'audio_filename': log.audio_filename,
                         'text_filename': log.text_filename,
@@ -2154,6 +2161,7 @@ def register(app: Flask, logger) -> None:
             date_from = request.args.get('date_from', '').strip()
             date_to = request.args.get('date_to', '').strip()
             service_filter = request.args.get('service', '').strip()
+            alert_filter = request.args.get('alert', '').strip()
 
             log_type_name, logs_data = _load_logs_data(log_type, limit, service_filter)
 
@@ -2164,6 +2172,15 @@ def register(app: Flask, logger) -> None:
                     if (search_query.lower() in log.get('message', '').lower() or
                         search_query.lower() in log.get('module', '').lower() or
                         search_query.lower() in str(log.get('details', '')).lower())
+                ]
+
+            if alert_filter:
+                # Exact match on the correlation ID; clicking a chip in the UI
+                # passes the full identifier so substring matching would be
+                # surprising (different alerts can share a prefix).
+                logs_data = [
+                    log for log in logs_data
+                    if (log.get('alert_identifier') or '') == alert_filter
                 ]
 
             if log_level_filter:
@@ -2219,6 +2236,7 @@ def register(app: Flask, logger) -> None:
                 date_from=date_from,
                 date_to=date_to,
                 service_filter=service_filter,
+                alert_filter=alert_filter,
                 available_services=get_all_log_services(),
             )
 


### PR DESCRIPTION
Introduce app_core/logging_context.py — a contextvars-backed alert ID
bound to every LogRecord by AlertContextFilter — so the lifecycle of a
single alert can be reconstructed with `grep alert=<id>` instead of
guessing which log lines belong together.

The same ID flows through the two ingestion paths and onward to forwarding,
SAME encoding, broadcast, and notifications:

  * CAP path:  save_cap_alert binds cap_alert.identifier;
               auto_forward_cap_alert re-pushes on entry as a safety net
               for direct callers.
  * OTA path:  EASMonitor._handle_alert and UnifiedEASMonitorService
               derive a stable correlation ID from the raw SAME header
               (sha1, 8 hex chars) and bind it; auto_forward_ota_alert
               does the same so callers that bypass the monitor still
               get a coherent trail.

Every service's basicConfig is updated to use a format string that
includes [alert=%(alert_id)s]; the filter renders "-" when no alert is
bound so idle log lines stay aligned.

Includes tests covering bind/push/pop/set/clear semantics, nesting,
no-op None handling, and idempotent filter installation.

https://claude.ai/code/session_015c5HAY4nQ7RQRTtJPNaGr5