### PR TITLE
Give /logs report tabs a real layout instead of jamming columns into one cell

### DIFF
--- a/templates/logs.html
+++ b/templates/logs.html
@@ -443,6 +443,18 @@
                 <div class="alert alert-info mb-3">
                     {% if log_type == 'all' %}
                         <strong><i class="fas fa-info-circle"></i> All Logs:</strong> Unified view of all system logs organized by category. Click category headers to expand/collapse sections.
+                    {% elif log_type == 'report_received' %}
+                        <strong><i class="fas fa-info-circle"></i> Received Alerts Report:</strong> FCC-shaped log of every EAS alert received in the reporting window, including the forwarding decision and reason. Use the CSV/PDF buttons above for the printable layout.
+                    {% elif log_type == 'report_forwarded' %}
+                        <strong><i class="fas fa-info-circle"></i> Forwarded Alerts Report:</strong> Alerts that were relayed downstream during the reporting window. Export as CSV/PDF for FCC-shaped formatting.
+                    {% elif log_type == 'report_ignored' %}
+                        <strong><i class="fas fa-info-circle"></i> Ignored Alerts Report:</strong> Alerts received but not relayed, with the reason for each decision. Export as CSV/PDF for FCC-shaped formatting.
+                    {% elif log_type == 'report_initiated' %}
+                        <strong><i class="fas fa-info-circle"></i> Initiated Alerts Report:</strong> Alerts this station originated — automated relays plus manual activations.
+                    {% elif log_type == 'report_weekly' %}
+                        <strong><i class="fas fa-info-circle"></i> Weekly Summary Report:</strong> Per-week roll-up of received, forwarded, ignored, tests and station-initiated alerts.
+                    {% elif log_type == 'report_monthly' %}
+                        <strong><i class="fas fa-info-circle"></i> Monthly Summary Report:</strong> Per-month roll-up of received, forwarded, ignored, tests and station-initiated alerts.
                     {% elif log_type == 'system' %}
                         <strong><i class="fas fa-info-circle"></i> System Logs:</strong> General application logs including errors, warnings, and informational messages.
                     {% elif log_type == 'polling' %}
@@ -471,7 +483,111 @@
                 </div>
 
                 <!-- Logs Display -->
-                {% if logs %}
+                {% if report %}
+                    <!-- FCC report layout: summary cards + proper columnar table (desktop) / stacked cards (mobile) -->
+                    {% if report.summary_lines %}
+                    <div class="report-summary mb-3">
+                        <div class="row g-2">
+                            {% for line in report.summary_lines %}
+                                {% set parts = line.split(':', 1) %}
+                                {% set label = parts[0]|trim if parts|length == 2 else line %}
+                                {% set value = parts[1]|trim if parts|length == 2 else '' %}
+                                <div class="col-6 col-md-4 col-lg-3">
+                                    <div class="card h-100">
+                                        <div class="card-body py-2 px-3">
+                                            <div class="text-muted small text-uppercase">{{ label }}</div>
+                                            <div class="fw-semibold report-summary-value">{{ value or '—' }}</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        {% if report.window_start and report.window_end %}
+                        <div class="mt-2 text-muted small">
+                            <i class="fas fa-calendar-alt"></i>
+                            Window:
+                            <strong>{{ report.window_start.strftime('%Y-%m-%d') }}</strong>
+                            →
+                            <strong>{{ report.window_end.strftime('%Y-%m-%d') }}</strong>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+
+                    {% if logs %}
+                        {# Filter out the synthetic summary rows that older code paths pushed
+                           into logs_data — the cards above render the same information. #}
+                        {% set report_rows = [] %}
+                        {% for log in logs %}
+                            {% if log.details %}{% set _ = report_rows.append(log) %}{% endif %}
+                        {% endfor %}
+
+                        {% if report_rows %}
+                        <!-- Desktop: real columnar table -->
+                        <div class="table-responsive d-none d-md-block">
+                            <table class="table table-sm table-hover report-table mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        {% for col in report.columns %}
+                                        <th>{{ col }}</th>
+                                        {% endfor %}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for log in report_rows %}
+                                    <tr>
+                                        {% for col in report.columns %}
+                                        {% set cell = log.details.get(col, '') %}
+                                        <td>{% if cell %}{{ cell }}{% else %}<span class="text-muted">—</span>{% endif %}</td>
+                                        {% endfor %}
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <!-- Mobile: stacked cards so every field has a label and wraps cleanly -->
+                        <div class="d-md-none report-card-list">
+                            {% for log in report_rows %}
+                            <div class="card mb-2 report-card">
+                                <div class="card-body p-2">
+                                    <dl class="report-card-dl mb-0">
+                                        {% for col in report.columns %}
+                                        {% set cell = log.details.get(col, '') %}
+                                        <dt>{{ col }}</dt>
+                                        <dd>{% if cell %}{{ cell }}{% else %}<span class="text-muted">—</span>{% endif %}</dd>
+                                        {% endfor %}
+                                    </dl>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div class="alert alert-secondary mb-0">
+                            <i class="fas fa-info-circle"></i> No rows in this report window.
+                            {% if search_query or log_level_filter or date_from or date_to %}
+                            <br><small>Try adjusting your filters or <a href="?type={{ log_type }}&limit={{ limit }}">clear all filters</a>.</small>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+
+                        <div class="mt-3 d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <small class="text-muted">
+                                <i class="fas fa-list"></i> Showing {{ report_rows|length }} of {{ report.row_count or report_rows|length }} record{{ '' if report_rows|length == 1 else 's' }}
+                                {% if search_query or log_level_filter or date_from or date_to %}
+                                (filtered)
+                                {% endif %}
+                            </small>
+                            <small class="text-muted">
+                                <i class="fas fa-clock"></i> Last updated: <span id="lastUpdate">{{ 'now' }}</span>
+                            </small>
+                        </div>
+                    {% else %}
+                        <div class="alert alert-secondary mb-0">
+                            <i class="fas fa-info-circle"></i> No rows in this report window.
+                        </div>
+                    {% endif %}
+                {% elif logs %}
                     {% if log_type == 'all' %}
                         <!-- Grouped display for All Logs -->
                         {% set logs_by_category = {} %}
