### PR TITLE
Add signaling metadata display for manual EAS activations

### DIFF
--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -402,15 +402,23 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
         same_wav = _wav('same_samples')
         eom_wav = _wav('eom_samples')
         composite_wav = _wav('composite_samples')
+        pre_chime_wav = _wav('pre_chime_samples')
+        post_chime_wav = _wav('post_chime_samples')
 
         components_payload: Dict[str, Any] = {}
         for component_key, sample_key, suffix, wav in (
             ('same', 'same_samples', 'same', same_wav),
             ('eom', 'eom_samples', 'eom', eom_wav),
             ('composite', 'composite_samples', 'full', composite_wav),
+            ('pre_chime', 'pre_chime_samples', 'pre_chime', pre_chime_wav),
+            ('post_chime', 'post_chime_samples', 'post_chime', post_chime_wav),
         ):
             entry = _meta(sample_key, suffix, wav)
             if entry:
+                if component_key == 'pre_chime':
+                    entry['profile'] = components.get('pre_chime_profile')
+                elif component_key == 'post_chime':
+                    entry['profile'] = components.get('post_chime_profile')
                 components_payload[component_key] = entry
 
         # Archive any previously-active rows so the detail page surfaces the
@@ -443,10 +451,13 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
             metadata_payload={
                 'automated': True,
                 'schedule_id': config.id,
+                'signaling': components.get('signaling') or {},
             },
             composite_audio_data=composite_wav,
             same_audio_data=same_wav,
             eom_audio_data=eom_wav,
+            pre_chime_audio_data=pre_chime_wav,
+            post_chime_audio_data=post_chime_wav,
         )
 
         db.session.add(activation_record)

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -3113,6 +3113,50 @@ class EASAudioGenerator:
             composite_samples.extend(chime_separator)
             composite_samples.extend(post_chime_samples_list)
 
+        pre_chime_profile_norm = str(pre_chime_profile or 'none').lower()
+        post_chime_profile_norm = str(post_chime_profile or 'none').lower()
+
+        signaling_meta: Dict[str, Any] = {
+            'pre_chime': {
+                'profile': pre_chime_profile_norm,
+                'duration_seconds': float(pre_chime_duration) if pre_chime_profile_norm != 'none' else 0.0,
+                'used': bool(pre_chime_samples_list),
+            },
+            'post_chime': {
+                'profile': post_chime_profile_norm,
+                'duration_seconds': float(post_chime_duration) if post_chime_profile_norm != 'none' else 0.0,
+                'used': bool(post_chime_samples_list),
+            },
+        }
+        if pre_chime_profile_norm == 'mdc1200' or post_chime_profile_norm == 'mdc1200':
+            signaling_meta['mdc1200'] = {
+                'unit_id': int(mdc1200_unit_id or 0),
+                'target_unit_id': (
+                    int(mdc1200_target_unit_id)
+                    if mdc1200_target_unit_id not in (None, 0) else None
+                ),
+                'op_code': mdc1200_op_code,
+                'op_code_raw': (
+                    int(mdc1200_op_code_raw)
+                    if mdc1200_op_code_raw is not None else None
+                ),
+                'arg_raw': (
+                    int(mdc1200_arg_raw)
+                    if mdc1200_arg_raw is not None else None
+                ),
+                'pre_op_code': _resolve_mdc1200_op_for_position(mdc1200_op_code, 'pre'),
+                'post_op_code': _resolve_mdc1200_op_for_position(mdc1200_op_code, 'post'),
+            }
+        if pre_chime_profile_norm == 'dtmf' or post_chime_profile_norm == 'dtmf':
+            signaling_meta['dtmf_sequence'] = dtmf_seq
+        if pre_chime_profile_norm == 'qc2' or post_chime_profile_norm == 'qc2':
+            signaling_meta['qc2'] = {
+                'tone_a_freq': qc2_freq_a,
+                'tone_b_freq': qc2_freq_b,
+                'long_tone_enabled': bool(qc2_long_tone),
+                'long_tone_seconds': float(qc2_long_secs),
+            }
+
         return {
             'header': header,
             'message_text': message_text,
@@ -3130,8 +3174,9 @@ class EASAudioGenerator:
             'post_alert_samples': norm_post_alert,
             'pre_chime_samples': pre_chime_samples_list,
             'post_chime_samples': post_chime_samples_list,
-            'pre_chime_profile': str(pre_chime_profile or 'none').lower(),
-            'post_chime_profile': str(post_chime_profile or 'none').lower(),
+            'pre_chime_profile': pre_chime_profile_norm,
+            'post_chime_profile': post_chime_profile_norm,
+            'signaling': signaling_meta,
             'composite_samples': composite_samples,
             'sample_rate': self.sample_rate,
         }

