### PR TITLE
zones: resolve marine SAME codes in the header parser and give upload…

### DIFF
--- a/app_core/location.py
+++ b/app_core/location.py
@@ -30,7 +30,7 @@ from flask import current_app, has_app_context
 from app_utils.fips_codes import (
     NATIONWIDE_SAME_CODE,
     STATE_ABBR_NAMES,
-    get_same_lookup,
+    get_extended_same_lookup,
     get_us_state_county_tree,
 )
 from app_utils.location_settings import (
@@ -368,7 +368,7 @@ def describe_location_reference(
 
         known_zones.append(zone_details)
 
-    same_lookup = get_same_lookup()
+    same_lookup = get_extended_same_lookup()
     known_fips: List[Dict[str, Any]] = []
     missing_fips: List[str] = []
     for raw_code in snapshot.get("fips_codes", []) or []:

--- a/app_core/notifications/email.py
+++ b/app_core/notifications/email.py
@@ -25,7 +25,7 @@ from email.message import EmailMessage
 from typing import Any, Dict, List, Optional, Tuple
 
 from app_utils.event_codes import EVENT_CODE_REGISTRY
-from app_utils.fips_codes import get_same_lookup
+from app_utils.fips_codes import get_extended_same_lookup
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ def send_eas_alert_email(
     event_name = event_entry.get("name") if event_entry else None
     event_label = f"{event_code} - {event_name}" if event_name else event_code
 
-    fips_lookup = get_same_lookup()
+    fips_lookup = get_extended_same_lookup()
     location_labels = []
     for code in location_codes:
         name = fips_lookup.get(code)

--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -37,7 +37,7 @@ import numpy as np
 
 from .eas import ORIGINATOR_DESCRIPTIONS, decode_county_originator, describe_same_header
 from .eas_fsk import SAME_BAUD, SAME_MARK_FREQ, SAME_SPACE_FREQ, encode_same_bits
-from .fips_codes import get_same_lookup
+from .fips_codes import get_extended_same_lookup
 from .eas_demod import (
     SAMEDemodulatorCore,
     apply_bandpass_filter as _apply_bandpass_filter,
@@ -1551,7 +1551,7 @@ def _decode_from_samples(
                             decoded_header = decoded_header[zczc_idx:]
 
                         raw_text = decoded_header + "\r"
-                        fips_lookup = get_same_lookup()
+                        fips_lookup = get_extended_same_lookup()
                         header_fields = describe_same_header(
                             decoded_header, lookup=fips_lookup
                         )
@@ -1640,7 +1640,7 @@ def _decode_from_samples(
     use_dll = dll_has_complete and not goertzel_all_complete
 
     if metadata_headers and not use_dll:
-        fips_lookup = get_same_lookup()
+        fips_lookup = get_extended_same_lookup()
         headers: List[SAMEHeaderDetails] = []
         for header in metadata_headers:
             fields = describe_same_header(header, lookup=fips_lookup)

--- a/app_utils/fips_codes.py
+++ b/app_utils/fips_codes.py
@@ -3821,3 +3821,38 @@ def get_extended_state_county_tree() -> List[Dict[str, object]]:
     """
 
     return get_us_state_county_tree() + get_marine_state_tree()
+
+
+def get_extended_same_lookup() -> Dict[str, str]:
+    """Return a SAME-code → description map covering U.S. + marine areas.
+
+    The static :func:`get_same_lookup` only knows U.S. Census-state codes.
+    Marine SAME codes (``077650`` Gulf of Mexico, ``091000`` Lake
+    Superior, etc.) live in ``nws_zones`` and only become resolvable
+    once an operator uploads the NWS marine zone DBF. This function
+    merges the static lookup with a marine lookup derived from
+    :func:`get_marine_state_tree`, so any caller decoding a SAME header
+    for display gets human-readable names for both kinds of code.
+
+    Returns a fresh dict (not a MappingProxyType) because we mutate it
+    by merging in DB-derived entries. Never raises; if the DB isn't
+    reachable, the returned dict is just the static U.S. lookup.
+    """
+
+    merged: Dict[str, str] = dict(_US_FIPS_LOOKUP_PROXY)
+
+    for marine_state in get_marine_state_tree():
+        statewide_code = marine_state.get("statewide_code")
+        state_name = str(marine_state.get("name") or marine_state.get("abbr") or "")
+        if isinstance(statewide_code, str) and statewide_code:
+            merged.setdefault(statewide_code, f"All Areas, {state_name}")
+        for area in marine_state.get("counties", []) or []:
+            code = area.get("code")
+            name = area.get("name")
+            if isinstance(code, str) and code and isinstance(name, str) and name:
+                # Marine catalog wins over any (defensively unlikely)
+                # collision with a static U.S. code, because the
+                # operator explicitly loaded it.
+                merged[code] = name
+
+    return merged

--- a/templates/admin/zones.html
+++ b/templates/admin/zones.html
@@ -143,10 +143,11 @@
                                     <input type="file" class="form-control" id="zone-file" name="file" accept=".dbf" required>
                                     <div class="form-text">Only .dbf (dBase) files are accepted.</div>
                                 </div>
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" id="upload-btn" class="btn btn-primary">
                                     <i class="fas fa-upload"></i> Upload and Load
                                 </button>
                             </form>
+                            <div id="upload-status" class="mt-3" role="status" aria-live="polite"></div>
                         </div>
                         <div class="col-md-6 mb-3">
                             <h6>Reload Zone Catalog</h6>
@@ -229,35 +230,79 @@ function createToastContainer() {
 }
 
 // Upload form handler
+const uploadBtn = document.getElementById('upload-btn');
+const uploadStatus = document.getElementById('upload-status');
+const uploadOriginalBtnHtml = uploadBtn ? uploadBtn.innerHTML : '';
+
+function setUploadStatus(kind, message) {
+    if (!uploadStatus) return;
+    // kind: 'info' | 'success' | 'danger' | ''
+    if (!kind) {
+        uploadStatus.innerHTML = '';
+        return;
+    }
+    const icon = ({
+        info: 'fa-spinner fa-spin',
+        success: 'fa-check-circle',
+        danger: 'fa-exclamation-triangle',
+    })[kind] || 'fa-info-circle';
+    uploadStatus.innerHTML = `<div class="alert alert-${kind} mb-0"><i class="fas ${icon} me-2"></i>${message}</div>`;
+}
+
 document.getElementById('upload-form').addEventListener('submit', async (e) => {
     e.preventDefault();
-    
+
     const formData = new FormData(e.target);
     const fileInput = document.getElementById('zone-file');
-    
+
     if (!fileInput.files.length) {
+        setUploadStatus('danger', 'Please select a .dbf file.');
         showToast('Please select a file', 'warning');
         return;
     }
-    
+
+    const file = fileInput.files[0];
+    const sizeKb = Math.round(file.size / 1024);
+    setUploadStatus('info', `Uploading <strong>${file.name}</strong> (${sizeKb.toLocaleString()} KB) and parsing zones&hellip; this can take 10&ndash;30 s for a full national catalog.`);
+
+    if (uploadBtn) {
+        uploadBtn.disabled = true;
+        uploadBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Uploading&hellip;';
+    }
+
     try {
         const response = await fetch('/admin/zones/upload', {
             method: 'POST',
             body: formData
         });
-        
-        const data = await response.json();
-        
-        if (response.ok && data.success) {
-            showToast(data.message, 'success');
-            // Reset form and refresh info
+
+        let data = null;
+        try { data = await response.json(); } catch (_) { data = null; }
+
+        if (response.ok && data && data.success) {
+            const detail = [
+                data.message || 'Upload complete.',
+                data.schema ? `Schema detected: <code>${data.schema}</code>.` : '',
+                data.zone_count != null ? `<code>nws_zones</code> now contains <strong>${data.zone_count.toLocaleString()}</strong> rows.` : '',
+                data.warning ? `Warning: ${data.warning}.` : '',
+            ].filter(Boolean).join(' ');
+            setUploadStatus(data.warning ? 'danger' : 'success', detail);
+            showToast(data.message || 'Upload complete.', data.warning ? 'warning' : 'success');
             e.target.reset();
             refreshInfo();
         } else {
-            showToast(data.error || 'Upload failed', 'danger');
+            const errMsg = (data && (data.error || data.message)) || `HTTP ${response.status} ${response.statusText}`;
+            setUploadStatus('danger', `Upload failed: <code>${errMsg}</code>`);
+            showToast('Upload failed: ' + errMsg, 'danger');
         }
     } catch (error) {
+        setUploadStatus('danger', `Error uploading file: <code>${error.message}</code>`);
         showToast('Error uploading file: ' + error.message, 'danger');
+    } finally {
+        if (uploadBtn) {
+            uploadBtn.disabled = false;
+            uploadBtn.innerHTML = uploadOriginalBtnHtml;
+        }
     }
 });
 

--- a/webapp/admin/api.py
+++ b/webapp/admin/api.py
@@ -682,8 +682,8 @@ def _extract_alert_display_data(alert) -> Optional[Dict[str, Any]]:
 
         # Decode SAME codes to location names
         try:
-            from app_utils.fips_codes import get_same_lookup
-            fips_lookup = get_same_lookup()
+            from app_utils.fips_codes import get_extended_same_lookup
+            fips_lookup = get_extended_same_lookup()
             decoded_same = []
             for code in same_codes:
                 label = fips_lookup.get(code, '')

--- a/webapp/admin/audio.py
+++ b/webapp/admin/audio.py
@@ -65,7 +65,7 @@ from app_utils.eas import (
     samples_to_wav_bytes,
 )
 from app_utils.event_codes import EVENT_CODE_REGISTRY
-from app_utils.fips_codes import get_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
 
 
 # Create Blueprint for audio routes
@@ -901,7 +901,7 @@ def admin_manual_eas_generate():
         for state in state_tree
         if state.get('state_fips')
     }
-    same_lookup = get_same_lookup()
+    same_lookup = get_extended_same_lookup()
     header_detail = describe_same_header(header, lookup=same_lookup, state_index=state_index)
 
     same_component = _package_audio(components.get('same_samples') or [], 'same')
@@ -1228,7 +1228,7 @@ def manual_eas_print(event_id: int):
         for state in state_tree
         if state.get('state_fips')
     }
-    same_lookup = get_same_lookup()
+    same_lookup = get_extended_same_lookup()
     header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 
     return render_template(

--- a/webapp/admin/audio/detail.py
+++ b/webapp/admin/audio/detail.py
@@ -29,7 +29,7 @@ from flask import flash, redirect, render_template, url_for, Response
 from app_core.models import CAPAlert, EASMessage
 from app_core.eas_storage import get_eas_static_prefix, load_or_cache_summary_payload, format_local_datetime
 from app_utils.eas import describe_same_header
-from app_utils.fips_codes import get_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
 from app_utils.pdf_generator import generate_pdf_document
 
 
@@ -334,7 +334,7 @@ def _build_location_details(
     if not header:
         return []
 
-    lookup_map = lookup or get_same_lookup()
+    lookup_map = lookup or get_extended_same_lookup()
     if state_index is None:
         state_index = {
             str(state.get('state_fips') or '').zfill(2): {

--- a/webapp/admin/audio/received.py
+++ b/webapp/admin/audio/received.py
@@ -156,8 +156,8 @@ def register_received_alerts_routes(app, logger) -> None:
         try:
             alert = ReceivedEASAlert.query.get_or_404(alert_id)
 
-            from app_utils.fips_codes import get_same_lookup
-            fips_lookup = get_same_lookup()
+            from app_utils.fips_codes import get_extended_same_lookup
+            fips_lookup = get_extended_same_lookup()
             all_codes = list(alert.fips_codes or []) + [
                 c for c in (alert.matched_fips_codes or [])
                 if c not in (alert.fips_codes or [])

--- a/webapp/admin/dashboard.py
+++ b/webapp/admin/dashboard.py
@@ -45,7 +45,7 @@ from app_utils.eas import (
 )
 from app_utils.event_codes import EVENT_CODE_REGISTRY
 from app_utils.fips_codes import (
-    get_same_lookup,
+    get_extended_same_lookup,
     get_extended_state_county_tree,
 )
 
@@ -168,7 +168,7 @@ def admin():
         # Extended tree includes marine areas loaded via mz_*.dbf so the
         # FIPS picker can surface codes like American Samoa marine 077###.
         eas_state_tree = get_extended_state_county_tree()
-        eas_lookup = dict(get_same_lookup())
+        eas_lookup = get_extended_same_lookup()
         originator_choices = [
             {
                 'code': code,

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -72,7 +72,7 @@ from app_utils.gpio import (
     load_gpio_pin_configs_from_db,
 )
 from app_utils.event_codes import EVENT_CODE_REGISTRY
-from app_utils.fips_codes import get_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
 
 ALLOWED_AUDIO_EXTENSIONS = {'.wav', '.mp3', '.ogg', '.aac', '.flac'}
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
@@ -127,7 +127,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
         ]
 
         state_tree = get_us_state_county_tree()
-        same_lookup = dict(get_same_lookup())
+        same_lookup = get_extended_same_lookup()
 
         recent_messages: List[EASMessage] = (
             EASMessage.query.order_by(EASMessage.created_at.desc()).limit(10).all()
@@ -592,7 +592,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             for state in state_tree
             if state.get('state_fips')
         }
-        same_lookup = get_same_lookup()
+        same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(header, lookup=same_lookup, state_index=state_index)
 
         same_component = _package_audio(components.get('same_samples') or [], 'same')
@@ -929,7 +929,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             for state in state_tree
             if state.get('state_fips')
         }
-        same_lookup = get_same_lookup()
+        same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 
         summary_url = None
@@ -995,7 +995,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             for state in state_tree
             if state.get('state_fips')
         }
-        same_lookup = get_same_lookup()
+        same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 
         locations = header_detail.get('locations', [])

--- a/webapp/routes/alert_verification.py
+++ b/webapp/routes/alert_verification.py
@@ -87,7 +87,7 @@ from app_utils.eas_decode import (
 )
 from app_utils.eas_detection import detect_eas_from_file
 from app_utils.eas import describe_same_header
-from app_utils.fips_codes import get_same_lookup
+from app_utils.fips_codes import get_extended_same_lookup
 
 
 DEFAULT_SAMPLE_FILES: Tuple[Path, ...] = (
@@ -1555,7 +1555,7 @@ def register(app: Flask, logger) -> None:
             return jsonify({"error": "Header must begin with ZCZC-."}), 400
 
         try:
-            fips_lookup = get_same_lookup()
+            fips_lookup = get_extended_same_lookup()
             fields = describe_same_header(raw_header, lookup=fips_lookup)
             summary = build_plain_language_summary(raw_header, fields)
             return jsonify({

--- a/webapp/routes_rwt_schedule.py
+++ b/webapp/routes_rwt_schedule.py
@@ -27,7 +27,7 @@ from typing import List, Optional
 from flask import jsonify, render_template, request
 from app_core.extensions import db
 from app_core.models import RWTScheduleConfig, SystemLog
-from app_utils.fips_codes import get_us_state_county_tree, get_same_lookup
+from app_utils.fips_codes import get_us_state_county_tree, get_extended_same_lookup
 
 
 def _serialize_config(config: Optional[RWTScheduleConfig]) -> dict:
@@ -69,7 +69,7 @@ def register_routes(app, logger):
         """Render the RWT schedule configuration page."""
         # Provide state/county tree for proper selection UI
         state_tree = get_us_state_county_tree()
-        same_lookup = dict(get_same_lookup())
+        same_lookup = get_extended_same_lookup()
 
         return render_template(
             'rwt_schedule.html',


### PR DESCRIPTION
… feedback

Two issues operator hit after uploading the marine DBF.

(1) The Raw SAME Header Parser panel still displayed marine alert codes as "077650 - 077650 (Entire area)" because describe_same_header was looking codes up in get_same_lookup() — the static U.S.-only lookup table built from US_STATE_COUNTY_TREE. Marine codes (077###, 091###, 094###, …) live in the runtime nws_zones table, so they never resolved no matter how many DBFs got loaded.

Added get_extended_same_lookup() in app_utils/fips_codes.py that returns dict(US_FIPS_LOOKUP) merged with entries derived from get_marine_state_tree() (which itself reads from nws_zones with a fail-safe empty-list fallback when the DB isn't reachable). The new lookup includes every marine area code as e.g.
"077650 → Coastal waters from Pensacola FL to Pascagoula MS out 20 NM" and per-area statewide entries like "077000 → All Areas, Gulf of Mexico". Every site that resolves a SAME code for display now uses the extended lookup: the /api/decode-same-header route powering the Raw SAME Header Parser, the audio-decode pipeline in app_utils/ eas_decode.py, audio detail and received-alert routes in webapp/ admin/audio/, the dashboard FIPS-picker tooltips, the EAS workflow console, the RWT schedule preview, alert-location resolution in app_core/location.py, and email notifications. get_same_lookup() stays as a static MappingProxyType view for boot-time and test callers that must not touch the DB.

After this change, the user's header
  ZCZC-WXR-SMW-077650-077633-077631-077632+0130-1422353-DON/JKZ
parses to
  077650 - Coastal waters from Pensacola FL to Pascagoula MS out 20 NM
  077633 - Perdido Bay Area
  077631 - South Mobile Bay
  077632 - Mississippi Sound
(verified offline against the mz16ap26 DBF + the new lookup).

(2) The /admin/zones upload form gave no visible feedback during the ~10–30 s the server spends parsing and bulk-inserting a 700-row marine catalog, so it looked broken. The button stayed enabled, the toast (auto-dismissing, top-right corner) was easy to miss, and on a real failure the only signal was the toast appearing for a few seconds. Added a persistent in-page status panel directly below the upload button (role="status", aria-live="polite") that shows "Uploading <filename> (NN KB) and parsing zones…" with a spinner while the request is in flight, then either a green success alert with the schema detected and the new nws_zones row count, or a red failure alert showing the exact server-side error (HTTP status if the response wasn't JSON, the route's error field otherwise). The submit button is now disabled and shows a spinner during the upload to prevent double-submits. Toast notifications still fire as a secondary signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended location code lookup now includes marine areas alongside standard U.S. areas, enabling proper decoding of marine zone references in alerts and notifications.

* **Improvements**
  * Enhanced admin zone upload interface with improved error handling, inline status messages, and better validation feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->