### PR TITLE
Stop certbot renewals failing on chown EPERM in the archive directory

### DIFF
--- a/config/sudoers-eas-station
+++ b/config/sudoers-eas-station
@@ -22,6 +22,7 @@ eas-station ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /opt/eas-station/certbot_data/
 eas-station ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /opt/eas-station/certbot_data/work
 eas-station ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /opt/eas-station/certbot_data/logs
 eas-station ALL=(ALL) NOPASSWD: /usr/bin/chmod -R 777 /opt/eas-station/certbot_data
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/chown -R root\:root /opt/eas-station/certbot_data
 eas-station ALL=(ALL) NOPASSWD: /usr/bin/find /opt/eas-station/certbot_data -name .certbot.lock -delete
 eas-station ALL=(ALL) NOPASSWD: /usr/bin/cat /opt/eas-station/certbot_data/logs/letsencrypt.log
 

--- a/install.sh
+++ b/install.sh
@@ -1693,13 +1693,18 @@ else
     echo_warning "Sudoers configuration file not found (config/sudoers-eas-station)"
 fi
 
-# Create certbot data directories with proper permissions
-# These directories must be writable by both the eas-station user and root (for certbot via sudo)
+# Create certbot data directories with proper permissions.
+# Certbot runs as root (via sudo) and creates root-owned files. It also
+# calls os.chown() to mirror the previous cert's group onto the new key,
+# which fails with EPERM on hosts where AppArmor/user-namespace policy
+# blocks root from chowning to a non-root group. Keep the whole tree
+# owned by root:root so that copy_group step is a no-op; chmod 777
+# preserves read access for the eas-station user.
 echo_progress "Creating certbot data directories..."
 CERTBOT_DATA_DIR="$INSTALL_DIR/certbot_data"
 mkdir -p "$CERTBOT_DATA_DIR/config" "$CERTBOT_DATA_DIR/work" "$CERTBOT_DATA_DIR/logs"
 chmod -R 777 "$CERTBOT_DATA_DIR"
-chown -R "$SERVICE_USER:$SERVICE_USER" "$CERTBOT_DATA_DIR"
+chown -R root:root "$CERTBOT_DATA_DIR"
 echo_success "Certbot data directories created"
 
 # Create ACME challenge directory for certbot webroot method

--- a/update.sh
+++ b/update.sh
@@ -718,13 +718,17 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
         echo_warning "Sudoers configuration file not found (config/sudoers-eas-station)"
     fi
 
-    # Fix certbot data directories permissions
-    # These directories must be writable by both the eas-station user and root (for certbot via sudo)
+    # Fix certbot data directories permissions.
+    # Keep ownership root:root (not eas-station) so certbot's internal
+    # copy_ownership_and_apply_mode() step doesn't try to chown new key
+    # files to a non-root group — that chown fails with EPERM under
+    # AppArmor and aborts the renewal. chmod 777 preserves read access
+    # for the eas-station user.
     echo_progress "Fixing certbot data directories permissions..."
     CERTBOT_DATA_DIR="$INSTALL_DIR/certbot_data"
     mkdir -p "$CERTBOT_DATA_DIR/config" "$CERTBOT_DATA_DIR/work" "$CERTBOT_DATA_DIR/logs"
     chmod -R 777 "$CERTBOT_DATA_DIR"
-    chown -R "$SERVICE_USER:$SERVICE_USER" "$CERTBOT_DATA_DIR"
+    chown -R root:root "$CERTBOT_DATA_DIR"
     # Remove any stale lock files that can cause permission errors
     find "$CERTBOT_DATA_DIR" -name ".certbot.lock" -delete 2>/dev/null || true
     echo_success "Certbot data directories configured"

--- a/webapp/admin/certbot.py
+++ b/webapp/admin/certbot.py
@@ -61,9 +61,28 @@ CERTBOT_LOGS_DIR = CERTBOT_BASE_DIR / 'logs'
 # Use standalone or webroot modes instead.
 
 
