### PR TITLE
Fix EAS decode confidence scoring to reflect structural validity

### DIFF
--- a/app_core/audio/eas_monitor.py
+++ b/app_core/audio/eas_monitor.py
@@ -85,6 +85,25 @@ def _same_alert_to_dict(alert: Any) -> Dict[str, Any]:
     except Exception:
         fields = {}
 
+    # The decoder reports a raw per-bit FSK tone margin, which is structurally
+    # floored near 0.5 because the SAME mark/space tones are only one baud apart
+    # (see score_decode_confidence).  Re-score the headline confidence from the
+    # NRSC-4-B structural validity of the decoded header so a clean, spec-valid
+    # alert reads high instead of perpetually "~50%".  Preserve the raw margin
+    # separately for diagnostics.
+    # Coerce to a plain Python float — the raw value may be a numpy float that
+    # would break the JSONB commit downstream (same reason 'confidence' is
+    # coerced before storage).
+    try:
+        signal_margin = float(getattr(alert, 'confidence', 0.0) or 0.0)
+    except (TypeError, ValueError):
+        signal_margin = 0.0
+    try:
+        from app_utils.eas import score_decode_confidence
+        scored_confidence = float(score_decode_confidence(fields, signal_margin))
+    except Exception:
+        scored_confidence = signal_margin
+
     # Normalise raw location strings to plain 6-digit FIPS codes
     location_codes = []
     for loc in fields.get('raw_locations', []):
@@ -112,7 +131,8 @@ def _same_alert_to_dict(alert: Any) -> Dict[str, Any]:
         'callsign': (fields.get('station_identifier') or '').strip('-').strip(),
         'issue_time': issue_time_iso,
         'purge_time': purge_time,
-        'confidence': getattr(alert, 'confidence', 0.0),
+        'confidence': scored_confidence,
+        'signal_margin': signal_margin,
         'timestamp': ts.isoformat() if hasattr(ts, 'isoformat') else str(ts),
         'endec_mode': getattr(alert, 'endec_mode', 'UNKNOWN') or 'UNKNOWN',
         'burst_timing_gaps_ms': list(getattr(alert, 'burst_timing_gaps_ms', [])),

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -990,6 +990,91 @@ def describe_same_header(
     }
 
 
+# Six independent NRSC-4-B field checks emitted by ``describe_same_header``.
+# Each one that passes means a distinct byte group decoded into a value that is
+# valid per the spec — strong, decode-*correctness* evidence that the raw per-bit
+# tone margin cannot provide.
+_NRSC4B_FIELD_FLAGS: Tuple[str, ...] = (
+    'nrsc4b_valid_originator',
+    'nrsc4b_valid_event',
+    'nrsc4b_valid_purge',
+    'nrsc4b_valid_issue_time',
+    'nrsc4b_valid_location_count',
+    'nrsc4b_valid_station_id',
+)
+
+
+def score_decode_confidence(
+    fields: Optional[Dict[str, object]],
+    signal_margin: float,
+) -> float:
+    """Score how likely a decoded SAME header is correct, in [0.0, 1.0].
+
+    The DSP layer reports ``signal_margin`` = mean per-bit
+    ``|mark_power - space_power| / (mark_power + space_power)``.  Because the
+    SAME mark (2083.3 Hz) and space (1562.5 Hz) tones are separated by exactly
+    one baud (520.83 Hz), a single bit period gives only ~520 Hz of frequency
+    resolution, so the two Goertzel/correlator bins overlap heavily.  Each bin
+    captures a large share of the other tone's energy even on a flawless
+    transmission, which floors this margin near 0.5 regardless of how clean the
+    decode is.  Displaying it directly makes every real alert look "low
+    confidence" (~50-55%).
+
+    This function instead derives confidence from what actually proves a good
+    decode: the structural / NRSC-4-B field validity already computed by
+    :func:`describe_same_header`.  SAME has no per-byte checksum — its error
+    protection is the 3x burst repetition plus self-consistent framing — so a
+    header whose originator, event code, purge time, issue time, location count
+    and station ID all independently parse to spec-valid values is, for
+    practical purposes, a verified decode.  Random bit errors are very unlikely
+    to land on six simultaneously-valid fields.
+
+    Args:
+        fields: Parsed field dict from :func:`describe_same_header`.  An empty
+            or ``None`` dict (e.g. an ``NNNN`` EOM or an unparseable header)
+            falls back to ``signal_margin`` so the caller's forward gate still
+            has a value to act on.
+        signal_margin: Raw mean per-bit tone margin in [0.0, 1.0].
+
+    Returns:
+        A confidence score in [0.0, 1.0].  Fully NRSC-4-B-compliant headers
+        floor high (>=0.95) so a clean alert never displays as low confidence;
+        weakly-valid headers never read *higher* than their raw signal margin,
+        keeping the forward gate conservative against garbled decodes.
+    """
+    try:
+        margin = float(signal_margin)
+    except (TypeError, ValueError):
+        margin = 0.0
+    margin = max(0.0, min(1.0, margin))
+
+    if not fields:
+        # No parseable header to corroborate the bits — the signal margin is
+        # the only evidence we have.
+        return margin
+
+    passed = sum(1 for flag in _NRSC4B_FIELD_FLAGS if fields.get(flag))
+    structural = passed / len(_NRSC4B_FIELD_FLAGS)
+
+    # When fewer than half the fields validate, the structure is too weak to
+    # trust; fall back to the raw signal margin so we never *inflate* a suspect
+    # decode above what its FSK quality alone would justify.
+    if structural < 0.5:
+        return margin
+
+    # Structural validity dominates (it is decode-correctness evidence); the
+    # signal margin contributes a minority weight so that among equally-valid
+    # decodes, cleaner audio still ranks slightly higher.
+    confidence = 0.6 * structural + 0.4 * margin
+
+    if fields.get('nrsc4b_compliant'):
+        # Every field independently parsed to a spec-valid value — treat as a
+        # verified decode and floor the score high, nudged by signal quality.
+        confidence = max(confidence, 0.95 + 0.05 * margin)
+
+    return max(0.0, min(1.0, confidence))
+
+
 def _julian_time(dt: datetime) -> str:
     dt = dt.astimezone(timezone.utc)
     julian_day = dt.timetuple().tm_yday
