### PR TITLE
Improve PPS refclock precision and stability in chrony configuration

### DIFF
--- a/bin/eas-station-hwsetup
+++ b/bin/eas-station-hwsetup
@@ -973,7 +973,16 @@ def _build_chrony_block(
         if user_has_refclock_pps:
             skipped.append(f"refclock PPS {pps_device} (already in user-authored section)")
         else:
-            payload.append(f"refclock PPS {pps_device} lock GPS refid PPS")
+            # precision 1e-7 reflects the ~100 ns class edge at the GPIO pin
+            # before IRQ latency; filter 16 takes the median of a sliding
+            # window which lops off the IRQ-tail outliers that dominate
+            # peak jitter on pps-gpio; prefer makes PPS the selected source
+            # over any pool/server entries the user has; maxlockage 2 stops
+            # PPS from being used if the NMEA seconds-reference goes stale.
+            payload.append(
+                f"refclock PPS {pps_device} lock GPS refid PPS "
+                "precision 1e-7 filter 16 prefer maxlockage 2"
+            )
     if not payload:
         return "", skipped
     block_lines = [_CHRONY_BLOCK_BEGIN, *payload, _CHRONY_BLOCK_END]

--- a/docs/hardware/GPS_HAT_SETUP.md
+++ b/docs/hardware/GPS_HAT_SETUP.md
@@ -346,7 +346,12 @@ Edit `/etc/chrony/chrony.conf`, adding:
 refclock SHM 0 offset 0.5 delay 0.2 refid GPS
 
 # GPS PPS (high precision — requires NMEA fix from above)
-refclock PPS /dev/pps0 lock GPS refid PPS
+#   precision 1e-7  : weight the edge as ~100 ns class (true at the GPIO pin)
+#   filter 16       : median-of-16 cuts the IRQ-latency tail you get with
+#                     pps-gpio on a Pi (single biggest knob for peak jitter)
+#   prefer          : pick PPS over any pool/server time sources
+#   maxlockage 2    : ignore PPS if the NMEA seconds reference goes stale
+refclock PPS /dev/pps0 lock GPS refid PPS precision 1e-7 filter 16 prefer maxlockage 2
 ```
 
 Restart chrony:


### PR DESCRIPTION
## Summary
Enhanced the GPS PPS (Pulse Per Second) refclock configuration in chrony to improve timing precision and stability by adding precision, filter, prefer, and maxlockage parameters.

## Key Changes
- **Updated `bin/eas-station-hwsetup`**: Modified the PPS refclock configuration generation to include four new parameters:
  - `precision 1e-7`: Reflects the ~100 ns class edge timing at the GPIO pin before IRQ latency
  - `filter 16`: Uses median-of-16 filtering to eliminate IRQ-tail outliers that dominate peak jitter on pps-gpio
  - `prefer`: Makes PPS the preferred time source over pool/server entries
  - `maxlockage 2`: Prevents stale PPS usage if the NMEA seconds reference becomes unavailable

- **Updated `docs/hardware/GPS_HAT_SETUP.md`**: Added detailed inline documentation explaining each parameter's purpose and rationale

## Implementation Details
The changes address known timing issues with PPS-GPIO on Raspberry Pi systems by:
1. Properly weighting the PPS edge precision based on actual GPIO pin timing characteristics
2. Filtering out IRQ latency artifacts that are the primary source of jitter
3. Ensuring PPS is prioritized as the timing reference when available
4. Adding a safety mechanism to fall back to other sources if the NMEA reference becomes stale

Both the automated setup script and manual configuration documentation have been updated consistently to ensure users receive the same optimized configuration regardless of setup method.

https://claude.ai/code/session_013KGFGfY7FbeU2jZWxQF8sA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GPS HAT setup documentation with enhanced PPS refclock configuration including precision, filter, and lockage parameters with explanatory comments.

* **Chores**
  * Improved hardware setup scripts with richer PPS refclock directives for optimized GPS synchronization performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->