+def _explain_certbot_failure(stderr: str, stdout: str) -> str:
+    """Return a human-readable hint prepended to certbot stderr when we
+    recognize the failure mode, so the UI surfaces a remediation step
+    instead of an opaque traceback.
+    """
+    blob = f"{stderr}\n{stdout}"
+    raw = (stderr or stdout or "").strip()
+    if "Operation not permitted" in blob and "/archive/" in blob and ".pem" in blob:
+        return (
+            "Certbot failed while chowning a new key file under the certbot "
+            "archive directory. This usually means existing files there are "
+            "owned by the eas-station user (left over from an older install) "
+            "and the kernel/AppArmor is denying root the chown to that group. "
+            "Re-run `update.sh` (or `sudo chown -R root:root "
+            f"{CERTBOT_BASE_DIR}`) and try again.\n\nOriginal error:\n{raw}"
+        )
+    return raw
+
+
 def _ensure_webroot_directory():
     """Ensure webroot directory exists with proper permissions for certbot.
-    
+
     The webroot directory must be writable by root (certbot runs as root via sudo)
     and readable by nginx (www-data) to serve the ACME challenge files.
     
@@ -132,6 +151,22 @@ def _ensure_certbot_directories():
         # Fix permissions on the entire certbot_data directory tree
         subprocess.run(
             ['sudo', 'chmod', '-R', '777', str(CERTBOT_BASE_DIR)],
+            capture_output=True,
+            timeout=10
+        )
+
+        # Normalize ownership to root:root. Certbot runs as root and calls
+        # copy_ownership_and_apply_mode(old_key, new_key, copy_group=True),
+        # which translates to os.chown(new_key, -1, old_key_gid). On hosts
+        # where that chown returns EPERM (AppArmor profile, user namespaces,
+        # certain bind-mounts), the renewal aborts with
+        #     PermissionError: [Errno 1] Operation not permitted:
+        #     '.../archive/<domain>/privkeyN.pem'
+        # Leaving the tree owned by root makes the copy-group step a no-op
+        # so the failure cannot recur. The chmod 777 above keeps read access
+        # for the eas-station user.
+        subprocess.run(
+            ['sudo', 'chown', '-R', 'root:root', str(CERTBOT_BASE_DIR)],
             capture_output=True,
             timeout=10
         )
@@ -1277,13 +1312,13 @@ def obtain_certificate_execute():
                     logger.error(f"Failed to restart nginx: {start_result.stderr}")
                 
                 if certbot_result.returncode != 0:
-                    error_msg = certbot_result.stderr
-                    
+                    error_msg = _explain_certbot_failure(certbot_result.stderr, certbot_result.stdout)
+
                     # Log the full error for debugging
                     logger.error(f"Certbot standalone failed with return code {certbot_result.returncode}")
-                    logger.error(f"Certbot stderr: {error_msg}")
+                    logger.error(f"Certbot stderr: {certbot_result.stderr}")
                     logger.error(f"Certbot stdout: {certbot_result.stdout}")
-                    
+
                     # Check for common permission errors and provide helpful messages
                     if "Permission denied" in error_msg or "Errno 13" in error_msg:
                         error_msg = (
@@ -1603,9 +1638,10 @@ def renew_certificate_execute():
             if result.returncode != 0:
                 logger.error(f"Certbot renewal failed: {result.stderr}")
                 logger.error(f"Certbot stdout: {result.stdout}")
+                explained = _explain_certbot_failure(result.stderr, result.stdout)
                 return jsonify({
                     "success": False,
-                    "error": f"Certbot renew failed: {result.stderr}",
+                    "error": f"Certbot renew failed: {explained}",
                     "output": result.stdout
                 }), 500
             


### PR DESCRIPTION
Certbot internally calls copy_ownership_and_apply_mode(old_key, new_key, copy_group=True) when saving a renewed lineage, which becomes os.chown(new_key, -1, old_key_gid). On hosts where AppArmor / user namespaces / certain bind mounts deny root the right to chown a file to a non-root group, the renewal aborts with:

    PermissionError: [Errno 1] Operation not permitted:
    '/opt/eas-station/certbot_data/config/archive/<domain>/privkeyN.pem'

The trigger was install.sh/update.sh chowning the whole certbot_data tree to eas-station:eas-station, so each new key file (root-owned) had to be chowned to that group on every renewal.

Keep the tree owned by root:root so the copy-group step is a no-op:
* install.sh / update.sh: chown root:root instead of $SERVICE_USER
* _ensure_certbot_directories: re-chown to root:root on every web request that touches certbot, to fix already-broken hosts
* sudoers: add the matching NOPASSWD entry for the chown

Also add _explain_certbot_failure() so the next time this pattern appears in stderr the UI shows a remediation hint pointing at the chown / update.sh, instead of the raw traceback.