### PR TITLE
Improve historical alerts API: add parameter aliases and fix description handling

### DIFF
--- a/webapp/admin/api.py
+++ b/webapp/admin/api.py
@@ -1368,8 +1368,8 @@ def get_alerts():
 def get_historical_alerts():
     """Get historical alerts as GeoJSON with date filtering"""
     try:
-        start_date = request.args.get('start_date')
-        end_date = request.args.get('end_date')
+        start_date = request.args.get('start_date') or request.args.get('start')
+        end_date = request.args.get('end_date') or request.args.get('end')
         include_active = request.args.get('include_active', 'false').lower() == 'true'
 
         if include_active:
@@ -1459,6 +1459,10 @@ def get_historical_alerts():
                     sent_dt = alert.sent.replace(tzinfo=UTC_TZ) if alert.sent.tzinfo is None else alert.sent.astimezone(UTC_TZ)
                     sent_iso = sent_dt.isoformat()
 
+                description = alert.description or ''
+                if len(description) > 500:
+                    description = description[:500] + '...'
+
                 features.append(
                     {
                         'type': 'Feature',
@@ -1469,11 +1473,7 @@ def get_historical_alerts():
                             'severity': alert.severity,
                             'urgency': alert.urgency,
                             'headline': alert.headline,
-                            'description': (
-                                alert.description[:500] + '...'
-                                if len(alert.description) > 500
-                                else alert.description
-                            ),
+                            'description': description,
                             'sent': sent_iso,
                             'expires': expires_iso,
                             'area_desc': alert.area_desc,


### PR DESCRIPTION
## Summary
This PR improves the `get_historical_alerts()` endpoint by adding support for alternative query parameter names and fixing the description truncation logic to handle null values gracefully.

## Key Changes
- **Parameter aliases**: Added support for `start` and `end` query parameters as alternatives to `start_date` and `end_date`, improving API flexibility
- **Null-safe description handling**: Fixed a potential bug where `alert.description` could be `None`, causing an error when attempting string slicing. Now defaults to empty string before truncation
- **Code refactoring**: Extracted description truncation logic into a separate variable assignment for improved readability and maintainability

## Implementation Details
- The description is now safely initialized as `alert.description or ''` before any length checks
- Truncation logic remains the same (500 character limit with ellipsis), but is now more robust
- Query parameter fallback uses the `or` operator for clean, Pythonic code

https://claude.ai/code/session_019r6vrGRnWE8JsX3rLDv2Hi