--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -112,6 +112,87 @@
                 </div>
             </div>
             {% endif %}
+
+            {% set pre_chime_meta = signaling.get('pre_chime') if signaling else None %}
+            {% set post_chime_meta = signaling.get('post_chime') if signaling else None %}
+            {% set mdc_meta = signaling.get('mdc1200') if signaling else None %}
+            {% set dtmf_seq = signaling.get('dtmf_sequence') if signaling else None %}
+            {% set qc2_meta = signaling.get('qc2') if signaling else None %}
+            <div class="card shadow-sm mt-4">
+                <div class="card-header bg-light">
+                    <strong>Pre/Post-Alert Signals</strong>
+                </div>
+                <div class="card-body">
+                    {% macro chime_badge(meta) -%}
+                        {%- if not meta or not meta.get('used') or (meta.get('profile') or 'none')|lower == 'none' -%}
+                            <span class="badge bg-secondary">None</span>
+                        {%- else -%}
+                            <span class="badge bg-info text-dark text-uppercase">{{ meta.get('profile') }}</span>
+                            {%- if meta.get('duration_seconds') %}
+                            <span class="text-muted small ms-1">({{ '%.2f'|format(meta.get('duration_seconds')) }} s)</span>
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endmacro %}
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Pre-Alert Signal</dt>
+                        <dd class="col-sm-8">{{ chime_badge(pre_chime_meta) }}</dd>
+                        <dt class="col-sm-4">Post-Alert Signal</dt>
+                        <dd class="col-sm-8">{{ chime_badge(post_chime_meta) }}</dd>
+
+                        {% if mdc_meta %}
+                        <dt class="col-sm-12 mt-3"><h6 class="mb-2">MDC1200 Selective Calling</h6></dt>
+                        <dt class="col-sm-4">Source Unit ID</dt>
+                        <dd class="col-sm-8"><code>{{ mdc_meta.get('unit_id', 'N/A') }}</code></dd>
+                        <dt class="col-sm-4">Target Unit ID</dt>
+                        <dd class="col-sm-8">
+                            {% if mdc_meta.get('target_unit_id') %}
+                                <code>{{ mdc_meta.get('target_unit_id') }}</code>
+                            {% else %}
+                                <span class="text-muted">None (single-packet emission)</span>
+                            {% endif %}
+                        </dd>
+                        <dt class="col-sm-4">Op-Code Preset</dt>
+                        <dd class="col-sm-8"><code>{{ mdc_meta.get('op_code', 'N/A') }}</code></dd>
+                        {% if mdc_meta.get('pre_op_code') and mdc_meta.get('pre_op_code') != mdc_meta.get('op_code') %}
+                        <dt class="col-sm-4">Resolved Pre Op-Code</dt>
+                        <dd class="col-sm-8"><code>{{ mdc_meta.get('pre_op_code') }}</code></dd>
+                        {% endif %}
+                        {% if mdc_meta.get('post_op_code') and mdc_meta.get('post_op_code') != mdc_meta.get('op_code') %}
+                        <dt class="col-sm-4">Resolved Post Op-Code</dt>
+                        <dd class="col-sm-8"><code>{{ mdc_meta.get('post_op_code') }}</code></dd>
+                        {% endif %}
+                        {% if mdc_meta.get('op_code_raw') is not none %}
+                        <dt class="col-sm-4">Raw Op-Code Byte</dt>
+                        <dd class="col-sm-8"><code>0x{{ '%02X'|format(mdc_meta.get('op_code_raw')) }} ({{ mdc_meta.get('op_code_raw') }})</code></dd>
+                        {% endif %}
+                        {% if mdc_meta.get('arg_raw') is not none %}
+                        <dt class="col-sm-4">Raw Argument Byte</dt>
+                        <dd class="col-sm-8"><code>0x{{ '%02X'|format(mdc_meta.get('arg_raw')) }} ({{ mdc_meta.get('arg_raw') }})</code></dd>
+                        {% endif %}
+                        {% endif %}
+
+                        {% if dtmf_seq %}
+                        <dt class="col-sm-4 mt-3">DTMF Sequence</dt>
+                        <dd class="col-sm-8 mt-3"><code>{{ dtmf_seq }}</code></dd>
+                        {% endif %}
+
+                        {% if qc2_meta %}
+                        <dt class="col-sm-12 mt-3"><h6 class="mb-2">QC-II Tones</h6></dt>
+                        <dt class="col-sm-4">Tone A</dt>
+                        <dd class="col-sm-8">{{ qc2_meta.get('tone_a_freq', 'N/A') }} Hz</dd>
+                        <dt class="col-sm-4">Tone B</dt>
+                        <dd class="col-sm-8">{{ qc2_meta.get('tone_b_freq', 'N/A') }} Hz</dd>
+                        {% if qc2_meta.get('long_tone_enabled') %}
+                        <dt class="col-sm-4">Long Tone</dt>
+                        <dd class="col-sm-8">Enabled ({{ qc2_meta.get('long_tone_seconds', 0) }} s)</dd>
+                        {% endif %}
+                        {% endif %}
+                    </dl>
+                    {% if not signaling %}
+                    <p class="text-muted mb-0 small">No pre/post-alert signal metadata is recorded for this activation. Newly generated alerts will include this section.</p>
+                    {% endif %}
+                </div>
+            </div>
         </div>
         <div class="col-lg-5">
             <div class="card shadow-sm">

