### PR TITLE
Reflect the 5-subsystem hardware split on the about page

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -364,9 +364,37 @@
                     </div>
                     <div class="col-md-6 col-lg-4">
                         <div class="feature-card fc-orange">
-                            <div class="feature-card-icon"><i class="fas fa-sliders"></i></div>
-                            <h5 class="feature-card-title">hardware-service</h5>
-                            <p class="feature-card-text">GPIO relays, OLED/VFD displays, LED sign protocols. <em>I2C/GPIO access.</em></p>
+                            <div class="feature-card-icon"><i class="fas fa-network-wired"></i></div>
+                            <h5 class="feature-card-title">hardware: network</h5>
+                            <p class="feature-card-text">nmcli proxy, DNS, hostname, link diagnostics. <em>Port 5101.</em></p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-orange">
+                            <div class="feature-card-icon"><i class="fas fa-tower-broadcast"></i></div>
+                            <h5 class="feature-card-title">hardware: zigbee</h5>
+                            <p class="feature-card-text">zigpy-znp coordinator, join window, paired devices. <em>USB serial. Port 5102.</em></p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-orange">
+                            <div class="feature-card-icon"><i class="fas fa-satellite"></i></div>
+                            <h5 class="feature-card-title">hardware: gps</h5>
+                            <p class="feature-card-text">GPSManager, NMEA + PPS, trend archive. <em>UART. Port 5103.</em></p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-orange">
+                            <div class="feature-card-icon"><i class="fas fa-display"></i></div>
+                            <h5 class="feature-card-title">hardware: displays</h5>
+                            <p class="feature-card-text">OLED, LED sign, VFD, screen rotation manager. <em>I2C / SPI / serial. Port 5104.</em></p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-orange">
+                            <div class="feature-card-icon"><i class="fas fa-plug"></i></div>
+                            <h5 class="feature-card-title">hardware: gpio</h5>
+                            <p class="feature-card-text">GPIO controller, tower light, NeoPixel, status indicators. <em>GPIO. Port 5105.</em></p>
                         </div>
                     </div>
                     <div class="col-md-6 col-lg-4">
@@ -393,7 +421,7 @@
                 </div>
                 <div class="alert alert-info mt-4 mb-0 d-flex align-items-start" role="alert">
                     <i class="fas fa-circle-info me-2 mt-1"></i>
-                    <div><strong>Why separated?</strong> A web UI crash won't affect audio processing, and a hardware failure won't take down the dashboard. Every service restarts independently.</div>
+                    <div><strong>Why separated?</strong> A web UI crash won't affect audio processing, and a wedged Zigbee dongle won't block OLED renders or take down the GPS time source. Every service — including each of the five hardware subsystems — restarts independently under <code>eas-station-hardware.target</code>.</div>
                 </div>
             </section>
 


### PR DESCRIPTION
Phases 4/5 replaced the monolithic hardware-service with five per-subsystem processes, but the architecture section of about.html still showed it as one card. Replaces the single card with five peer cards (network/zigbee/gps/displays/gpio) sharing the hardware-family colour, each labelled with its port (5101-5105) and bus access. Updates the "Why separated?" callout to mention subsystem-level isolation explicitly — a wedged Zigbee dongle no longer blocks OLED renders.

The card-grid order keeps the hardware subsystems contiguous so the architectural grouping (web, capture, hardware, ingest, cache, storage) still reads cleanly even at 10 cards.

https://claude.ai/code/session_01HNPJB8zaHpVcQj1twEd1Jt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated About page with individual hardware subsystem details including network, zigbee, GPS, displays, and GPIO, each with dedicated card displays and port numbers.
  * Enhanced service architecture explanation with clarified isolation and independent restart information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->