@@ -794,6 +910,60 @@
     #autoRefreshBtn.active {
         background-color: var(--primary-color);
         color: white;
+    }
+
+    /* FCC report layout — both desktop table and mobile stacked cards
+       share these tweaks so labels never collide with values. */
+    .report-summary .report-summary-value {
+        word-break: break-word;
+    }
+
+    .report-table {
+        font-size: 0.9rem;
+    }
+
+    .report-table th,
+    .report-table td {
+        vertical-align: top;
+        word-break: break-word;
+    }
+
+    /* Mobile: each report row becomes a card with a two-column
+       definition list so the column label is always next to the value. */
+    .report-card-dl {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.15rem;
+        font-size: 0.9rem;
+    }
+
+    .report-card-dl dt {
+        color: var(--text-muted);
+        font-weight: 600;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        margin: 0;
+        align-self: start;
+    }
+
+    .report-card-dl dd {
+        margin: 0;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+
+    /* Very narrow phones: stack the label above the value so long values
+       don't get squeezed into a tiny column. */
+    @media (max-width: 380px) {
+        .report-card-dl {
+            grid-template-columns: 1fr;
+            row-gap: 0;
+        }
+        .report-card-dl dd {
+            margin-bottom: 0.4rem;
+        }
     }
 </style>
 

--- a/webapp/routes_public.py
+++ b/webapp/routes_public.py
@@ -1515,11 +1515,23 @@ def register(app: Flask, logger) -> None:
                 f"<p>{exc}</p><p><a href='/'>← Back to Main</a></p>"
             )
 
-    def _load_logs_data(log_type: str, limit: int, service_filter: str = None) -> Tuple[str, List[Dict[str, Any]]]:
-        """Load the requested log data and metadata for rendering or export."""
+    def _load_logs_data(
+        log_type: str,
+        limit: int,
+        service_filter: str = None,
+    ) -> Tuple[str, List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        """Load the requested log data and metadata for rendering or export.
+
+        Returns a triple of ``(display_name, logs_data, report_meta)``.  The
+        third element is populated only for ``report_*`` log types and carries
+        the FCC report's column labels, summary lines, and window — the
+        template uses it to render a real columnar layout instead of cramming
+        every column into the generic ``message`` cell.
+        """
 
         log_type_name = "System Logs"
         logs_data: List[Dict[str, Any]] = []
+        report_meta: Optional[Dict[str, Any]] = None
 
         if log_type == 'all':
             log_type_name = "All Logs"
@@ -2176,12 +2188,16 @@ def register(app: Flask, logger) -> None:
                 })
 
         elif log_type.startswith('report_'):
-            # Inline preview of one of the FCC-shaped report builders.  The
-            # rich PDF/CSV exports still go through
+            # FCC-shaped report rendered inline on /logs.  Each row is also
+            # mirrored into ``logs_data`` so the page's search/level/date
+            # filters and the generic CSV exporter keep working — but the
+            # template renders the proper columnar layout from
+            # ``report_meta`` instead of cramming every column into the
+            # generic ``message`` cell (which was unreadable on mobile).
+            #
+            # The rich PDF/CSV exports still go through
             # /admin/compliance/report/<kind>.<fmt> which keeps the
-            # report-specific column layout — this branch just renders a
-            # readable summary inline so the page is consistent with the
-            # rest of /logs.
+            # report-specific column layout.
             from app_core.eas_storage import REPORT_BUILDERS, resolve_report_window
             report_kind = log_type[len('report_'):]
             builder = REPORT_BUILDERS.get(report_kind)