--- a/webapp/admin/audio.py
+++ b/webapp/admin/audio.py
@@ -1025,6 +1025,7 @@ def admin_manual_eas_generate():
             'summary_subpath': summary_subpath,
             'web_prefix': web_prefix,
             'includes_tts': bool(tts_component),
+            'signaling': components.get('signaling') or {},
         },
     )
 
@@ -1213,6 +1214,7 @@ def manual_eas_print(event_id: int):
             'filename': meta.get('filename'),
             'duration_seconds': meta.get('duration_seconds'),
             'size_bytes': meta.get('size_bytes'),
+            'profile': meta.get('profile'),
             'download_url': download_url,
         }
 
@@ -1227,6 +1229,9 @@ def manual_eas_print(event_id: int):
     same_lookup = get_extended_same_lookup()
     header_detail = describe_same_header(event.same_header, lookup=same_lookup, state_index=state_index)
 
+    metadata_payload = event.metadata_payload or {}
+    signaling = metadata_payload.get('signaling') or {}
+
     return render_template(
         'manual_eas_print.html',
         event=event,
@@ -1235,6 +1240,7 @@ def manual_eas_print(event_id: int):
         summary_url=url_for('manual_eas_export', event_id=event.id)
         if event.summary_filename
         else None,
+        signaling=signaling,
     )
 
 @audio_bp.route('/admin/eas/manual_events/<int:event_id>/export')

