### PR TITLE
Fix GPIO relay timing to match actual audio playback duration

### DIFF
--- a/webapp/eas/messages.py
+++ b/webapp/eas/messages.py
@@ -188,8 +188,9 @@ def register_message_routes(bp, logger) -> None:
         import os
         import subprocess
         import tempfile
+        import time
 
-        from app_utils.eas import set_broadcast_active, clear_broadcast_active
+        from app_utils.eas import set_broadcast_active, clear_broadcast_active, _wav_duration_seconds
         from app_utils.gpio import GPIOController, GPIOActivationType
         from app_utils.gpio_behavior import GPIOBehaviorManager, load_gpio_behavior_matrix_from_db
         from app_core.models import GPIOConfig
@@ -209,7 +210,11 @@ def register_message_routes(bp, logger) -> None:
 
         metadata = message.metadata_payload or {}
         event_code = metadata.get('event_code') or ''
-        playback_duration = metadata.get('playback_duration_seconds') or metadata.get('duration_seconds') or 60.0
+        # Prefer the actual WAV length so we hold GPIO for the right window
+        # even when the audio player exits early (no audio device, etc.).
+        actual_audio_duration = _wav_duration_seconds(message.audio_data) if message.audio_data else 0.0
+        metadata_duration = metadata.get('playback_duration_seconds') or metadata.get('duration_seconds') or 0.0
+        playback_duration = actual_audio_duration or float(metadata_duration) or 60.0
 
         from app_utils.event_codes import EVENT_CODE_REGISTRY as _ECR
         _ei = _ECR.get(event_code, {})
@@ -279,6 +284,10 @@ def register_message_routes(bp, logger) -> None:
             )
 
             audio_played = False
+            # Hold the airchain for the full composite duration regardless of
+            # whether the player actually blocks (e.g. no audio device on this
+            # host) — otherwise GPIO drops as soon as the player exits.
+            playout_start = time.monotonic()
             if audio_player_cmd:
                 try:
                     command = list(audio_player_cmd) + [tmp_path]
@@ -288,6 +297,10 @@ def register_message_routes(bp, logger) -> None:
                     logger.warning('Resend audio playback timed out for message %s', message_id)
                 except Exception as exc:
                     logger.warning('Resend audio playback failed: %s', exc)
+
+            remaining_playout = float(playback_duration) - (time.monotonic() - playout_start)
+            if remaining_playout > 0:
+                time.sleep(remaining_playout)
 
         finally:
             if gpio_controller and activated_any:

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
@@ -1297,7 +1298,12 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 source='manual',
             )
 
-            # Play audio via configured player command
+            # Play audio via configured player command. The GPIO airchain must
+            # stay asserted for the full composite duration regardless of
+            # whether the player actually blocks for that long — on hosts
+            # without an audio device the player can exit immediately, which
+            # would otherwise drop the relay before the encoder finishes.
+            playout_start = time.monotonic()
             if audio_player_cmd:
                 try:
                     command = list(audio_player_cmd) + [tmp_path]
@@ -1321,6 +1327,10 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                     event_id,
                 )
                 send_result['audio_player_configured'] = False
+
+            remaining_playout = playback_duration - (time.monotonic() - playout_start)
+            if remaining_playout > 0:
+                time.sleep(remaining_playout)
 
         finally:
             # Release GPIO relays before clearing broadcast state so the


### PR DESCRIPTION
## Summary
This PR fixes an issue where GPIO relays (used to control broadcast equipment) were being released prematurely when audio playback completed before the expected duration. This was particularly problematic on hosts without audio devices, where the player would exit immediately rather than blocking for the full playback duration.

## Key Changes
- **Import `time` module** in both `messages.py` and `workflow.py` to enable duration tracking
- **Calculate actual audio duration** from WAV file metadata using `_wav_duration_seconds()` instead of relying solely on stored metadata, with fallback to metadata values and a 60-second default
- **Track playout start time** using `time.monotonic()` before attempting audio playback
- **Hold GPIO relays for full duration** by sleeping for any remaining time after the audio player exits, ensuring the relay stays asserted for the complete composite duration
- **Add clarifying comments** explaining why GPIO must be held regardless of whether the audio player blocks

## Implementation Details
The fix ensures that:
1. The actual WAV file duration is preferred over metadata values to account for any discrepancies
2. A timer is started before audio playback begins
3. After the player exits (or fails to start), the code calculates remaining time and sleeps if necessary
4. This guarantees GPIO relays remain active for the full intended duration, allowing downstream equipment (like encoders) to complete their work before the relay is released

This change applies to both the message resend workflow (`messages.py`) and the manual EAS send workflow (`workflow.py`).

https://claude.ai/code/session_01YMeGR4VgirEPBxcPCbkiyu