### PR TITLE
Enforce FCC RWT compliance and persist audio blobs to database

### DIFF
--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -40,6 +40,7 @@ from app_utils.eas import (
     build_same_header,
     load_eas_config,
     manual_default_same_codes,
+    samples_to_wav_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -203,32 +204,61 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
             location_settings=None,
         )
 
-        # Generate audio components
+        # Generate audio components. RWT enforcement (no Attention Signal,
+        # no TTS) is hardcoded inside build_manual_components() per
+        # FCC 47 CFR §11.61(a)(1)(ii); we don't pass tone_profile/include_tts
+        # here so there is no way for this path to request otherwise.
         generator = EASAudioGenerator(eas_config, logger=log)
-
-        # For RWT: no TTS, no attention tones (will be auto-detected by event code)
-        components = generator.build_manual_components(
-            alert_object,
-            header,
-            tone_profile='none',
-            include_tts=False,
-        )
+        components = generator.build_manual_components(alert_object, header)
 
         if not components:
             raise ValueError("Failed to generate RWT audio components")
 
-        # Store in database.  ``manual_eas_activations.storage_path`` is
-        # NOT NULL at the schema level (it carries the on-disk directory
-        # relative to EAS_OUTPUT_DIR for operator-triggered broadcasts —
-        # see webapp/eas/workflow.py).  Automated RWTs don't write any
-        # files; the audio is generated in-memory and persisted to the
-        # blob columns at the application layer.  Pass an empty string so
-        # the NOT NULL constraint is satisfied and so the cleanup
-        # path in _remove_manual_eas_files() (which guards on
-        # ``if not activation.storage_path: return``) treats RWT rows as
-        # "no on-disk files to delete".  Previously this field was left
-        # unset and every automatic fire failed with psycopg2
-        # NotNullViolation, so RWT had never successfully fired.
+        sample_rate = int(eas_config.get('sample_rate', 16000) or 16000)
+
+        # Render the in-memory sample arrays to WAV blobs for the database.
+        # Automated RWTs never write to disk — playback streams from these
+        # blob columns (see admin/audio.py:1153 and the activation detail
+        # page), and storage_path stays empty so _remove_manual_eas_files()
+        # treats the row as "no on-disk files to delete".
+        def _wav(key: str) -> Optional[bytes]:
+            samples = components.get(key) or []
+            if not samples:
+                return None
+            return samples_to_wav_bytes(samples, sample_rate)
+
+        def _meta(key: str, suffix: str, wav_bytes: Optional[bytes]) -> Optional[Dict[str, Any]]:
+            if not wav_bytes:
+                return None
+            samples = components.get(key) or []
+            return {
+                'filename': f'{identifier}_{suffix}.wav',
+                'duration_seconds': round(len(samples) / sample_rate, 3),
+                'size_bytes': len(wav_bytes),
+                'storage_subpath': '',
+            }
+
+        same_wav = _wav('same_samples')
+        eom_wav = _wav('eom_samples')
+        composite_wav = _wav('composite_samples')
+
+        components_payload: Dict[str, Any] = {}
+        for component_key, sample_key, suffix, wav in (
+            ('same', 'same_samples', 'same', same_wav),
+            ('eom', 'eom_samples', 'eom', eom_wav),
+            ('composite', 'composite_samples', 'full', composite_wav),
+        ):
+            entry = _meta(sample_key, suffix, wav)
+            if entry:
+                components_payload[component_key] = entry
+
+        # Archive any previously-active rows so the detail page surfaces the
+        # newest RWT as the current activation (mirrors the manual workflow
+        # at webapp/eas/workflow.py:695-697).
+        ManualEASActivation.query.filter(
+            ManualEASActivation.archived_at.is_(None)
+        ).update({'archived_at': now}, synchronize_session=False)
+
         activation_record = ManualEASActivation(
             identifier=identifier,
             event_code='RWT',
@@ -239,7 +269,7 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
             same_locations=formatted_locations,
             tone_profile='none',
             tone_seconds=0.0,
-            sample_rate=eas_config.get('sample_rate', 16000),
+            sample_rate=sample_rate,
             includes_tts=False,
             sent_at=now,
             expires_at=now + timedelta(minutes=15),
@@ -248,10 +278,14 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
             instruction_text='No action required. This is only a test.',
             duration_minutes=15,
             storage_path='',
+            components_payload=components_payload,
             metadata_payload={
                 'automated': True,
                 'schedule_id': config.id,
             },
+            composite_audio_data=composite_wav,
+            same_audio_data=same_wav,
+            eom_audio_data=eom_wav,
         )
 
         db.session.add(activation_record)

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -2819,7 +2819,6 @@ class EASAudioGenerator:
         include_tts: bool = True,
         silence_between_headers: float = 1.0,
         silence_after_header: float = 1.0,
-        force_rwt_defaults: bool = True,
         narration_upload_samples: Optional[List[int]] = None,
         pre_alert_samples: Optional[List[int]] = None,
         post_alert_samples: Optional[List[int]] = None,
@@ -2832,14 +2831,12 @@ class EASAudioGenerator:
             if len(parts) > 2:
                 event_code = parts[2].strip().upper()
 
-        # For RWT (Required Weekly Test), optionally disable TTS and attention tones
-        # By default (force_rwt_defaults=True), RWT only has SAME header and EOM tones
-        # Set force_rwt_defaults=False to allow TTS and attention tones for RWT
-        if event_code == 'RWT' and force_rwt_defaults:
+        # FCC 47 CFR §11.61(a)(1)(ii): the Required Weekly Test does not carry
+        # the two-tone Attention Signal and does not include voice narration.
+        # The RWT is SAME header + EOM only — no exceptions, no override.
+        if event_code == 'RWT':
             include_tts = False
             tone_profile = 'none'
