### PR TITLE
Add multi-packet MDC1200 decoder and improve EAS fingerprinting

### DIFF
--- a/app_utils/eas_decode.py
+++ b/app_utils/eas_decode.py
@@ -939,17 +939,37 @@ def _bits_to_text(bits: List[int]) -> Dict[str, object]:
                 end_bit = trimmed_positions[-1] + 8
                 burst_bit_ranges.append((start_bit, end_bit))
 
-    if char_positions:
+    # Scope frame counting to bits inside the detected SAME burst regions.
+    # The scan above starts at burst_positions[0] and runs to the end of the
+    # bit stream, so without scoping every 8-bit window of inter-burst
+    # silence, the audio message, the EOM gap, and any post-alert audio gets
+    # counted as a failed frame.  On a clean signal that inflates
+    # frame_errors and drags the headline confidence down by 20% via the
+    # error-rate penalty in _calculate_adjusted_confidence().
+    def _bit_in_burst_ranges(pos: int) -> bool:
+        if not burst_bit_ranges:
+            return True
+        for start_bit, end_bit in burst_bit_ranges:
+            if start_bit <= pos < end_bit:
+                return True
+        return False
+
+    if burst_bit_ranges:
+        relevant_chars = [pos for pos in char_positions if _bit_in_burst_ranges(pos)]
+        relevant_errors = [pos for pos in error_positions if _bit_in_burst_ranges(pos)]
+        frame_errors = len(relevant_errors)
+        frame_count = len(relevant_chars) + frame_errors
+    elif char_positions:
         first_bit = char_positions[0]
         last_bit = char_positions[-1]
         relevant_errors = [
             pos for pos in error_positions if first_bit <= pos <= last_bit
         ]
+        frame_errors = len(relevant_errors)
+        frame_count = len(characters) + frame_errors
     else:
