### PR TITLE
zones: preserve marine catalog across service restarts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1288,8 +1288,15 @@ def initialize_database():
                 return False
             
             logger.info("[13/16] Loading NWS zone catalog (may take time)...")
-            # Zone catalog is optional - app can start without it
-            if not ensure_zone_catalog(logger):
+            # Zone catalog is optional - app can start without it.
+            # delete_scope="public" scopes the orphan-delete pass to
+            # public-zone rows only, so the bundled z_*.dbf still
+            # round-trips cleanly on boot but any marine zones the
+            # operator uploaded separately via /admin/zones (mz_*.dbf,
+            # oz_*.dbf) survive across restarts. Without this, every
+            # service restart treated marine rows as orphans of the
+            # public catalog and silently wiped them.
+            if not ensure_zone_catalog(logger, delete_scope="public"):
                 logger.warning("NWS zone catalog could not be loaded - continuing without it")
 
             logger.info("[14/16] Loading US county boundaries (may take time on first run)...")

--- a/webapp/admin/zones.py
+++ b/webapp/admin/zones.py
@@ -146,8 +146,11 @@ def reload_zones():
         # Clear cache first
         clear_zone_lookup_cache()
         
-        # Reload from file
-        success = ensure_zone_catalog(logger)
+        # Reload from file. Scope deletions to public so an operator
+        # clicking "Reload from File" against the bundled public-zone
+        # DBF refreshes the public catalog without wiping marine zones
+        # that were uploaded separately via the upload form.
+        success = ensure_zone_catalog(logger, delete_scope="public")
         
         if success:
             zone_count = NWSZone.query.count()


### PR DESCRIPTION
The marine zones operators uploaded via /admin/zones (mz_*.dbf, oz_*.dbf) were silently disappearing after every service restart — including the one update.sh performs as its final step — even though the upload itself worked and the rows landed in nws_zones.

Root cause is in app.py:1292. Boot-time DB initialisation calls ensure_zone_catalog(logger) with no delete_scope, which defaults to None and triggers sync_zone_catalog's full orphan-delete pass: any zone_code in nws_zones that isn't present in the bundled DBF being loaded gets deleted. The bundled DBF is assets/z_*.dbf, a public- zone catalog with prefixes like OHZ, FLZ, CAZ — it contains zero marine prefixes. So every restart classified every marine row as an orphan of the public catalog and dropped it. That had been the behaviour from day one; the upload UI quietly worked between restarts and then quietly lost the data on the next boot.

Fix is to pass delete_scope="public" at the boot call so the orphan-delete pass only considers rows with two-letter U.S. state prefixes. The bundled public catalog still round-trips cleanly on boot — additions, removals, and rename in z_*.dbf all propagate — but any non-public rows (every UGC prefix in MARINE_PREFIX_TO_SAME_ STATE: GM, AM, AN, PZ, PH, PK, PM, PS, LE, LM, LH, LC, LS, LO, SL) are filtered out of the orphan set and survive across restarts.

The "Reload from File" button at webapp/admin/zones.py:150 had the exact same bug — clicking it after uploading a marine DBF would nuke the marine zones the next moment because it also called ensure_zone_catalog(logger) with the default scope. Applied the same delete_scope="public" so the button is safe to use against the bundled public DBF without collateral damage to marine.

The upload route at webapp/admin/zones.py:225 already passes delete_scope=False, so mz/oz uploads remain additive against each other and against the public catalog; no change needed there.

After this commit the marine workflow survives the full restart cycle: upload mz_16ap26.dbf -> rows visible in nws_zones -> systemctl restart eas-station.target (or update.sh, or a host reboot) -> rows still in nws_zones -> Broadcast Builder picker and SAME header parser keep resolving GM/AM/AN/etc. codes to their human names.