--- a/webapp/eas/workflow.py
+++ b/webapp/eas/workflow.py
@@ -83,6 +83,86 @@ ALLOWED_AUDIO_EXTENSIONS = {'.wav', '.mp3', '.ogg', '.aac', '.flac'}
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
 
 
+_MDC1200_OP_CODE_LABELS = {
+    'ptt_id_pre': 'PTT-ID (Pre)',
+    'ptt_id_post': 'PTT-ID (Post)',
+    'emergency': 'Emergency',
+    'request_to_talk': 'Request to Talk',
+    'remote_monitor': 'Remote Monitor',
+    'call_alert': 'Call Alert',
+    'selective_call': 'Selective Call',
+    'custom': 'Custom (raw bytes)',
+}
+
+
+def _mdc1200_op_label(op_code: Optional[str]) -> str:
+    if not op_code:
+        return 'N/A'
+    key = str(op_code).strip().lower()
+    return _MDC1200_OP_CODE_LABELS.get(key, op_code)
+
+
+def _format_signaling_lines(signaling: Optional[Dict[str, Any]]) -> List[str]:
+    """Render the saved pre/post-alert signal metadata as plain-text lines for PDF/log output."""
+    if not signaling:
+        return []
+
+    lines: List[str] = []
+    for position_key, label in (('pre_chime', 'Pre-Alert Signal'), ('post_chime', 'Post-Alert Signal')):
+        entry = signaling.get(position_key) or {}
+        profile = (entry.get('profile') or 'none').lower()
+        duration = entry.get('duration_seconds')
+        used = entry.get('used')
+
+        if profile == 'none' or not used:
+            lines.append(f"{label}: None")
+            continue
+
+        detail = profile.upper()
+        if duration:
+            try:
+                detail += f" ({float(duration):.2f}s)"
+            except (TypeError, ValueError):
+                pass
+        lines.append(f"{label}: {detail}")
+
+    mdc = signaling.get('mdc1200') or {}
+    if mdc:
+        lines.append("")
+        lines.append("MDC1200 Selective Calling:")
+        lines.append(f"  Source Unit ID: {mdc.get('unit_id', 'N/A')}")
+        target = mdc.get('target_unit_id')
+        if target:
+            lines.append(f"  Target Unit ID: {target}")
+        else:
+            lines.append("  Target Unit ID: (none — single-packet emission)")
+        lines.append(f"  Op-Code Preset: {_mdc1200_op_label(mdc.get('op_code'))}")
+        if mdc.get('pre_op_code') and mdc.get('pre_op_code') != mdc.get('op_code'):
+            lines.append(f"  Resolved Pre Op-Code: {_mdc1200_op_label(mdc.get('pre_op_code'))}")
+        if mdc.get('post_op_code') and mdc.get('post_op_code') != mdc.get('op_code'):
+            lines.append(f"  Resolved Post Op-Code: {_mdc1200_op_label(mdc.get('post_op_code'))}")
+        if mdc.get('op_code_raw') is not None:
+            lines.append(f"  Raw Op-Code Byte: 0x{int(mdc['op_code_raw']):02X} ({mdc['op_code_raw']})")
+        if mdc.get('arg_raw') is not None:
+            lines.append(f"  Raw Argument Byte: 0x{int(mdc['arg_raw']):02X} ({mdc['arg_raw']})")
+
+    dtmf_sequence = signaling.get('dtmf_sequence')
+    if dtmf_sequence:
+        lines.append("")
+        lines.append(f"DTMF Sequence: {dtmf_sequence}")
+
+    qc2 = signaling.get('qc2') or {}
+    if qc2:
+        lines.append("")
+        lines.append("QC-II Tones:")
+        lines.append(f"  Tone A: {qc2.get('tone_a_freq', 'N/A')} Hz")
+        lines.append(f"  Tone B: {qc2.get('tone_b_freq', 'N/A')} Hz")
+        if qc2.get('long_tone_enabled'):
+            lines.append(f"  Long Tone: enabled ({qc2.get('long_tone_seconds', 0)} s)")
+
+    return lines
+
+
 def _get_local_authority(user) -> Optional[LocalAuthority]:
     """Return the LocalAuthority record for a user, or None if not a local authority."""
     if not user:
@@ -749,6 +829,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 'local_authority_id': local_authority.id if local_authority else None,
                 'local_authority_name': local_authority.name if local_authority else None,
                 'local_authority_station_id': local_authority.station_id if local_authority else None,
+                'signaling': components.get('signaling') or {},
             },
             composite_audio_data=composite_component.get('wav_bytes') if composite_component else None,
             same_audio_data=same_component.get('wav_bytes') if same_component else None,
@@ -924,6 +1005,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 'duration_seconds': meta.get('duration_seconds'),
                 'size_bytes': meta.get('size_bytes'),
                 'storage_subpath': storage_subpath,
+                'profile': meta.get('profile'),
                 'download_url': download_url,
                 'stream_url': url_for('manual_eas_audio', event_id=event.id, component=component_key),
             }
@@ -942,6 +1024,9 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                 web_parts = [web_prefix, summary_subpath] if web_prefix else [summary_subpath]
                 summary_url = url_for('static', filename='/'.join(web_parts))
 
+        metadata_payload = event.metadata_payload or {}
+        signaling = metadata_payload.get('signaling') or {}
+
         return render_template(
             'manual_eas_print.html',
             event=event,
@@ -951,6 +1036,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             },
             header_detail=header_detail,
             summary_url=summary_url,
+            signaling=signaling,
         )
 
     @bp.route('/manual/events/<int:event_id>/print.pdf')
@@ -967,6 +1053,8 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
 
         event = ManualEASActivation.query.get_or_404(event_id)
         components_payload = event.components_payload or {}
+        metadata_payload = event.metadata_payload or {}
+        signaling = metadata_payload.get('signaling') or {}
 
         # Build PDF sections
         sections = []