-        relevant_errors = list(error_positions)
-
-    frame_errors = len(relevant_errors)
-    frame_count = len(characters) + frame_errors
+        frame_errors = len(error_positions)
+        frame_count = len(characters) + frame_errors
 
     metadata = _process_decoded_text(
         raw_text,

--- a/app_utils/eas_demod.py
+++ b/app_utils/eas_demod.py
@@ -33,7 +33,7 @@ fingerprinting now live here exactly once.
 from __future__ import annotations
 
 import logging
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -275,7 +275,11 @@ def detect_endec_mode(
     if not messages:
         return ENDEC_MODE_UNKNOWN
 
+    # EAS_STATION listed first so that on a vote tie it wins over the
+    # ENDECs whose terminator bytes (0x00 / 0xFF) overlap with the FSK
+    # silence floor.  max(...) returns the first key reaching the max.
     votes: dict = {
+        ENDEC_MODE_EAS_STATION:  0.0,
         ENDEC_MODE_DEFAULT:      0.0,
         ENDEC_MODE_NWS:          0.0,
         ENDEC_MODE_NWS_CRS:      0.0,
@@ -283,12 +287,28 @@ def detect_endec_mode(
         ENDEC_MODE_SAGE_3644:    0.0,
         ENDEC_MODE_SAGE_1822:    0.0,
         ENDEC_MODE_TRILITHIC:    0.0,
-        ENDEC_MODE_EAS_STATION:  0.0,
     }
 
-    # 1. Terminator byte votes — primary ENDEC discriminator
+    # 1. Terminator byte votes — primary ENDEC discriminator.
+    # Collapse repeated per-burst entries to the MAX run length seen for
+    # each byte value, so a single noise-corrupted run cannot dominate
+    # the vote and so legitimate fingerprints aren't double-counted
+    # across all three SAME bursts.  KR8MER's 3 × 0xA9 trill is a hard
+    # signature — when it appears with a clean run length, it wins
+    # outright (no other ENDEC emits 0xA9 bytes).
     if terminator_runs:
+        max_run_per_byte: Dict[int, int] = {}
         for byte_val, run_length in terminator_runs:
+            if run_length > max_run_per_byte.get(byte_val, 0):
+                max_run_per_byte[byte_val] = run_length
+
+        if max_run_per_byte.get(0xA9, 0) >= 3:
+            # KR8MER EAS Station fingerprint is deliberate and unambiguous;
+            # short-circuit the vote so 0x00/0xFF silence-floor evidence
+            # captured on neighbouring bursts can't override it.
+            return ENDEC_MODE_EAS_STATION
+
+        for byte_val, run_length in max_run_per_byte.items():
             if byte_val == 0x00:
                 # Null-byte terminator → NWS variants.
                 # Vote strength is proportional to run length, and the specific
@@ -490,6 +510,19 @@ class SAMEDemodulatorCore:
         self._all_terminator_runs: List[Tuple[int, int]] = []  # (byte_val, run_len) per burst
         self._leading_null_detected: bool = False  # 0x00 seen just before preamble
         self._prev_decoded_byte: Optional[int] = None  # last successfully decoded byte
+        # Cap captured terminator bytes per burst.  Real ENDECs append 1-3
+        # terminator bytes after each SAME burst; anything longer is the FSK
+        # noise floor (inter-burst silence decoded as all-mark 0xFF bytes,
+        # or sustained DC as 0x00) and must not pollute the fingerprint.
+        self._post_message_bytes_captured: int = 0
+        self._MAX_TERMINATOR_BYTES_PER_BURST = 8
+
+        # Absolute sample position of the bit currently being processed.
+        # Updated by process_samples() before each _handle_bit_event() call so
+        # that burst_sample_ranges reflect the actual position of each burst
+        # in the audio (not the end-of-chunk position, which broke gap timing
+        # on batch decodes where the whole file arrives in a single chunk).
+        self._current_sample_position: int = 0
 
         # Prefix buffer for cross-chunk continuity (streaming use)
         self._prefix = np.zeros(self.corr_len - 1, dtype=np.float32)
@@ -603,7 +636,12 @@ class SAMEDemodulatorCore:
             self.sphase = int(self._dll_state[2])
             self.lasts = int(self._dll_state[3])
 
+            # Chunk-relative sample indices in out_indices[] become absolute
+            # positions by adding the chunk start.  samples_processed already
+            # advanced to end-of-chunk above (line 520) so subtract num_samples.
+            chunk_start_sample = self.samples_processed - num_samples
             for k in range(emitted):
+                self._current_sample_position = chunk_start_sample + int(out_indices[k])
                 self._handle_bit_event(
                     int(out_lasts[k]),
                     float(out_confidences[k]),
@@ -658,6 +696,7 @@ class SAMEDemodulatorCore:
             if self._post_message_mode:
                 self._flush_terminator_run()
                 self._post_message_mode = False
+                self._post_message_bytes_captured = 0
                 self._update_endec_from_evidence()
             self.synced = True
             self.byte_counter = 0
@@ -694,12 +733,39 @@ class SAMEDemodulatorCore:
                             self._flush_terminator_run()
                             self._terminator_byte = byte_val
                             self._terminator_run = 1
+                        self._post_message_bytes_captured += 1
+
+                        # KR8MER EAS Station fingerprint is a precise 3 × 0xA9
+                        # trill.  Once it's captured, lock it in immediately —
+                        # any further 0xFF accumulated during inter-burst
+                        # silence (the FSK demod outputs mark bits when the
+                        # signal goes quiet) would corrupt the fingerprint
+                        # vote with bogus SAGE_DIGITAL_3644 evidence.
+                        eas_station_locked = (
+                            self._terminator_byte == 0xA9
+                            and self._terminator_run >= 3
+                        )
+
+                        # Real ENDEC terminator runs are 1-3 bytes.  Anything
+                        # longer is signal noise — cap at MAX_TERMINATOR_BYTES
+                        # so a long silence cannot accumulate hundreds of
+                        # 0xFF/0x00 bytes into a single huge run.
+                        if (
+                            eas_station_locked
+                            or self._terminator_run >= self._MAX_TERMINATOR_BYTES_PER_BURST
+                            or self._post_message_bytes_captured >= self._MAX_TERMINATOR_BYTES_PER_BURST
+                        ):
+                            self._flush_terminator_run()
+                            self._post_message_mode = False
+                            self._post_message_bytes_captured = 0
+                            self._update_endec_from_evidence()
                     elif byte_val in (10, 13):
                         pass  # Skip CR/LF - part of FCC Section 11.31 header encoding
                     else:
                         # Non-terminator byte ends post-message capture
                         self._flush_terminator_run()
                         self._post_message_mode = False
+                        self._post_message_bytes_captured = 0
                         self._update_endec_from_evidence()
                         if byte_val != self.PREAMBLE_BYTE:
                             self.synced = False
@@ -714,7 +780,7 @@ class SAMEDemodulatorCore:
                         # Both begin with their own preamble so synced=True here
                         # means we just came off a valid 0xAB preamble run.
                         self.in_message = True
-                        self._burst_start_sample = self.samples_processed
+                        self._burst_start_sample = self._current_sample_position
                         self.current_msg = [char]
                     elif self.in_message:
                         self.current_msg.append(char)
@@ -728,6 +794,7 @@ class SAMEDemodulatorCore:
                             self.bit_confidences = []
                             self._burst_start_sample = None
                             self._post_message_mode = True
+                            self._post_message_bytes_captured = 0
                             # Keep self.synced = True for terminator capture
                         elif len(self.current_msg) > self.MAX_MSG_LEN:
                             self._reset_message_state()
@@ -770,11 +837,12 @@ class SAMEDemodulatorCore:
 
         # Record burst timing
         if self._burst_start_sample is not None:
+            burst_end_sample = self._current_sample_position
             self.burst_sample_ranges.append(
-                (self._burst_start_sample, self.samples_processed)
+                (self._burst_start_sample, burst_end_sample)
             )
             self._burst_sample_history.append(
-                (self._burst_start_sample, self.samples_processed)
+                (self._burst_start_sample, burst_end_sample)
             )
             self._burst_start_sample = None
             if len(self._burst_sample_history) > 4:

--- a/app_utils/eas_detection.py
+++ b/app_utils/eas_detection.py
@@ -244,7 +244,7 @@ def detect_eas_from_file(
         # MDC1200 selective-calling packets.  Uses the buffer or composite segment
         # already in memory from the SAME decode to avoid re-reading the file.
         try:
-            from app_utils.mdc1200 import decode_mdc1200_from_samples as _decode_mdc
+            from app_utils.mdc1200 import decode_all_mdc1200_from_samples as _decode_all_mdc
             mdc_audio: Optional[np.ndarray] = None
             mdc_rate: int = same_result.sample_rate or 16000
             for seg_key in ("buffer", "composite"):
@@ -265,8 +265,8 @@ def detect_eas_from_file(
                 except Exception:
                     continue
             if mdc_audio is not None:
-                pkt = _decode_mdc(mdc_audio, mdc_rate)
-                if pkt is not None:
+                packets = _decode_all_mdc(mdc_audio, mdc_rate)
+                for pkt in packets:
                     result.mdc1200_packets.append(pkt)
                     logger.info(
                         "MDC1200 packet decoded: unit_id=0x%04X op=0x%02X arg=0x%02X crc_ok=%s",

--- a/app_utils/mdc1200.py
+++ b/app_utils/mdc1200.py
@@ -942,11 +942,15 @@ def decode_mdc1200_from_samples(
     samples,
     sample_rate: int,
 ) -> Optional["MDC1200Packet"]:
-    """Demodulate MDC1200 FFSK from PCM audio and return the decoded packet.
+    """Demodulate MDC1200 FFSK from PCM audio and return the first decoded packet.
 
     Runs a Goertzel FSK demodulator at 1200 baud (mark = 1200 Hz,
     space = 1800 Hz) over the provided samples, searches for the MDC1200
-    preamble + sync word, and returns the decoded packet when found.
+    preamble + sync word, and returns the first decoded packet.
+
+    For audio containing multiple MDC1200 bursts (e.g. PTT-ID Pre at the
+    start of an EAS alert *and* PTT-ID Post at the end), use
+    :func:`decode_all_mdc1200_from_samples` to recover every packet.
 
     Both single-packet (26-byte) and double-packet (40-byte) frames are
     tried; double-packet is attempted first when enough bits are available.
@@ -960,13 +964,39 @@ def decode_mdc1200_from_samples(
         Decoded :class:`MDC1200Packet` on success, ``None`` if no valid
         MDC1200 frame is found in the audio.
     """
+    packets = decode_all_mdc1200_from_samples(samples, sample_rate)
+    return packets[0] if packets else None
+
+
+def decode_all_mdc1200_from_samples(
+    samples,
+    sample_rate: int,
+) -> List["MDC1200Packet"]:
+    """Demodulate MDC1200 FFSK from PCM audio and return every valid packet.
+
+    Mirrors :func:`decode_mdc1200_from_samples` but keeps searching past
+    the first sync match so multi-burst transmissions (PTT-ID Pre + Post,
+    or chained packets) are fully recovered.  After each successful
+    decode the cursor advances past the consumed frame; on a sync hit
+    that fails CRC the cursor advances one bit so the search continues
+    without looping.
+
+    Args:
+        samples: Audio samples as a list of floats or a numpy array.
+            May be int16-range or normalised − 1.0..1.0.
+        sample_rate: Sample rate in Hz.
+
+    Returns:
+        List of decoded :class:`MDC1200Packet`, in transmission order.
+        Empty list if no valid MDC1200 frame is found.
+    """
     try:
         sample_list = [float(s) for s in samples]
     except (TypeError, ValueError):
-        return None
+        return []
 
     if len(sample_list) < int(sample_rate / MDC1200_BAUD) * 4:
-        return None
+        return []
 
     # FSK demodulate: for each bit period, compare Goertzel power at the
     # mark (1200 Hz) and space (1800 Hz) carriers.  A stronger mark power
@@ -1011,16 +1041,7 @@ def decode_mdc1200_from_samples(
     _DOUBLE_BITS = (len(MDC1200_PREAMBLE) + len(MDC1200_SYNC) + _FEC_K * 2 + len(MDC1200_INTER_PACKET_PREAMBLE) + _FEC_K * 2) * 8
 
     if len(raw_bits) < _SINGLE_BITS:
-        return None
-
-    sync_result = find_sync_in_bits(raw_bits)
-    if sync_result is None:
-        return None
-    bit_offset, polarity = sync_result
-
-    frame_bits = raw_bits[bit_offset:]
-    if polarity:
-        frame_bits = [b ^ 1 for b in frame_bits]
+        return []
 
     def _bits_to_bytes(blist: List[int], n: int) -> Optional[List[int]]:
         if len(blist) < n * 8:
@@ -1036,22 +1057,64 @@ def decode_mdc1200_from_samples(
     _SINGLE_BYTES = _SINGLE_BITS // 8
     _DOUBLE_BYTES = _DOUBLE_BITS // 8
 
-    if len(frame_bits) >= _DOUBLE_BITS:
-        double_frame = _bits_to_bytes(frame_bits, _DOUBLE_BYTES)
-        if double_frame is not None:
+    packets: List["MDC1200Packet"] = []
+    cursor = 0
+    while cursor + _SINGLE_BITS <= len(raw_bits):
+        sync_result = find_sync_in_bits(raw_bits[cursor:])
+        if sync_result is None:
+            break
+        bit_offset, polarity = sync_result
+        sync_abs = cursor + bit_offset
+
+        frame_bits = raw_bits[sync_abs:]
+        if polarity:
+            frame_bits = [b ^ 1 for b in frame_bits]
+
+        packet: Optional["MDC1200Packet"] = None
+        consumed_bits = 0
+
+        # Try single-packet decode first.  Single-packet frames end with a
+        # 4-byte 0x00 post-preamble whose layout overlaps the start of a
+        # double-packet's inter-packet preamble; decoding the same audio as
+        # a double-packet "succeeds" for any single packet (with bogus
+        # packet-2 fields and crc2_ok=False) when the trailing audio is
+        # silence.  Preferring the single-packet path avoids that misread.
+        single_frame = _bits_to_bytes(frame_bits, _SINGLE_BYTES)
+        if single_frame is not None:
             try:
-                return decode_double_packet(double_frame)
+                packet = decode_packet(single_frame)
+                consumed_bits = _SINGLE_BITS
             except MDC1200DecodeError:
                 pass
 
-    single_frame = _bits_to_bytes(frame_bits, _SINGLE_BYTES)
-    if single_frame is not None:
-        try:
-            return decode_packet(single_frame)
-        except MDC1200DecodeError:
-            pass
+        # Only promote to a double-packet decode when (a) we have enough
+        # bits, AND (b) the recovered opcode/arg is a known double-packet
+        # operation.  This stops PTT-ID Pre / Post (single-packet ops)
+        # from being mis-promoted into a double-packet with target=0x0000.
+        if (
+            packet is not None
+            and len(frame_bits) >= _DOUBLE_BITS
+            and is_double_packet_op(packet.opcode, packet.arg)
+        ):
+            double_frame = _bits_to_bytes(frame_bits, _DOUBLE_BYTES)
+            if double_frame is not None:
+                try:
+                    double_packet = decode_double_packet(double_frame)
+                    if double_packet.crc_ok and double_packet.crc2_ok:
+                        packet = double_packet
+                        consumed_bits = _DOUBLE_BITS
+                except MDC1200DecodeError:
+                    pass
 
-    return None
+        if packet is not None:
+            packets.append(packet)
+            cursor = sync_abs + consumed_bits
+        else:
+            # Failed CRC at this sync candidate — advance past it so the
+            # search continues without re-locking onto the same offset.
+            cursor = sync_abs + 1
+
+    return packets
 
 
 def find_sync_in_bits(bits: Sequence[int]) -> Optional[Tuple[int, int]]:
@@ -1126,4 +1189,5 @@ __all__ = [
     "decode_double_packet",
     "find_sync_in_bits",
     "decode_mdc1200_from_samples",
+    "decode_all_mdc1200_from_samples",
 ]

--- a/tests/test_eas_decode.py
+++ b/tests/test_eas_decode.py
@@ -695,3 +695,49 @@ def test_dll_endec_detection_eas_station_integration() -> None:
         f"Expected EAS_STATION from 3×0xA9 terminator bytes, got {core.endec_mode!r}. "
         f"terminator_runs={core._all_terminator_runs!r}"
     )
+
+
+def test_detect_endec_eas_station_a9_beats_silence_floor_ff_noise() -> None:
+    """When the DLL captures a real KR8MER 3×0xA9 trill on every burst
+    but the FSK demod also picks up post-fingerprint silence as long
+    runs of 0xFF (mark tone), the EAS_STATION vote must still win.
+
+    Before this guard, repeated ``(0xFF, large_N)`` runs accumulated
+    enough SAGE_DIGITAL_3644 vote to tie or beat the legitimate KR8MER
+    fingerprint, and a clean EAS Station composite was misidentified as
+    SAGE DIGITAL.
+    """
+    runs = []
+    # Three bursts, each emitting the legitimate trill followed by a
+    # long silence-floor 0xFF run.
+    for _ in range(3):
+        runs.append((0xA9, 3))
+        runs.append((0xFF, 8))
+    mode = detect_endec_mode(
+        ["ZCZC-WXR-DMO-039003+0015-0001234-KR8MER-"],
+        [],
+        terminator_runs=runs,
+    )
+    assert mode == ENDEC_MODE_EAS_STATION, (
+        f"Expected EAS_STATION (0xA9 trill is unique to KR8MER), got {mode!r}"
+    )
+
+
+def test_detect_endec_deduplicates_repeated_burst_evidence() -> None:
+    """Three identical SAME bursts produce three identical terminator
+    runs; the vote must not multiply by three (which used to allow
+    accumulated 0xFF silence noise to override a single legitimate
+    fingerprint observed in a different vote slot)."""
+    # SAGE DIGITAL — 3 bursts × (0xFF, 3) should still pick SAGE_3644,
+    # but a single (0xFF, 3) entry should yield the same result.
+    mode_single = detect_endec_mode(
+        ["ZCZC-WXR-TOR-029015+0030-0181500-KOAX/NWS-"],
+        [],
+        terminator_runs=[(0xFF, 3)],
+    )
+    mode_triple = detect_endec_mode(
+        ["ZCZC-WXR-TOR-029015+0030-0181500-KOAX/NWS-"],
+        [],
+        terminator_runs=[(0xFF, 3), (0xFF, 3), (0xFF, 3)],
+    )
+    assert mode_single == mode_triple == ENDEC_MODE_SAGE_3644

--- a/tests/test_mdc1200.py
+++ b/tests/test_mdc1200.py
@@ -58,7 +58,9 @@ from app_utils.mdc1200 import (  # noqa: E402
     _xor_modulate,
     bytes_to_bits_msb,
     compute_crc,
+    decode_all_mdc1200_from_samples,
     decode_double_packet,
+    decode_mdc1200_from_samples,
     decode_packet,
     encode_packet,
     find_sync_in_bits,
@@ -635,3 +637,93 @@ def test_mdc1200_packet_all_checks_pass_requires_double_packet_halves():
         target_unit_id=0x2222, crc2_ok=False, fec2_ok=True,
     )
     assert pkt.all_checks_pass is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-packet sample-level decoder
+# ---------------------------------------------------------------------------
+
+def test_decode_all_mdc1200_recovers_ptt_id_pre_and_post():
+    """Audio containing both PTT-ID Pre (start) and PTT-ID Post (end)
+    must yield two packets — the single-pass ``decode_mdc1200_from_samples``
+    used to return only the first sync match and silently dropped the
+    trailing Post burst that real EAS Station composites emit."""
+    import numpy as np
+
+    sr = 16000
+    amp = 0.7 * 32767
+    unit_id = 0x1F96
+
+    pre = generate_mdc1200_samples(0x01, 0x80, unit_id, sr, amp)
+    post = generate_mdc1200_samples(0x00, 0x80, unit_id, sr, amp)
+    silence = [0] * sr  # 1 second of silence between bursts
+
+    waveform = np.array(list(pre) + silence + list(post), dtype=np.float32) / 32768.0
+
+    packets = decode_all_mdc1200_from_samples(waveform, sr)
+    assert len(packets) == 2, f"Expected Pre + Post, got {len(packets)} packets"
+
+    assert packets[0].opcode == 0x01 and packets[0].arg == 0x80
+    assert packets[0].unit_id == unit_id
+    assert packets[0].crc_ok
+
+    assert packets[1].opcode == 0x00 and packets[1].arg == 0x80
+    assert packets[1].unit_id == unit_id
+    assert packets[1].crc_ok
+
+
+def test_decode_single_packet_is_not_misread_as_double_packet():
+    """A single-packet PTT-ID Pre must not be promoted into a double-
+    packet decode just because its trailing 4-byte 0x00 post-preamble
+    overlaps the start of a double-packet's inter-packet preamble.
+
+    Before this guard, ``target_unit_id`` ended up set to ``0x0000``
+    (with ``crc2_ok=False``) and the UI rendered the burst as
+    ``PTT-ID Pre → 0x0000`` — a phantom target that misled operators
+    into thinking the decoder had also recovered a Post burst.
+    """
+    import numpy as np
+
+    sr = 16000
+    amp = 0.7 * 32767
+    samples = generate_mdc1200_samples(0x01, 0x80, 0x1F96, sr, amp)
+    waveform = np.array(list(samples) + [0] * (sr // 2), dtype=np.float32) / 32768.0
+
+    packet = decode_mdc1200_from_samples(waveform, sr)
+    assert packet is not None
+    assert packet.opcode == 0x01 and packet.arg == 0x80
+    assert packet.crc_ok
+    assert packet.target_unit_id is None, (
+        f"Single-packet PTT-ID Pre must report target_unit_id=None, "
+        f"got {packet.target_unit_id!r}"
+    )
+    assert packet.is_double_packet is False
+
+
+def test_decode_all_mdc1200_returns_empty_on_silence():
+    """Pure silence must not produce any phantom packets."""
+    import numpy as np
+    sr = 16000
+    waveform = np.zeros(sr, dtype=np.float32)
+    assert decode_all_mdc1200_from_samples(waveform, sr) == []
+
+
+def test_decode_all_mdc1200_recovers_real_double_packet():
+    """A genuine double-packet op (Call Alert 0x63/0x85) must still
+    decode as a single double-packet, not be misread as two singles."""
+    import numpy as np
+    from app_utils.mdc1200 import generate_mdc1200_samples as gen
+
+    sr = 16000
+    amp = 0.7 * 32767
+    # Call Alert is in MDC1200_DOUBLE_PACKET_OPS — gen() emits 40-byte frame.
+    samples = gen(0x63, 0x85, 0x1111, sr, amp, target_unit_id=0x2222)
+    waveform = np.array(list(samples) + [0] * (sr // 2), dtype=np.float32) / 32768.0
+
+    packets = decode_all_mdc1200_from_samples(waveform, sr)
+    assert len(packets) == 1
+    pkt = packets[0]
+    assert pkt.opcode == 0x63 and pkt.arg == 0x85
+    assert pkt.unit_id == 0x1111
+    assert pkt.target_unit_id == 0x2222
+    assert pkt.crc_ok and pkt.crc2_ok


### PR DESCRIPTION
## Summary
This PR enhances MDC1200 decoding to recover multiple packets from a single audio stream and improves EAS ENDEC fingerprinting robustness by deduplicating evidence and protecting against silence-floor noise.

## Key Changes

### MDC1200 Multi-Packet Decoding
- **New function `decode_all_mdc1200_from_samples()`**: Decodes all valid MDC1200 packets from audio instead of stopping at the first match. This enables recovery of multi-burst transmissions like PTT-ID Pre + Post sequences commonly found in EAS Station composites.
- **Refactored `decode_mdc1200_from_samples()`**: Now delegates to `decode_all_mdc1200_from_samples()` and returns the first packet, maintaining backward compatibility.
- **Improved double-packet detection**: Added `is_double_packet_op()` guard to prevent single-packet operations (PTT-ID Pre/Post) from being misread as double-packet frames with phantom `target_unit_id=0x0000`.
- **Robust cursor advancement**: On sync match with failed CRC, advances one bit to continue searching without re-locking on the same offset.

### EAS ENDEC Fingerprinting
- **Terminator byte deduplication**: Collapses repeated per-burst terminator evidence to the maximum run length per byte value, preventing a single noise-corrupted run from dominating the vote across three SAME bursts.
- **KR8MER 0xA9 trill protection**: When the distinctive 3×0xA9 fingerprint is detected, immediately locks in `ENDEC_MODE_EAS_STATION` to prevent post-fingerprint silence (0xFF noise) from corrupting the vote.
- **Terminator byte capping**: Limits captured terminator bytes per burst to 8 (real ENDECs emit 1-3), preventing long silence periods from accumulating hundreds of noise bytes into a single run.

### EAS Demodulation Accuracy
- **Absolute sample position tracking**: Added `_current_sample_position` to track the actual bit position being processed, fixing burst timing calculations that were previously off by chunk boundaries in batch decodes.
- **Burst range precision**: `burst_sample_ranges` now reflect the true position of each burst in the audio stream rather than the end-of-chunk position.

### EAS Confidence Calculation
- **Scoped frame error counting**: Frame errors are now counted only within detected SAME burst regions, preventing inter-burst silence, audio messages, and post-alert content from inflating error rates and artificially reducing confidence scores.

## Testing
Added comprehensive test coverage for:
- Multi-packet recovery (PTT-ID Pre + Post)
- Single-packet misread prevention
- Silence handling
- Genuine double-packet decoding
- ENDEC fingerprinting with noise immunity
- Terminator byte deduplication

https://claude.ai/code/session_012L24MvQZhk9i6dK22Hi1GV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame error counting to only consider detected burst regions
  * Enhanced ENDEC fingerprint detection with better noise immunity
  * Fixed burst timing consistency in message processing
  * Improved MDC1200 multi-frame detection capability

* **New Features**
  * Added support for decoding multiple MDC1200 packets per audio stream

* **Tests**
  * Added regression tests for EAS detection and MDC1200 decoding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->