### PR TITLE
docs: bring compliance log docs current with FCC Part 11 fields

### DIFF
--- a/docs/guides/ANALYTICS_AND_REPORTING.md
+++ b/docs/guides/ANALYTICS_AND_REPORTING.md
@@ -123,20 +123,40 @@ GET /api/analytics/anomalies
 
 ### PDF Compliance Reports
 
-Navigate to **Compliance** (`/admin/compliance`) to generate FCC-ready documentation:
+Navigate to **Compliance** (`/admin/compliance`) to generate FCC-ready
+documentation:
 
 1. Select a date range using the date pickers.
-2. Click **Export PDF** to download a formatted compliance report including:
-   - Alert receipt log with timestamps
-   - Required Weekly Test (RWT) record
-   - System health summary
-   - Broadcast history
+2. Click **Export PDF** to download the **EAS Part 11 Compliance Log**, a
+   paginated landscape report whose columns satisfy 47 CFR §§ 11.35(a) and
+   11.54(a)(3):
+   - Timestamp (local / UTC)
+   - Category — `received` (CAP feeds), `relayed` (CAP→SAME), `off-air`
+     (RF/stream-decoded EAS), or `manual`
+   - Originator (ORG, 3-char SAME code + descriptive name)
+   - Event Code (EEE)
+   - Event (plain-language name)
+   - FIPS Codes (PSSCCC list)
+   - Station ID (LLLLLLLL, the 8-char identifier per § 11.31)
+   - Action Taken (`Initiated` / `Relayed` / `Not relayed` / `Received` /
+     `Decode error`)
+   - Identifier (CAP URN or full SAME header)
+   - Details (issue/purge times, forwarding reason, severity/urgency, etc.)
+
+   Cells wrap to as many lines as needed, alternating row shading separates
+   entries, and the trailing summary block breaks the totals out by
+   category, originator, and action.
 
 ### CSV Export
 
-1. Go to **Alert History** (`/admin/alerts`).
-2. Apply any filters (date range, severity, event type).
-3. Click **Export CSV** to download the filtered alert list.
+The compliance log CSV (also exported from `/admin/compliance`) carries
+the same FCC Part 11 columns as the PDF: Timestamp, Category, Originator,
+Event Code, Event, FIPS Codes, Issue Time, Purge / Expires, Station ID,
+Identifier, Status, Action Taken, Action Reason, and a JSON `Details`
+blob for any category-specific metadata that did not get its own column.
+
+To export raw CAP/alert history instead, go to **Alert History**
+(`/admin/alerts`), apply filters, and click **Export CSV**.
 
 ### Statistics Tab
 

--- a/docs/guides/HELP.md
+++ b/docs/guides/HELP.md
@@ -26,9 +26,9 @@ Welcome to the operator help guide for the NOAA CAP Emergency Alert System (EAS)
 3. Check **System Health** for CPU, memory, disk, receiver, and audio pipeline heartbeat metrics.
 
 ### Reviewing Compliance & Weekly Tests
-- Navigate to **Compliance** (`/admin/compliance`) for a consolidated view of received versus relayed alerts, Required Weekly Tests, and background worker activity.
+- Navigate to **Compliance** (`/admin/compliance`) for a consolidated view of CAP receipts, CAP→SAME relays, off-air decoded broadcasts (from RF/stream receivers), manual activations, Required Weekly Tests, and background worker activity.
 - Receiver health summaries, audio output heartbeat checks, and recent activity timelines pull directly from `app_core/system_health.py` and `app_core/eas_storage.py`.
-- Export CSV or PDF compliance logs from the buttons at the top of the page to generate FCC-ready documentation.
+- Export CSV or PDF compliance logs from the buttons at the top of the page to generate FCC-ready documentation. Each log entry carries the Part 11 identity fields — originator code (ORG), event code (EEE), location codes (PSSCCC), station identifier (LLLLLLLL), issue and purge times, and the action taken — per 47 CFR §§ 11.35(a) and 11.54(a)(3).
 
 ### Managing Boundaries and Alerts
 - Use the **Boundaries** module to upload county, district, or custom GIS polygons.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved guidance for generating and exporting compliance reports with clearer instructions and expected data fields.
  * Clarified the distinction between compliance log exports and raw alert history exports.
  * Enhanced Compliance page documentation with FCC Part 11 compliance details and required data fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->