### PR TITLE
fix(brand): make hero wordmark legible by darkening the logo card

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -7554,11 +7554,11 @@ a:not(.btn):not(.nav-link):not(.dropdown-item):hover {
     width: 100%;
     padding: 1.25rem 1.75rem;
     border-radius: var(--radius-xl);
-    background: rgba(255, 255, 255, 0.94);
+    background: rgba(15, 23, 42, 0.55);
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
-    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.22),
-                0 0 0 1px rgba(255, 255, 255, 0.55) inset;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.28),
+                0 0 0 1px rgba(255, 255, 255, 0.18) inset;
 }
 .eas-hero-title,
 .about-hero-title {


### PR DESCRIPTION
The wordmark SVG fills 'EAS' and the tagline with #ffffff (designed for the dark navbar). The about-hero card was rgba(255,255,255,0.94), so those elements rendered white-on-white and only the red 'STATION' word and red EQ bars survived. Switch the hero logo card to a dark translucent backdrop so the full wordmark is visible.