@@ -974,20 +1062,30 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
         # Event Information
         event_info = [
             f"Event Code: {event.event_code or 'N/A'}",
+            f"Event Name: {event.event_name or 'N/A'}",
+            f"Identifier: {event.identifier or 'N/A'}",
             f"SAME Header: {event.same_header or 'N/A'}",
             f"Created: {format_local_datetime(event.created_at, include_utc=True)}",
-            f"Status: {event.status or 'N/A'}",
+            f"Status: {event.status or 'N/A'} / {event.message_type or 'N/A'}",
+            f"Tone Profile: {(event.tone_profile or 'none').title()} ({float(event.tone_seconds or 0):.1f} seconds)",
+            f"Sample Rate: {event.sample_rate or 'N/A'} Hz",
         ]
 
         if event.triggered_at:
             event_info.append(f"Triggered: {format_local_datetime(event.triggered_at, include_utc=True)}")
-        if event.event_label:
-            event_info.append(f"Event Label: {event.event_label}")
 
         sections.append({
             'heading': 'Manual EAS Activation Information',
             'content': event_info,
         })
+
+        # Pre/Post-Alert Signals (system-level chimes, MDC1200, DTMF, QC-II)
+        signal_lines = _format_signaling_lines(signaling)
+        if signal_lines:
+            sections.append({
+                'heading': 'Pre/Post-Alert Signals',
+                'content': signal_lines,
+            })
 
         # Location Information
         state_tree = get_extended_state_county_tree()
@@ -1041,10 +1139,9 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
             })
 
         # Generation Metadata
-        if event.generation_metadata:
+        if metadata_payload:
             try:
-                import json
-                metadata_str = json.dumps(event.generation_metadata, indent=2)
+                metadata_str = json.dumps(metadata_payload, indent=2, default=str)
                 # Split JSON into lines to preserve formatting in PDF
                 metadata_lines = metadata_str.split('\n')
                 sections.append({
@@ -1052,7 +1149,7 @@ def register_workflow_routes(bp, logger, eas_config) -> None:
                     'content': metadata_lines,
                 })
             except (TypeError, ValueError) as exc:
-                logger.warning('Failed to serialize generation metadata: %s', exc)
+                workflow_logger.warning('Failed to serialize generation metadata: %s', exc)
 
         # Generate PDF
         pdf_bytes = generate_pdf_document(


### PR DESCRIPTION
## Summary
This PR enhances the manual EAS activation workflow to capture, store, and display detailed pre/post-alert signaling metadata including chime profiles, MDC1200 selective calling information, DTMF sequences, and QC-II tones. This metadata is now persisted in the database and rendered in both HTML and PDF output formats.

## Key Changes

- **Signaling Metadata Capture**: Added `signaling_meta` dictionary in `build_manual_components()` to capture pre/post-chime profiles, durations, and specialized signaling data (MDC1200, DTMF, QC-II) during manual activation generation.

- **Database Persistence**: Updated `ManualEASActivation` record creation to store signaling metadata in the `metadata_payload` field, alongside existing automated flag and schedule information.

- **HTML Display**: Added a new "Pre/Post-Alert Signals" card in the manual EAS print template with:
  - Pre/post-chime profile badges with duration information
  - MDC1200 selective calling details (unit IDs, op-codes, raw bytes)
  - DTMF sequence display
  - QC-II tone frequency and long-tone settings

- **PDF Generation**: Enhanced PDF output to include:
  - Expanded event information section (event name, identifier, tone profile, sample rate)
  - New "Pre/Post-Alert Signals" section with formatted signaling details via `_format_signaling_lines()` helper
  - Improved metadata serialization with `default=str` for JSON encoding

- **Helper Functions**: 
  - `_mdc1200_op_label()`: Converts MDC1200 op-code values to human-readable labels
  - `_format_signaling_lines()`: Renders signaling metadata as plain-text lines for PDF/log output

- **Component Metadata**: Added `profile` field to pre/post-chime component metadata in the components payload for tracking which signaling profile was used.

- **RWT Scheduler Integration**: Updated automated EAS activation workflow to capture and store pre/post-chime audio components and signaling metadata alongside existing SAME/EOM/composite audio.

## Implementation Details

- Signaling metadata is conditionally included only when relevant profiles are used (e.g., MDC1200 data only appears if MDC1200 profile is selected)
- The `_mdc1200_op_label()` function provides fallback handling for unknown op-codes
- PDF generation now uses `metadata_payload` instead of the deprecated `generation_metadata` field
- All signaling data is optional and gracefully handles missing or None values

https://claude.ai/code/session_01AHxyoStwQXnT3f7nsKJECB