### PR TITLE
Fix stability metric severity thresholds to match documentation

### DIFF
--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -3620,11 +3620,17 @@
         setTileSeverity(uEl, uSev);
         if (uEl) uEl.querySelector('.metric-val').textContent = (pct !== null) ? pct + '%' : '—';
 
-        // Stability (Allan dev at τ=10s).
+        // Stability (Allan dev at τ=10s).  Severity ladder mirrors the
+        // 5-bucket healthy-range table in the help popover
+        // ('stability-tau10'): excellent/good/acceptable all collapse
+        // to ok, watch → warn, bad → fault.  The previous thresholds
+        // started warning at 1e-9 and faulting at 1e-7, which was a
+        // decade tighter than the documented ranges and painted
+        // perfectly normal watch-zone readings as faults.
         var sEl = document.getElementById('qm-stability');
         var sSev = (adev10 === null) ? 'unknown'
-                 : (adev10 <= 1e-9) ? 'ok'
-                 : (adev10 <= 1e-7) ? 'warn'
+                 : (adev10 <= 1e-7) ? 'ok'
+                 : (adev10 <= 1e-6) ? 'warn'
                  : 'fault';
         setTileSeverity(sEl, sSev);
         if (sEl) sEl.querySelector('.metric-val').textContent = (adev10 !== null) ? fmtAdev(adev10) : '—';


### PR DESCRIPTION
## Summary
Corrected the Allan deviation (τ=10s) severity thresholds in the GPS dashboard to align with the documented healthy-range table and prevent false fault warnings for normal readings.

## Key Changes
- Updated stability severity thresholds:
  - `ok` range: changed from `≤ 1e-9` to `≤ 1e-7`
  - `warn` range: changed from `≤ 1e-7` to `≤ 1e-6`
  - `fault` range: now applies to values `> 1e-6`
- Added detailed comments explaining the rationale for the threshold adjustments

## Implementation Details
The previous thresholds were a decade tighter than the documented ranges in the help popover, causing readings that fell within the normal "watch zone" to be incorrectly flagged as faults. The new thresholds now properly map the 5-bucket healthy-range table to the 3-level severity system (excellent/good/acceptable → ok, watch → warn, bad → fault), eliminating false alarms for perfectly normal stability measurements.

https://claude.ai/code/session_013KGFGfY7FbeU2jZWxQF8sA