-            if self.logger:
-                self.logger.info("RWT detected: disabling TTS narration and attention tones (use force_rwt_defaults=False to override)")
 
         amplitude = 0.7 * 32767
         same_bits = encode_same_bits(header, include_preamble=True)

--- a/templates/eas/workflow.html
+++ b/templates/eas/workflow.html
@@ -1145,6 +1145,26 @@ function updateEventName() {
     const target = document.getElementById('eventNameInput');
     const code = select.value;
     target.value = EVENT_LOOKUP[code] || target.value;
+    applyRwtToneLock(code);
+}
+
+// FCC 47 CFR §11.61(a)(1)(ii): the Required Weekly Test has no Attention
+// Signal and no voice narration. Lock the tone selector to "none" whenever
+// RWT is selected so the operator can't request a tone the backend will
+// silently discard.
+function applyRwtToneLock(eventCode) {
+    const toneSelect = document.getElementById('toneProfileSelect');
+    if (!toneSelect) return;
+    const isRwt = (eventCode || '').toUpperCase() === 'RWT';
+    if (isRwt) {
+        toneSelect.value = 'none';
+        toneSelect.disabled = true;
+        toneSelect.title = 'RWT broadcasts cannot include the Attention Signal (FCC §11.61).';
+    } else {
+        toneSelect.disabled = false;
+        toneSelect.title = '';
+    }
+    updateToneControls();
 }
 
 function applyDefaultCodes() {
@@ -1708,6 +1728,9 @@ function initialiseWorkflow() {
     const eventSelect = document.getElementById('eventCodeSelect');
     if (eventSelect) {
         eventSelect.addEventListener('change', updateEventName);
+        // Apply the RWT tone-lock immediately so the default-selected event
+        // (RWT) loads with the tone selector already disabled.
+        applyRwtToneLock(eventSelect.value);
     }
 
     const loadDefaultsBtn = document.getElementById('loadDefaultCodes');

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -431,16 +431,14 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
 
         generator = EASAudioGenerator(manual_config, logger=workflow_logger)
 
-        # For RWT events, respect user's TTS choice if they explicitly enabled it
-        # By default (force_rwt_defaults=True), RWT disables TTS and attention tones per EAS spec
-        # If user explicitly requests TTS for RWT (include_tts=True), set force_rwt_defaults=False
-        # to honor their choice. For non-RWT events, force_rwt_defaults has no effect.
-        if event_code == 'RWT' and include_tts:
-            # User wants TTS for RWT - override the default RWT behavior
-            force_rwt_defaults = False
-        else:
-            # Use default behavior (RWT disables TTS, other events keep user's choice)
-            force_rwt_defaults = True
+        # FCC 47 CFR §11.61(a)(1)(ii): RWT carries SAME header + EOM only —
+        # no Attention Signal, no voice narration. Enforced unconditionally
+        # in build_manual_components(); mirror it here so the saved record
+        # reflects what was actually broadcast.
+        if event_code == 'RWT':
+            tone_profile = 'none'
+            tone_seconds = 0.0
+            include_tts = False
 
         # Process uploaded audio files (only present in multipart requests)
         uploaded_narration = _read_upload_file('narration_audio', workflow_logger)
@@ -454,7 +452,6 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 tone_profile=tone_profile,
                 tone_duration=tone_seconds,
                 include_tts=include_tts,
-                force_rwt_defaults=force_rwt_defaults,
                 narration_upload_samples=uploaded_narration,
                 pre_alert_samples=uploaded_pre_alert,
                 post_alert_samples=uploaded_post_alert,


### PR DESCRIPTION
## Summary
This PR hardens Required Weekly Test (RWT) compliance with FCC 47 CFR §11.61(a)(1)(ii) by unconditionally enforcing the RWT specification (SAME header + EOM only, no Attention Signal, no TTS) at all code paths, and implements proper persistence of generated audio to the database as WAV blobs instead of relying on disk storage.

## Key Changes

- **RWT Compliance Enforcement**: Removed the `force_rwt_defaults` parameter and made RWT restrictions unconditional in `build_manual_components()`. RWT now always disables TTS and Attention Signal regardless of user input or configuration.

- **Audio Blob Persistence**: Automated RWT broadcasts now render in-memory sample arrays to WAV bytes and store them in `composite_audio_data`, `same_audio_data`, and `eom_audio_data` database columns. Previously, RWT activations failed with `NotNullViolation` on the `storage_path` field.

- **Components Metadata**: Added `components_payload` to track audio component metadata (filename, duration, size) for each generated audio segment, enabling the detail page to display playback information.

- **Previous Activation Archival**: Automated RWT broadcasts now archive any previously-active manual activations before creating a new record, mirroring the manual workflow behavior so the detail page surfaces the newest RWT as current.

- **UI Enforcement**: Added `applyRwtToneLock()` function to disable the tone selector when RWT is selected in the manual workflow form, preventing operators from requesting tones that the backend will silently discard.

- **Workflow Simplification**: Removed conditional RWT handling in `webapp/eas/workflow.py` since RWT restrictions are now enforced unconditionally in the generator, eliminating the need for parameter negotiation.

## Implementation Details

- Imported `samples_to_wav_bytes` utility to convert sample arrays to WAV format
- Sample rate is extracted once and reused for all WAV conversions and duration calculations
- Helper functions `_wav()` and `_meta()` encapsulate the conversion logic for cleaner code
- RWT tone-lock is applied on page load to ensure the default-selected RWT event loads with the selector already disabled
- Comments reference the specific FCC regulation to document the compliance requirement

https://claude.ai/code/session_0155hMxXmXCUiBKtE3reHwLE