### PR TITLE
Send Accept: application/json from scripted fetches; remove navbar se…

### DIFF
--- a/templates/admin/certbot.html
+++ b/templates/admin/certbot.html
@@ -1490,8 +1490,22 @@ async function executeRenewal() {
             },
             body: JSON.stringify({ dry_run: dry_run, force: force })
         });
-        
-        const result = await response.json();
+
+        // Read as text first so a non-JSON response (e.g. nginx 502/504,
+        // a Flask HTML error page, a session-expired redirect) produces
+        // an actionable message instead of "Unexpected token '<'".
+        const rawText = await response.text();
+        let result;
+        try {
+            result = JSON.parse(rawText);
+        } catch (parseErr) {
+            const snippet = (rawText || '').trim().slice(0, 500);
+            throw new Error(
+                `Server returned a non-JSON response (HTTP ${response.status} ${response.statusText}). ` +
+                `This usually means the request was killed by a gateway timeout or the server raised ` +
+                `an unhandled error. First 500 chars of response: ${snippet}`
+            );
+        }
         
         if (result.success) {
             let html = `

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,13 +42,23 @@
             window.fetch = function(input, init) {
                 init = init || {};
                 const method = (init.method || 'GET').toUpperCase();
+                const headers = new Headers(init.headers || {});
+
+                // Mark every scripted fetch as wanting JSON. Without this, the
+                // server's auth/permission helpers fall back to HTML responses
+                // (login redirects, error pages) on session expiry — JSON-parsing
+                // those in JS surfaces as the unhelpful "Unexpected token '<'".
+                if (!headers.has('Accept')) {
+                    headers.set('Accept', 'application/json');
+                }
+
                 if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-                    const headers = new Headers(init.headers || {});
                     if (window.CSRF_TOKEN && !headers.has('X-CSRF-Token')) {
                         headers.set('X-CSRF-Token', window.CSRF_TOKEN);
                     }
-                    init.headers = headers;
                 }
+
+                init.headers = headers;
                 return originalFetch.call(this, input, init);
             };
         })();

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -427,45 +427,6 @@
                     </li>
                 </ul>
 
-                <!-- Global Search (between primary nav and user nav) -->
-                {% if current_user is defined and current_user.is_authenticated %}
-                <form class="d-flex ms-auto me-2 my-2 my-lg-0" role="search"
-                      action="/search" method="get">
-                    <div class="input-group input-group-sm">
-                        <span class="input-group-text" id="global-search-prefix">
-                            <i class="fas fa-magnifying-glass"></i>
-                        </span>
-                        <input class="form-control form-control-sm"
-                               type="search"
-                               name="q"
-                               id="global-search-input"
-                               placeholder="Search alert ID, event, text…"
-                               aria-label="Global search"
-                               aria-describedby="global-search-prefix"
-                               autocomplete="off"
-                               style="min-width: 200px;">
-                        <button class="btn btn-outline-light btn-sm" type="submit"
-                                title="Search (press / to focus)">
-                            <i class="fas fa-arrow-right"></i>
-                        </button>
-                    </div>
-                </form>
-                <script>
-                    // Press "/" anywhere outside an input to focus the search.
-                    // Honours the GitHub/StackOverflow convention so operators
-                    // arriving from other tools find it immediately.
-                    (function () {
-                        document.addEventListener('keydown', function (e) {
-                            if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
-                            var tag = (e.target.tagName || '').toUpperCase();
-                            if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
-                            var box = document.getElementById('global-search-input');
-                            if (box) { e.preventDefault(); box.focus(); box.select(); }
-                        });
-                    })();
-                </script>
-                {% endif %}
-
                 <!-- User Navigation (Right Side) -->
                 <ul class="navbar-nav utility-nav">
                     {% if current_user is defined and current_user.is_authenticated %}


### PR DESCRIPTION
…arch

* base.html: have the global fetch wrapper set Accept: application/json on every scripted call that doesn't already have one. The auth helpers in app_core/auth/roles.py only return JSON when that header is set — otherwise a session expiry or permission denial returns an HTML redirect, which the JS then tries to JSON.parse and dies with "Unexpected token '<'". This was the source of the renewal error popup even though the certbot dry-run itself succeeded.

* certbot.html: in executeRenewal(), if the response can't be parsed as JSON, surface the HTTP status + a 500-char body snippet so any remaining non-JSON failures are debuggable instead of opaque.

* navbar.html: remove the global search form and its "/" keypress handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for certificate renewal failures with detailed diagnostic information.
  * Enhanced request handling to properly expect JSON responses during authentication scenarios.

* **Chores**
  * Removed global search functionality and keyboard shortcut from the navigation bar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->