### PR TITLE
zones: extend Broadcast Builder + audio detail to marine areas

### DIFF
--- a/app_utils/fips_codes.py
+++ b/app_utils/fips_codes.py
@@ -3823,6 +3823,35 @@ def get_extended_state_county_tree() -> List[Dict[str, object]]:
     return get_us_state_county_tree() + get_marine_state_tree()
 
 
+def state_index_from_tree(
+    state_tree: List[Dict[str, object]],
+) -> Dict[str, Dict[str, object]]:
+    """Map SAME-header SS digits → {abbr, name} for the given tree.
+
+    ``describe_same_header`` uses this to label the per-location
+    ``state_name`` / ``state_abbr`` fields. Census states key on their
+    numeric ``state_fips`` (e.g. ``"12"`` → Florida). Marine entries
+    from :func:`get_marine_state_tree` have ``state_fips=None`` (they
+    are not Census states); their SS digit lives at characters 1:3 of
+    ``statewide_code`` (a ``PSSCCC`` literal), so ``"077000"`` for the
+    Gulf of Mexico yields ``"77" → {"abbr": "GM", "name": "Gulf of
+    Mexico"}``. Pass :func:`get_extended_state_county_tree` to get
+    proper labels for both kinds of code in a single index.
+    """
+
+    index: Dict[str, Dict[str, object]] = {}
+    for state in state_tree:
+        abbr = state.get("abbr")
+        name = state.get("name")
+        state_fips = state.get("state_fips")
+        if state_fips:
+            index[str(state_fips)] = {"abbr": abbr, "name": name}
+        statewide_code = state.get("statewide_code")
+        if isinstance(statewide_code, str) and len(statewide_code) == 6:
+            index.setdefault(statewide_code[1:3], {"abbr": abbr, "name": name})
+    return index
+
+
 def get_extended_same_lookup() -> Dict[str, str]:
     """Return a SAME-code → description map covering U.S. + marine areas.
 

--- a/webapp/admin/audio.py
+++ b/webapp/admin/audio.py
@@ -65,7 +65,11 @@ from app_utils.eas import (
     samples_to_wav_bytes,
 )
 from app_utils.event_codes import EVENT_CODE_REGISTRY
-from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import (
+    get_extended_same_lookup,
+    get_extended_state_county_tree,
+    state_index_from_tree,
+)
 
 
 # Create Blueprint for audio routes
@@ -895,12 +899,8 @@ def admin_manual_eas_generate():
             'size_bytes': len(wav_bytes),
         }
 
-    state_tree = get_us_state_county_tree()
-    state_index = {
-        state.get('state_fips'): {'abbr': state.get('abbr'), 'name': state.get('name')}
-        for state in state_tree
-        if state.get('state_fips')
-    }
+    state_tree = get_extended_state_county_tree()
+    state_index = state_index_from_tree(state_tree)
     same_lookup = get_extended_same_lookup()
     header_detail = describe_same_header(header, lookup=same_lookup, state_index=state_index)
 
@@ -1222,12 +1222,8 @@ def manual_eas_print(event_id: int):
         if component_value:
             components[key] = component_value
 
-    state_tree = get_us_state_county_tree()
-    state_index = {
-        state.get('state_fips'): {'abbr': state.get('abbr'), 'name': state.get('name')}
-        for state in state_tree
-        if state.get('state_fips')
-    }
+    state_tree = get_extended_state_county_tree()
+    state_index = state_index_from_tree(state_tree)
     same_lookup = get_extended_same_lookup()
     header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 

--- a/webapp/admin/audio/detail.py
+++ b/webapp/admin/audio/detail.py
@@ -29,7 +29,11 @@ from flask import flash, redirect, render_template, url_for, Response
 from app_core.models import CAPAlert, EASMessage
 from app_core.eas_storage import get_eas_static_prefix, load_or_cache_summary_payload, format_local_datetime
 from app_utils.eas import describe_same_header
-from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import (
+    get_extended_same_lookup,
+    get_extended_state_county_tree,
+    state_index_from_tree,
+)
 from app_utils.pdf_generator import generate_pdf_document
 
 
@@ -336,14 +340,7 @@ def _build_location_details(
 
     lookup_map = lookup or get_extended_same_lookup()
     if state_index is None:
-        state_index = {
-            str(state.get('state_fips') or '').zfill(2): {
-                'abbr': (state.get('abbr') or '').strip(),
-                'name': (state.get('name') or '').strip(),
-            }
-            for state in get_us_state_county_tree()
-            if state.get('state_fips')
-        }
+        state_index = state_index_from_tree(get_extended_state_county_tree())
 
     try:
         detail = describe_same_header(header, lookup=lookup_map, state_index=state_index)

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -72,7 +72,11 @@ from app_utils.gpio import (
     load_gpio_pin_configs_from_db,
 )
 from app_utils.event_codes import EVENT_CODE_REGISTRY
-from app_utils.fips_codes import get_extended_same_lookup, get_us_state_county_tree
+from app_utils.fips_codes import (
+    get_extended_same_lookup,
+    get_extended_state_county_tree,
+    state_index_from_tree,
+)
 
 ALLOWED_AUDIO_EXTENSIONS = {'.wav', '.mp3', '.ogg', '.aac', '.flac'}
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
@@ -126,7 +130,11 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             for code in PRIMARY_ORIGINATORS
         ]
 
-        state_tree = get_us_state_county_tree()
+        # Use the extended tree so the Broadcast Builder picker can
+        # surface marine areas (GM/AM/AN/lakes/etc.) loaded from the
+        # NWS marine zone DBF, not just U.S. Census states. Falls back
+        # to U.S.-only when no marine zones are loaded.
+        state_tree = get_extended_state_county_tree()
         same_lookup = get_extended_same_lookup()
 
         recent_messages: List[EASMessage] = (
@@ -586,12 +594,8 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 'wav_bytes': wav_bytes,
             }
 
-        state_tree = get_us_state_county_tree()
-        state_index = {
-            state.get('state_fips'): {'abbr': state.get('abbr'), 'name': state.get('name')}
-            for state in state_tree
-            if state.get('state_fips')
-        }
+        state_tree = get_extended_state_county_tree()
+        state_index = state_index_from_tree(state_tree)
         same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(header, lookup=same_lookup, state_index=state_index)
 
@@ -923,12 +927,8 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 'stream_url': url_for('manual_eas_audio', event_id=event.id, component=component_key),
             }
 
-        state_tree = get_us_state_county_tree()
-        state_index = {
-            state.get('state_fips'): {'abbr': state.get('abbr'), 'name': state.get('name')}
-            for state in state_tree
-            if state.get('state_fips')
-        }
+        state_tree = get_extended_state_county_tree()
+        state_index = state_index_from_tree(state_tree)
         same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 
@@ -989,12 +989,8 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
         })
 
         # Location Information
-        state_tree = get_us_state_county_tree()
-        state_index = {
-            state.get('state_fips'): {'abbr': state.get('abbr'), 'name': state.get('name')}
-            for state in state_tree
-            if state.get('state_fips')
-        }
+        state_tree = get_extended_state_county_tree()
+        state_index = state_index_from_tree(state_tree)
         same_lookup = get_extended_same_lookup()
         header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 


### PR DESCRIPTION
The Broadcast Builder Console at /eas/ rendered its State/Territory dropdown from get_us_state_county_tree() — the static U.S.-only tree — even though the alert-filtering picker had already been switched to the extended tree. That meant an operator could never build a manual Gulf-of-Mexico SMW (or any marine activation) from the Broadcast Builder: Florida and Mississippi appeared in the dropdown, "Gulf of Mexico" did not, so the SAME / FIPS Locations field couldn't be populated with codes like 077650/077633 even after the marine DBF had been loaded into nws_zones.

The fix swaps the call at workflow.py:155 to
get_extended_state_county_tree(), the same DB-aware composition the admin filter picker already uses. With the marine catalog loaded the dropdown now shows Gulf of Mexico → "Coastal waters from Pensacola FL to Pascagoula MS out 20 NM (077650)" alongside the Census states; with no marine catalog loaded the call gracefully degrades to the static tree (get_marine_state_tree returns [] when the DB query fails).

Three other call sites in workflow.py and the audio review paths (webapp/admin/audio.py:902 and webapp/admin/audio/detail.py:337) were rebuilding state_index — the SS-digit → {abbr, name} map describe_same_header() uses to label per-location state fields — from the static tree as well. Marine codes like 077650 therefore displayed with state_name="77" instead of "Gulf of Mexico" even when their description resolved correctly via the extended lookup. Each site now consumes a new shared helper
app_utils.fips_codes.state_index_from_tree, which walks any tree (static, marine, or extended) and indexes Census states by their state_fips while indexing marine entries by the SS chars of their statewide_code (PSSCCC chars 1:3). All three sites pass the extended tree, so marine + Census labels coexist in one index.