### PR TITLE
fix(eas): close ECIG V1.0 compliance gaps in CAP-to-EAS pipeline

### DIFF
--- a/app_core/audio/auto_forward.py
+++ b/app_core/audio/auto_forward.py
@@ -101,6 +101,28 @@ def _resolve_event_code(alert) -> Optional[str]:
     return None
 
 
+def _is_must_carry(raw_json: Optional[Dict]) -> bool:
+    """ECIG §3.4.1.7 — Governor's Must-Carry.
+
+    Returns True when the CAP alert carries
+    ``<parameter><valueName>EAS-Must-Carry</valueName><value>True</value></parameter>``.
+    A True value SHALL override originator and event-code filtering for
+    automatic forwarding (location filtering and duplicate prevention still
+    apply).  Only the first occurrence of the parameter is considered (per
+    §3.3.1).
+    """
+    if not isinstance(raw_json, dict):
+        return False
+    properties = raw_json.get('properties') or {}
+    parameters = properties.get('parameters') if isinstance(properties, dict) else None
+    if not isinstance(parameters, dict):
+        return False
+    value = parameters.get('EAS-Must-Carry')
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else None
+    return str(value or '').strip().lower() == 'true'
+
+
 def _alert_dedupe_lock_key(
     event_code: Optional[str],
     fips_codes: Optional[List[str]],
@@ -472,6 +494,43 @@ def auto_forward_cap_alert(
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
+        # ── ECIG §3.8: msgType handling ──────────────────────────────────────
+        # Alert  → process normally.
+        # Update → process; the cap_poller supersede pipeline replaces any
+        #          queued original (see CAPPoller._mark_vtec_chain_superseded
+        #          and _should_replace_alert) before we get here.
+        # Cancel → MUST NOT deliver the cancelled message.  An in-progress
+        #          broadcast would complete with EOM, but auto_forward only
+        #          fires for new broadcasts so a plain skip is correct.
+        # Ack/Error → not required to process.
+        message_type_raw = (
+            getattr(cap_alert, 'message_type', None)
+            or alert_data.get('message_type')
+            or alert_data.get('msgType')
+            or 'Alert'
+        )
+        msg_type = str(message_type_raw).strip().lower()
+        if msg_type in ('ack', 'error'):
+            reason = f"msgType '{message_type_raw}' is not aired (ECIG §3.8)"
+            log.debug("Auto-forward skipped for %s: %s", result['identifier'], reason)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            return result
+        if msg_type == 'cancel':
+            reason = (
+                f"msgType 'Cancel' — cancelled message MUST NOT be aired (ECIG §3.8)"
+            )
+            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            return result
+        if msg_type not in ('alert', 'update'):
+            reason = f"Unknown msgType '{message_type_raw}' — not aired (ECIG §3.8)"
+            log.info("Auto-forward skipped for %s: %s", result['identifier'], reason)
+            result['reason'] = reason
+            _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
+            return result
+
         # ── ECIG §3.3: expired alerts shall not be broadcast ─────────────────
         sent_dt = getattr(cap_alert, 'sent', None) or alert_data.get('sent')
         expires_dt = getattr(cap_alert, 'expires', None) or alert_data.get('expires')
@@ -496,6 +555,14 @@ def auto_forward_cap_alert(
         raw_json = alert_data.get('raw_json', {})
         fips_codes = _get_fips_from_cap_alert(cap_alert, raw_json)
         event_code = _resolve_event_code(cap_alert)
+        must_carry = _is_must_carry(raw_json)
+        if must_carry:
+            result['must_carry'] = True
+            log.info(
+                "Auto-forward %s: EAS-Must-Carry asserted — bypassing originator "
+                "and event-code filters (ECIG §3.4.1.7)",
+                result['identifier'],
+            )
 
         # Event code filtering: forward only events the operator has selected.
         # An empty allowlist means "forward all event types" — except RWT, which is
@@ -503,11 +570,13 @@ def auto_forward_cap_alert(
         # to forwarded_event_codes.  This keeps the CAP path consistent with the
         # OTA path (auto_forward_ota_alert) so test activations are not silently
         # rebroadcast just because the allowlist is empty.
+        # ECIG §3.4.1.7: when EAS-Must-Carry=True, event-code filtering is
+        # bypassed (location filtering and dedupe still apply below).
         forwarded_event_codes = eas_config.get('forwarded_event_codes') or []
         allowed = {str(c).strip().upper() for c in forwarded_event_codes if str(c).strip()}
         event_code_upper = event_code.upper() if event_code else ''
 
-        if event_code_upper == 'RWT' and 'RWT' not in allowed:
+        if not must_carry and event_code_upper == 'RWT' and 'RWT' not in allowed:
             reason = (
                 "RWT not forwarded — add 'RWT' to forwarded_event_codes to relay test activations"
             )
@@ -516,7 +585,7 @@ def auto_forward_cap_alert(
             _update_cap_forwarding_status(cap_alert, db_session, False, reason, log)
             return result
 
-        if allowed and event_code_upper not in allowed:
+        if not must_carry and allowed and event_code_upper not in allowed:
             # An unresolved event code (event_code_upper == '') with a configured
             # allowlist must also be rejected: we cannot prove the alert is on the
             # allowlist, so refuse to forward rather than silently bypassing the

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1338,11 +1338,22 @@ def _normalize_text_for_tts(text: str) -> str:
     # These clean up formatting conventions unique to NWS/NOAA alert text
     # before the acronym table runs.
 
-    # Asterisk removal — NWS uses "* WHAT...", "* WHERE...", "* WHEN..." etc.
+    # Asterisk handling — NWS uses "* WHAT...", "* WHERE...", "* WHEN..." etc.
     # as bullet-point markers.  TTS engines read a bare asterisk as "asterisk"
-    # which sounds unnatural.  Strip leading bullet asterisks first, then remove
-    # any remaining asterisks so they are never spoken.
+    # which sounds unnatural.  Strip leading bullet asterisks first.
     result = re.sub(r'^\s*\*\s*', '', result, flags=re.MULTILINE)
+
+    # ECIG §3.5.2 / §3.5.4: text deletions are marked with three asterisks
+    # ("***") and MUST be followed by a one-second pause in TTS / audio.
+    # Insert a sentence break (period + space) which every TTS backend in
+    # this project — Azure, espeak-ng, the local fallback — renders as an
+    # audible sentence-length pause comparable to one second.  Consume
+    # adjacent spaces/tabs so the downstream multi-space → ", " rule does
+    # not append a comma to the pause.  Run this BEFORE the remaining-
+    # asterisk strip so the markers are not erased.
+    result = re.sub(r'[ \t]*\*{3,}[ \t]*', '. ', result)
+
+    # Strip any remaining stray asterisks so they are never spoken.
     result = result.replace('*', '')
 
     # Whitespace / punctuation — convert structural whitespace to spoken
@@ -1513,11 +1524,29 @@ def _compose_message_text(alert: object, payload: Optional[Dict[str, object]] = 
         parameters = {}
 
     # ── FCC Required Text ───────────────────────────────────────────────
-    # Originator description
+    # Originator description.
+    #
+    # ECIG §3.10: when a CAP 1.1 message arrives with no originator, assume
+    # CIV.  In practice CAP 1.2 IPAWS messages always carry EAS-ORG; the
+    # fallback below only fires for non-NOAA sources missing the parameter.
+    # NOAA / NWS alerts default to WXR because their CAP feeds typically
+    # omit EAS-ORG and the National Weather Service is the implicit
+    # originator.
     eas_org_val = parameters.get('EAS-ORG')
     if isinstance(eas_org_val, list):
         eas_org_val = eas_org_val[0] if eas_org_val else None
-    originator_code = (str(eas_org_val).strip().upper() if eas_org_val else None) or 'WXR'
+    if eas_org_val:
+        originator_code = str(eas_org_val).strip().upper()
+    else:
+        alert_source = (
+            getattr(alert, 'source', None)
+            or payload.get('source')
+            or ''
+        )
+        if str(alert_source).strip().upper() in ('NOAA', 'NWS'):
+            originator_code = 'WXR'
+        else:
+            originator_code = 'CIV'  # ECIG §3.10
     originator_desc = ORIGINATOR_DESCRIPTIONS.get(originator_code, originator_code)
 
     # Event name
@@ -2090,11 +2119,18 @@ def _run_command(command: Sequence[str], logger) -> None:
             logger.warning(f"Failed to run command {' '.join(command)}: {exc}")
 
 
+#: ECIG §3.5.1 — recorded-audio download timeout cap (2 minutes).
+EMBEDDED_AUDIO_DOWNLOAD_TIMEOUT = 120
+
+#: ECIG §3.5.1 — streaming-audio fetch timeout cap (30 seconds).
+EMBEDDED_AUDIO_STREAMING_TIMEOUT = 30
+
+
 def _fetch_embedded_audio(
     resources: List[Dict[str, str]],
     target_sample_rate: int,
     logger,
-    timeout: int = 30,
+    timeout: Optional[int] = None,
 ) -> Tuple[Optional[List[int]], Optional[str]]:
     """Fetch and convert embedded audio from CAP resources.
 
@@ -2105,11 +2141,17 @@ def _fetch_embedded_audio(
     inferred from the decoded bytes so that alerts that omit MIME metadata
     still produce valid audio.
 
+    ECIG §3.5.1 caps per-resource fetch time at 2 minutes for downloads and
+    30 seconds for streaming sources; on timeout the caller falls back to
+    TTS for that alert.
+
     Args:
         resources: List of resource dicts from CAP XML parsing
         target_sample_rate: Target sample rate for output
         logger: Logger instance
-        timeout: Download timeout in seconds
+        timeout: Optional override for the per-resource timeout (seconds).
+            When ``None`` the spec-mandated cap is selected per resource
+            (streaming → 30 s, otherwise → 120 s).
 
     Returns:
         Tuple of (audio_samples, source_description) or (None, None) if no
@@ -2183,13 +2225,27 @@ def _fetch_embedded_audio(
 
         # --- external URI audio ---
         if uri:
+            # ECIG §3.5.1: streaming sources are capped at 30 s, downloadable
+            # MP3/WAV at 120 s; on timeout the loop continues to the next
+            # resource and ultimately falls back to TTS for the alert.
+            mime_lower = mime_type.lower() if mime_type else ''
+            desc_lower = resource_desc.lower() if resource_desc else ''
+            is_streaming = ('streaming' in mime_lower) or ('streaming' in desc_lower)
+            if timeout is not None:
+                per_resource_timeout = timeout
+            elif is_streaming:
+                per_resource_timeout = EMBEDDED_AUDIO_STREAMING_TIMEOUT
+            else:
+                per_resource_timeout = EMBEDDED_AUDIO_DOWNLOAD_TIMEOUT
             logger.info(
                 f"Fetching embedded audio from IPAWS: {resource_desc or 'unnamed'} "
-                f"({mime_type}) from {uri[:80]}..."
+                f"({mime_type}) from {uri[:80]}... "
+                f"[timeout={per_resource_timeout}s, "
+                f"{'streaming' if is_streaming else 'download'}]"
             )
             try:
                 # Disable proxy to allow direct download from IPAWS
-                response = requests.get(uri, timeout=timeout, stream=True, proxies={'http': None, 'https': None})
+                response = requests.get(uri, timeout=per_resource_timeout, stream=True, proxies={'http': None, 'https': None})
                 response.raise_for_status()
 
                 audio_data = response.content

--- a/tests/test_ecig_compliance.py
+++ b/tests/test_ecig_compliance.py
@@ -1,0 +1,490 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""ECIG CAP-to-EAS Implementation Guide V1.0 compliance tests.
+
+Covers the five gaps closed in the audit pass:
+  - §3.4.1.7  EAS-Must-Carry parameter overrides event-code filter
+  - §3.8      msgType filtering (Cancel/Ack/Error suppressed)
+  - §3.5.1    Embedded-audio fetch timeouts (120 s download, 30 s streaming)
+  - §3.5.2/4  '***' text-deletion marker becomes an audible pause
+  - §3.10     Default originator is CIV (not WXR) for non-NOAA sources
+"""
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies so only the gating logic is exercised.  Note:
+# `app_core` is NOT stubbed because TestMustCarryDetection imports the real
+# `app_core.audio.auto_forward` module; only the `app_core.models` and
+# `app_core.tts_settings` submodules used by `app_utils.eas` are replaced.
+_STUBS = [
+    'flask', 'flask_sqlalchemy',
+    'sqlalchemy', 'sqlalchemy.orm',
+    'pytz',
+    'azure', 'azure.cognitiveservices', 'azure.cognitiveservices.speech',
+    'pyttsx3', 'pydub',
+    'RPi', 'RPi.GPIO', 'gpiozero',
+    'psutil',
+    'app_core.models', 'app_core.tts_settings',
+]
+for _mod in _STUBS:
+    sys.modules.setdefault(_mod, MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# §3.5.2 / §3.5.4 — '***' deletion marker becomes an audible pause
+# ---------------------------------------------------------------------------
+
+def _get_normalize():
+    with patch('app_utils.eas._load_pronunciation_rules', return_value=[]):
+        from app_utils.eas import _normalize_text_for_tts
+    return _normalize_text_for_tts
+
+
+class TestAsteriskDeletionPause(unittest.TestCase):
+    """Three or more asterisks ('***') mark a deletion and SHALL be followed
+    by a one-second pause (ECIG §3.5.2, §3.5.4).  In this codebase that
+    pause is rendered as a sentence break ('. ') because every TTS backend
+    we ship treats a sentence break as roughly a one-second silence."""
+
+    def setUp(self):
+        self.n = _get_normalize()
+
+    def test_triple_asterisk_becomes_sentence_break(self):
+        result = self.n('WARNING ISSUED *** DETAILS WITHHELD')
+        self.assertNotIn('***', result)
+        self.assertNotIn('*', result)
+        # A sentence break ". " (post-lowercasing) must appear where the
+        # deletion marker was.
+        self.assertIn('. ', result)
+
+    def test_quadruple_asterisk_also_becomes_pause(self):
+        result = self.n('LINE ONE **** LINE TWO')
+        self.assertNotIn('*', result)
+        self.assertIn('. ', result)
+
+    def test_single_asterisk_still_stripped(self):
+        # NWS bullet markers ("* WHAT...") remain stripped, not turned into
+        # a pause — that behavior predates the ECIG fix.
+        result = self.n('* WHAT...TORNADO WARNING')
+        self.assertNotIn('*', result)
+
+    def test_double_asterisk_stripped(self):
+        result = self.n('A ** B')
+        self.assertNotIn('*', result)
+
+
+# ---------------------------------------------------------------------------
+# §3.4.1.7 — Governor's Must-Carry detection
+# ---------------------------------------------------------------------------
+
+def _load_auto_forward_module():
+    """Load app_core/audio/auto_forward.py directly from disk.
+
+    Importing it through the `app_core.audio` package would pull in the
+    full audio-ingest pipeline (SDR, ALSA, redis_client, etc.), which is
+    far more than this test needs.  spec_from_file_location bypasses the
+    package machinery while still letting auto_forward import its own
+    function-scoped dependencies.  The function-scoped imports pull in
+    `app_core.logging_context` which transitively imports redis; stub
+    those before exec'ing the module.
+    """
+    import importlib.util
+    import contextlib
+
+    # Satisfy the module-level `from app_utils.vtec import ...`.
+    sys.modules.setdefault('app_utils.vtec', MagicMock(
+        VTEC_BROADCAST_ACTIONS=set(),
+        VTEC_SKIP_ACTIONS=set(),
+        VTEC_TERMINAL_ACTIONS=set(),
+    ))
+
+    # Stub the function-scoped imports that auto_forward_cap_alert pulls
+    # in at call time — these would otherwise drag in redis, gevent, etc.
+    @contextlib.contextmanager
+    def _noop_ctx(*args, **kwargs):
+        yield None
+
+    logging_ctx_stub = MagicMock()
+    logging_ctx_stub.push_alert = MagicMock(return_value=object())
+    logging_ctx_stub.pop_alert = MagicMock()
+    sys.modules.setdefault('app_core.logging_context', logging_ctx_stub)
+    sys.modules.setdefault('app_core.extensions', MagicMock())
+    sys.modules.setdefault('app_core.redis_client', MagicMock())
+    sys.modules.setdefault('app_utils.event_codes', MagicMock(
+        EVENT_CODE_REGISTRY={
+            'CEM': {'name': 'Civil Emergency Message'},
+            'RWT': {'name': 'Required Weekly Test'},
+            'TOR': {'name': 'Tornado Warning'},
+        },
+    ))
+
+    path = ROOT / 'app_core' / 'audio' / 'auto_forward.py'
+    spec = importlib.util.spec_from_file_location(
+        'auto_forward_under_test', str(path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMustCarryDetection(unittest.TestCase):
+    """`_is_must_carry` reads
+    `<parameter><valueName>EAS-Must-Carry</valueName><value>True</value></parameter>`
+    from the parsed raw_json dict."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mod = _load_auto_forward_module()
+
+    def setUp(self):
+        self.is_must_carry = self._mod._is_must_carry
+
+    def test_true_string_detected(self):
+        raw = {'properties': {'parameters': {'EAS-Must-Carry': 'True'}}}
+        self.assertTrue(self.is_must_carry(raw))
+
+    def test_lowercase_true_detected(self):
+        raw = {'properties': {'parameters': {'EAS-Must-Carry': 'true'}}}
+        self.assertTrue(self.is_must_carry(raw))
+
+    def test_list_value_first_occurrence(self):
+        # §3.3.1: when a parameter appears multiple times, only the first
+        # occurrence is honored.
+        raw = {'properties': {'parameters': {
+            'EAS-Must-Carry': ['True', 'False'],
+        }}}
+        self.assertTrue(self.is_must_carry(raw))
+
+    def test_false_value_returns_false(self):
+        raw = {'properties': {'parameters': {'EAS-Must-Carry': 'False'}}}
+        self.assertFalse(self.is_must_carry(raw))
+
+    def test_missing_parameter_returns_false(self):
+        raw = {'properties': {'parameters': {}}}
+        self.assertFalse(self.is_must_carry(raw))
+
+    def test_missing_raw_json_returns_false(self):
+        self.assertFalse(self.is_must_carry(None))
+        self.assertFalse(self.is_must_carry({}))
+
+
+# ---------------------------------------------------------------------------
+# §3.5.1 — embedded-audio fetch timeouts
+# ---------------------------------------------------------------------------
+
+class TestEmbeddedAudioTimeouts(unittest.TestCase):
+    """Per ECIG §3.5.1, downloads get up to 120 s and streaming sources up
+    to 30 s.  _fetch_embedded_audio selects per-resource based on MIME or
+    resourceDesc.  On timeout the loop falls through and the caller
+    eventually renders TTS instead."""
+
+    def setUp(self):
+        from app_utils import eas as eas_mod
+        self.eas_mod = eas_mod
+
+    def _run_with_resource(self, resource):
+        import requests
+        captured = {}
+
+        class _FakeResponse:
+            def __init__(self):
+                self.content = b''
+            def raise_for_status(self):
+                pass
+
+        def fake_get(url, **kwargs):
+            captured['timeout'] = kwargs.get('timeout')
+            return _FakeResponse()
+
+        log = MagicMock()
+        with patch.object(self.eas_mod, '_convert_audio_to_samples', return_value=None), \
+             patch.object(requests, 'get', side_effect=fake_get):
+            self.eas_mod._fetch_embedded_audio([resource], 24000, log)
+        return captured
+
+    def test_download_uses_120s_timeout(self):
+        # Plain MP3 download: spec cap is 2 minutes.
+        captured = self._run_with_resource({
+            'uri': 'https://example.com/eas.mp3',
+            'mimeType': 'audio/mpeg',
+            'resourceDesc': 'EAS Broadcast Content',
+        })
+        self.assertEqual(captured.get('timeout'),
+                         self.eas_mod.EMBEDDED_AUDIO_DOWNLOAD_TIMEOUT)
+        self.assertEqual(captured.get('timeout'), 120)
+
+    def test_streaming_mime_uses_30s_timeout(self):
+        captured = self._run_with_resource({
+            'uri': 'https://example.com/eas.m3u',
+            'mimeType': 'audio/x-ipaws-streaming-audio-mp3',
+            'resourceDesc': 'EAS Broadcast Content',
+        })
+        self.assertEqual(captured.get('timeout'),
+                         self.eas_mod.EMBEDDED_AUDIO_STREAMING_TIMEOUT)
+        self.assertEqual(captured.get('timeout'), 30)
+
+    def test_streaming_in_desc_uses_30s_timeout(self):
+        # Some originators only signal "streaming" in the resourceDesc.
+        captured = self._run_with_resource({
+            'uri': 'https://example.com/eas',
+            'mimeType': 'audio/mpeg',
+            'resourceDesc': 'EAS Streaming Audio',
+        })
+        self.assertEqual(captured.get('timeout'), 30)
+
+    def test_explicit_override_wins(self):
+        import requests
+        captured = {}
+
+        class _FakeResponse:
+            content = b''
+            def raise_for_status(self):
+                pass
+
+        def fake_get(url, **kwargs):
+            captured['timeout'] = kwargs.get('timeout')
+            return _FakeResponse()
+
+        log = MagicMock()
+        resource = {
+            'uri': 'https://example.com/eas.mp3',
+            'mimeType': 'audio/mpeg',
+            'resourceDesc': 'EAS Broadcast Content',
+        }
+        with patch.object(self.eas_mod, '_convert_audio_to_samples', return_value=None), \
+             patch.object(requests, 'get', side_effect=fake_get):
+            self.eas_mod._fetch_embedded_audio([resource], 24000, log, timeout=5)
+        self.assertEqual(captured.get('timeout'), 5)
+
+
+# ---------------------------------------------------------------------------
+# §3.10 — Default originator: CIV for non-NOAA, WXR for NOAA
+# ---------------------------------------------------------------------------
+
+class TestDefaultOriginator(unittest.TestCase):
+    """When the CAP message omits an EAS-ORG parameter, §3.10 says assume
+    CIV.  NOAA/NWS feeds are the practical exception: they consistently
+    omit EAS-ORG and are by definition WXR."""
+
+    def setUp(self):
+        from app_utils import eas as eas_mod
+        self.eas_mod = eas_mod
+        # Stub the heavy machinery that _construct_alert_text doesn't need
+        # for the originator-selection branch.
+
+    def _construct(self, alert_source):
+        alert = SimpleNamespace(
+            event='Civil Emergency Message',
+            description='',
+            instruction='',
+            sent=None,
+            expires=None,
+            source=alert_source,
+        )
+        payload = {'raw_json': {'properties': {}}, 'source': alert_source}
+        with patch.object(self.eas_mod, '_load_pronunciation_rules', return_value=[]):
+            return self.eas_mod._compose_message_text(alert, payload)
+
+    def test_noaa_source_defaults_to_wxr(self):
+        text = self._construct('NOAA')
+        # ORIGINATOR_DESCRIPTIONS['WXR'] = 'National Weather Service'
+        # (text gets lowercased by the TTS normalizer).
+        self.assertIn('national weather service', text.lower())
+
+    def test_ipaws_source_defaults_to_civ(self):
+        text = self._construct('IPAWS')
+        # ORIGINATOR_DESCRIPTIONS['CIV'] = 'Civil authorities'.
+        self.assertIn('civil authorit', text.lower())
+        self.assertNotIn('national weather service', text.lower())
+
+    def test_unknown_source_defaults_to_civ(self):
+        text = self._construct('UNKNOWN')
+        self.assertIn('civil authorit', text.lower())
+        self.assertNotIn('national weather service', text.lower())
+
+
+# ---------------------------------------------------------------------------
+# §3.8 — msgType filtering (Cancel/Ack/Error not aired; Alert/Update aired)
+# ---------------------------------------------------------------------------
+
+class TestMsgTypeFiltering(unittest.TestCase):
+    """auto_forward_cap_alert must respect CAP msgType (ECIG §3.8):
+      - Alert     → process
+      - Update    → process (supersede handled by cap_poller upstream)
+      - Cancel    → MUST NOT air the cancelled message
+      - Ack/Error → not required to process
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mod = _load_auto_forward_module()
+
+    def _call(self, msg_type):
+        """Invoke auto_forward_cap_alert with just enough scaffolding to
+        reach the msgType gate (status=Actual, scope=Public).
+
+        For msgTypes that pass §3.8 (Alert, Update), we short-circuit the
+        downstream broadcaster path by forcing the cross-source dedupe
+        check to claim duplicate — that way the function returns with a
+        non-§3.8 reason and never tries to import the real audio
+        machinery.
+        """
+        from datetime import datetime, timezone, timedelta
+        sent = datetime.now(timezone.utc) - timedelta(minutes=1)
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        cap_alert = SimpleNamespace(
+            identifier='TEST-001',
+            status='Actual',
+            scope='Public',
+            message_type=msg_type,
+            sent=sent,
+            expires=expires,
+            source='IPAWS',
+            event='Civil Emergency Message',
+            vtec_action=None,
+        )
+        with patch.object(self._mod, '_update_cap_forwarding_status'), \
+             patch.object(self._mod, '_acquire_dedupe_lock'), \
+             patch.object(self._mod, 'is_duplicate_broadcast', return_value=True):
+            return self._mod.auto_forward_cap_alert(
+                cap_alert,
+                {'raw_json': {'properties': {'geocode': {'SAME': ['039001']}}}},
+                db_session=MagicMock(),
+                eas_message_cls=MagicMock(),
+                eas_config={'enabled': True, 'forwarded_event_codes': []},
+            )
+
+    def test_cancel_is_not_aired(self):
+        result = self._call('Cancel')
+        self.assertFalse(result['forwarded'])
+        self.assertIn('Cancel', result.get('reason', ''))
+        self.assertIn('§3.8', result.get('reason', ''))
+
+    def test_ack_is_not_aired(self):
+        result = self._call('Ack')
+        self.assertFalse(result['forwarded'])
+        self.assertIn('§3.8', result.get('reason', ''))
+
+    def test_error_is_not_aired(self):
+        result = self._call('Error')
+        self.assertFalse(result['forwarded'])
+        self.assertIn('§3.8', result.get('reason', ''))
+
+    def test_unknown_msgtype_is_not_aired(self):
+        result = self._call('Bogus')
+        self.assertFalse(result['forwarded'])
+        self.assertIn('§3.8', result.get('reason', ''))
+
+    def test_alert_passes_msgtype_gate(self):
+        # Alert msgType should clear the §3.8 gate; downstream gates
+        # (event-code filter, dedupe, etc.) may still reject it but the
+        # reason MUST NOT cite §3.8.
+        result = self._call('Alert')
+        self.assertNotIn('§3.8', result.get('reason', '') or '')
+
+    def test_update_passes_msgtype_gate(self):
+        result = self._call('Update')
+        self.assertNotIn('§3.8', result.get('reason', '') or '')
+
+
+# ---------------------------------------------------------------------------
+# §3.4.1.7 — Must-Carry bypasses event-code filter in auto_forward
+# ---------------------------------------------------------------------------
+
+class TestMustCarryBypassesEventFilter(unittest.TestCase):
+    """When EAS-Must-Carry=True, auto_forward must NOT reject the alert on
+    the event-code allowlist (§3.4.1.7).  We can verify this by setting a
+    restrictive allowlist that would otherwise reject the alert."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mod = _load_auto_forward_module()
+
+    def _call(self, must_carry, event_name='Civil Emergency Message',
+              allowlist=('TOR',)):
+        from datetime import datetime, timezone, timedelta
+        sent = datetime.now(timezone.utc) - timedelta(minutes=1)
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        cap_alert = SimpleNamespace(
+            identifier='TEST-002',
+            status='Actual',
+            scope='Public',
+            message_type='Alert',
+            sent=sent,
+            expires=expires,
+            source='IPAWS',
+            event=event_name,
+            vtec_action=None,
+        )
+        parameters = {'EAS-Must-Carry': 'True'} if must_carry else {}
+        # Force the cross-source dedupe to claim duplicate so the function
+        # bails out before hitting the real broadcaster (which would pull
+        # in scipy / alert_metadata).  We're only verifying the upstream
+        # event-code gate here.
+        with patch.object(self._mod, '_update_cap_forwarding_status'), \
+             patch.object(self._mod, '_acquire_dedupe_lock'), \
+             patch.object(self._mod, 'is_duplicate_broadcast', return_value=True):
+            return self._mod.auto_forward_cap_alert(
+                cap_alert,
+                {'raw_json': {'properties': {
+                    'parameters': parameters,
+                    'geocode': {'SAME': ['039001']},
+                }}},
+                db_session=MagicMock(),
+                eas_message_cls=MagicMock(),
+                eas_config={
+                    'enabled': True,
+                    'forwarded_event_codes': list(allowlist),
+                },
+            )
+
+    def test_without_must_carry_event_outside_allowlist_is_rejected(self):
+        result = self._call(must_carry=False)
+        self.assertFalse(result['forwarded'])
+        self.assertIn('not in the configured forwarding allowlist',
+                      result.get('reason', ''))
+
+    def test_must_carry_bypasses_event_allowlist(self):
+        result = self._call(must_carry=True)
+        # Reason (if any) MUST NOT be the event-code allowlist; the alert
+        # may still fail later gates (no dedupe table, no real DB), but the
+        # event-code gate must let it through.
+        reason = result.get('reason') or ''
+        self.assertNotIn('not in the configured forwarding allowlist', reason)
+        self.assertTrue(result.get('must_carry'))
+
+    def test_must_carry_bypasses_rwt_suppression(self):
+        # RWT is normally suppressed unless explicitly listed; must-carry
+        # overrides this too.
+        result = self._call(must_carry=True, event_name='Required Weekly Test',
+                            allowlist=())
+        reason = result.get('reason') or ''
+        self.assertNotIn('RWT not forwarded', reason)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Audit against ECIG-CAP-to-EAS Implementation Guide V1.0 surfaced five
spec deviations in the auto-forward and audio-rendering paths.  This
change closes all five, with unit coverage for each.

§3.4.1.7 Governor's Must-Carry: a new EAS-Must-Carry CAP parameter
detector lets governor-mandated alerts bypass the event-code allowlist
and RWT suppression in auto_forward_cap_alert.  Location filtering and
duplicate prevention still apply per spec.

§3.8 msgType filtering: auto_forward now rejects Cancel (cancelled
messages MUST NOT be aired), Ack, Error, and unknown msgType values.
Alert and Update fall through to the existing supersede pipeline.

§3.5.1 Resource-URI timeouts: _fetch_embedded_audio now selects 120 s
for downloadable MP3/WAV resources and 30 s for streaming sources,
matching the spec caps.  Timeouts fall through to TTS as before.

§3.5.2 / §3.5.4 '***' deletion pause: the TTS normalizer now converts
three-or-more asterisks to a sentence break instead of silently
stripping them, giving the spec-required ~1 s pause across every TTS
backend in the project.

§3.10 default originator: when EAS-ORG is absent the originator now
defaults to CIV (per spec) instead of WXR.  NOAA/NWS sources retain
WXR since their CAP feeds intentionally omit EAS-ORG.