@@ -3595,6 +3680,8 @@ __all__ = [
     'EASAudioGenerator',
     'build_same_header',
     'build_eom_header',
+    'describe_same_header',
+    'score_decode_confidence',
     'samples_to_wav_bytes',
     'manual_default_same_codes',
     'convert_audio_to_samples',

--- a/tests/test_decode_confidence_scoring.py
+++ b/tests/test_decode_confidence_scoring.py
@@ -1,0 +1,110 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Tests for structural (NRSC-4-B) decode confidence scoring.
+
+These cover the fix for the long-standing "every alert shows ~50% confidence
+even on a perfect decode" problem: the raw per-bit FSK tone margin is
+structurally floored near 0.5 because the SAME mark/space tones are only one
+baud apart, so the headline confidence is instead derived from how many SAME
+header fields independently parse to spec-valid values.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_utils.eas import describe_same_header, score_decode_confidence
+
+# A clean, fully NRSC-4-B-compliant header (the everyday "good decode" case).
+VALID_HEADER = "ZCZC-WXR-TOR-039137+0030-3662322-WTHI/TV-"
+
+
+def test_valid_header_reads_high_despite_floored_signal_margin():
+    """A perfect decode must NOT report ~50% just because the tone margin does."""
+    fields = describe_same_header(VALID_HEADER)
+    assert fields.get("nrsc4b_compliant") is True
+
+    # The raw per-bit margin saturates near 0.5 on real EAS audio; the headline
+    # confidence should reflect the verified structure instead.
+    scored = score_decode_confidence(fields, signal_margin=0.52)
+    assert scored >= 0.95
+    # Sanity: dramatically higher than the raw margin it replaces.
+    assert scored > 0.52 + 0.30
+
+
+def test_weak_signal_valid_header_still_reads_high():
+    """A spec-valid header with weak audio is still a real alert and must not be
+    suppressed by the forward gate."""
+    fields = describe_same_header(VALID_HEADER)
+    scored = score_decode_confidence(fields, signal_margin=0.20)
+    assert scored >= 0.95
+
+
+def test_cleaner_audio_ranks_slightly_higher_among_valid_decodes():
+    fields = describe_same_header(VALID_HEADER)
+    low = score_decode_confidence(fields, signal_margin=0.30)
+    high = score_decode_confidence(fields, signal_margin=0.90)
+    assert high > low
+
+
+def test_garbled_header_is_not_inflated_above_signal_margin():
+    """A header whose fields do not validate must never read higher than the raw
+    signal margin — the structure cannot vouch for a bad decode."""
+    fields = describe_same_header("ZCZC-XXX-ZZZ-999999+9999-9999999-")
+    assert fields.get("nrsc4b_compliant") is False
+    for margin in (0.20, 0.55, 0.80):
+        assert score_decode_confidence(fields, signal_margin=margin) <= margin + 1e-9
+
+
+def test_empty_fields_fall_back_to_signal_margin():
+    """EOM (NNNN) and unparseable headers produce no fields; the raw margin is
+    the only evidence available and must pass through unchanged."""
+    assert score_decode_confidence({}, signal_margin=0.41) == 0.41
+    assert score_decode_confidence(None, signal_margin=0.41) == 0.41
+
+
+def test_confidence_is_clamped_to_unit_interval():
+    fields = describe_same_header(VALID_HEADER)
+    assert 0.0 <= score_decode_confidence(fields, signal_margin=5.0) <= 1.0
+    assert 0.0 <= score_decode_confidence(fields, signal_margin=-3.0) <= 1.0
+    # Non-numeric margin must not raise.
+    assert 0.0 <= score_decode_confidence({}, signal_margin="not-a-number") <= 1.0  # type: ignore[arg-type]
+
+
+def test_partial_structure_below_half_falls_back_to_margin():
+    """When fewer than half the fields validate, trust the raw margin only."""
+    # Valid originator/event but everything else garbage -> < 3 of 6 valid.
+    fields = describe_same_header("ZCZC-WXR-TOR-ZZZZZZ+ZZZZ-ZZZZZZZ-")
+    passed = sum(
+        1
+        for flag in (
+            "nrsc4b_valid_originator",
+            "nrsc4b_valid_event",
+            "nrsc4b_valid_purge",
+            "nrsc4b_valid_issue_time",
+            "nrsc4b_valid_location_count",
+            "nrsc4b_valid_station_id",
+        )
+        if fields.get(flag)
+    )
+    assert passed < 3
+    assert score_decode_confidence(fields, signal_margin=0.33) == 0.33


### PR DESCRIPTION
## Summary

Fixes the long-standing issue where every EAS alert displays ~50% confidence even on a perfect decode. The raw per-bit FSK tone margin is structurally floored near 0.5 because the SAME mark/space tones are only one baud apart, making direct margin display misleading. This change derives confidence from NRSC-4-B structural validity instead.

## Key Changes

- **Added `score_decode_confidence()` function** in `app_utils/eas.py`:
  - Scores decode confidence based on how many SAME header fields independently parse to spec-valid values (originator, event, purge time, issue time, location count, station ID)
  - Fully compliant headers floor high (≥0.95) so clean alerts never display as low confidence
  - Weakly-valid headers never read higher than raw signal margin, keeping the forward gate conservative
  - Falls back to raw signal margin when structural evidence is insufficient (<50% of fields valid)
  - Clamps output to [0.0, 1.0] unit interval

- **Updated `_same_alert_to_dict()` in `app_core/audio/eas_monitor.py`**:
  - Calls `score_decode_confidence()` to re-score the headline confidence from structural validity
  - Preserves raw signal margin separately in output for diagnostics
  - Properly coerces values to plain Python floats for downstream JSONB storage

- **Added comprehensive test suite** in `tests/test_decode_confidence_scoring.py`:
  - Validates that perfect decodes read high despite floored signal margin
  - Confirms weak signal valid headers still read high
  - Verifies cleaner audio ranks higher among valid decodes
  - Ensures garbled headers never inflate above signal margin
  - Tests edge cases (empty fields, non-numeric margins, partial structure)

## Implementation Details

The confidence scoring uses a weighted formula: `0.6 * structural + 0.4 * margin`, where structural validity is the fraction of six NRSC-4-B field checks that pass. This gives structural validity dominance while allowing cleaner audio to rank slightly higher among equally-valid decodes. For fully compliant headers, confidence is floored at `0.95 + 0.05 * margin` to ensure real alerts display with high confidence.

https://claude.ai/code/session_01PMKLkV3aU3d1uCyJhoKvBQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Strengthened emergency alert confidence scoring by validating message structure components for enhanced accuracy
  - Added signal margin diagnostics for monitoring alert signal quality

* **Tests**
  - Added comprehensive test coverage for the confidence scoring system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->