### PR TITLE
fix(alert-detail): stop social-export dropdown caret from ballooning

### DIFF
--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -1844,20 +1844,15 @@
                                 <a href="{{ url_for('api.alert_detail_pdf', alert_id=alert.id) }}" target="_blank" class="btn btn-outline-secondary">
                                     <i class="fas fa-file-pdf"></i> Export PDF
                                 </a>
-                                <div class="btn-group" role="group" aria-label="Export Social Image">
-                                    <a href="{{ url_for('api.alert_detail_image', alert_id=alert.id, ratio='landscape') }}"
-                                       class="btn btn-outline-primary flex-grow-1"
-                                       title="Download a 1200×630 PNG ready to post on Facebook, X/Twitter, or LinkedIn">
-                                        <i class="fas fa-share-alt"></i> Export Social Image
-                                    </a>
+                                <div class="dropdown d-grid">
                                     <button type="button"
-                                            class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0"
+                                            class="btn btn-outline-primary w-100"
                                             data-bs-toggle="dropdown"
                                             aria-expanded="false"
-                                            title="Pick another size or format">
-                                        <span class="visually-hidden">Pick a size or format</span>
+                                            title="Download an image sized for Facebook, X/Twitter, Instagram, or Stories">
+                                        <i class="fas fa-share-alt"></i> Export Social Image
                                     </button>
-                                    <ul class="dropdown-menu">
+                                    <ul class="dropdown-menu w-100">
                                         <li><h6 class="dropdown-header">PNG · universal</h6></li>
                                         <li>
                                             <a class="dropdown-item"

--- a/templates/alert_detail.html
+++ b/templates/alert_detail.html
@@ -1846,12 +1846,12 @@
                                 </a>
                                 <div class="btn-group" role="group" aria-label="Export Social Image">
                                     <a href="{{ url_for('api.alert_detail_image', alert_id=alert.id, ratio='landscape') }}"
-                                       class="btn btn-outline-primary"
+                                       class="btn btn-outline-primary flex-grow-1"
                                        title="Download a 1200×630 PNG ready to post on Facebook, X/Twitter, or LinkedIn">
                                         <i class="fas fa-share-alt"></i> Export Social Image
                                     </a>
                                     <button type="button"
-                                            class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
+                                            class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0"
                                             data-bs-toggle="dropdown"
                                             aria-expanded="false"
                                             title="Pick another size or format">


### PR DESCRIPTION
The 'Export Social Image' control is a Bootstrap split-button .btn-group
placed as a direct child of a .d-grid container. The grid stretches the
group to full width, and because Bootstrap gives every .btn-group > .btn
'flex: 1 1 auto', the extra width was split evenly between the main
button and the dropdown-toggle-split caret — so the caret ballooned to
roughly half the control's width and the button looked broken.

Pin the caret toggle to flex-grow-0 and let the main button take the
slack with flex-grow-1, so it renders as a normal full-width button with
a thin caret beside it, matching the other action buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Export Social Image" button in the Actions panel to a full-width primary button design, improving visual consistency and streamlining the user interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KR8MER/eas-station/pull/2205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->