@@ -2203,14 +2219,19 @@ def register(app: Flask, logger) -> None:
                     report = builder(window_start=window_start, window_end=window_end)
                 except Exception as exc:
                     route_logger.error("report builder %s failed: %s", report_kind, exc)
-                    report = {"columns": [], "rows": [], "summary_lines": []}
-                # The builder returns columns + rows.  Render each row as
-                # one logs_data entry — the message string concatenates the
-                # row's column values so the existing display table handles
-                # it without a per-report custom template.
+                    report = {
+                        "columns": [],
+                        "rows": [],
+                        "summary_lines": [],
+                        "window_start": None,
+                        "window_end": None,
+                    }
                 column_labels = [c.get("label", "") for c in report.get("columns", [])]
                 for row in report.get("rows", [])[:limit]:
                     cells = [str(c) if c is not None else "" for c in row]
+                    # Keep a readable fallback ``message`` for search matching
+                    # and the generic CSV export, but the template prefers
+                    # ``details`` (label→value) when ``report`` is set.
                     pairs = " · ".join(
                         f"{label}: {value}" for label, value in zip(column_labels, cells) if value
                     )
@@ -2234,16 +2255,17 @@ def register(app: Flask, logger) -> None:
                         'alert_identifier': None,
                         'details': dict(zip(column_labels, cells)),
                     })
-                # Append the summary lines as virtual entries at the top.
-                for summary in reversed(report.get("summary_lines", [])):
-                    logs_data.insert(0, {
-                        'timestamp': None,
-                        'level': 'SUCCESS',
-                        'module': f"report:{report_kind}",
-                        'message': summary,
-                        'alert_identifier': None,
-                        'details': {},
-                    })
+
+                report_meta = {
+                    'kind': report_kind,
+                    'title': report.get('title') or log_type_name,
+                    'subtitle': report.get('subtitle'),
+                    'columns': column_labels,
+                    'summary_lines': list(report.get('summary_lines') or []),
+                    'window_start': report.get('window_start'),
+                    'window_end': report.get('window_end'),
+                    'row_count': report.get('row_count', len(logs_data)),
+                }
 
         elif log_type == 'services':
             log_type_name = "Service Logs (systemd)"
@@ -2286,7 +2308,7 @@ def register(app: Flask, logger) -> None:
             logs_data.sort(key=get_sort_key, reverse=True)
             logs_data = logs_data[:limit]
 
-        return log_type_name, logs_data
+        return log_type_name, logs_data, report_meta
 
     @app.route("/logs")
     def logs():
@@ -2303,7 +2325,9 @@ def register(app: Flask, logger) -> None:
             service_filter = request.args.get('service', '').strip()
             alert_filter = request.args.get('alert', '').strip()
 
-            log_type_name, logs_data = _load_logs_data(log_type, limit, service_filter)
+            log_type_name, logs_data, report_meta = _load_logs_data(
+                log_type, limit, service_filter
+            )
 
             # Apply filters
             if search_query:
@@ -2392,6 +2416,7 @@ def register(app: Flask, logger) -> None:
                 alert_filter=alert_filter,
                 available_services=get_all_log_services(),
                 compliance_summary=compliance_summary,
+                report=report_meta,
             )
 
         except Exception as exc:  # pragma: no cover - fallback content
@@ -2413,7 +2438,7 @@ def register(app: Flask, logger) -> None:
             log_type = request.args.get('type', 'system')
             limit = min(int(request.args.get('limit', 100)), 500)
 
-            log_type_name, logs_data = _load_logs_data(log_type, limit)
+            log_type_name, logs_data, _report_meta = _load_logs_data(log_type, limit)
 
             # Create CSV in memory
             output = io.StringIO()
@@ -2461,7 +2486,7 @@ def register(app: Flask, logger) -> None:
 
             from datetime import datetime
 
-            log_type_name, logs_data = _load_logs_data(log_type, limit)
+            log_type_name, logs_data, _report_meta = _load_logs_data(log_type, limit)
 
             sections = []
 


### PR DESCRIPTION
The Received / Forwarded / Ignored / Initiated / Weekly / Monthly tabs
on /logs were rendering FCC reports through the generic log table:
every report column was concatenated into the "Message" cell as
"Label: value · Label: value · …". It was hard to scan on desktop and
unreadable on mobile.

Reports now render as:
- Summary metric cards (one per summary line) with the reporting window
- A real columnar table on desktop (one <th>/<td> per report column)
- Stacked per-row cards with label/value pairs on mobile

The generic log row mirror is kept so the existing search/level/date
filters and the /logs/export.csv path keep working unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FCC reports with new report-specific log types (report received, forwarded, ignored, initiated, weekly, and monthly).
  * Responsive report layout optimized for both desktop and mobile devices.
  * Report summary cards with window date range display.
  * Improved empty state messaging for filtered report views.

* **Style**
  * Enhanced visual formatting for report tables and mobile card layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->