### PR TITLE
Tighten EOM-to-post-alert gap and fix MDC1200 badge casing

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1817,6 +1817,13 @@ def _generate_silence(duration: float, sample_rate: int) -> List[int]:
 # Allowed chime profile values for pre/post-alert chimes.
 ALERT_CHIME_PROFILES = ('none', 'bell', 'beep', 'three_tone', 'qc2', 'dtmf', 'mdc1200')
 
+# Silence inserted between the EOM sequence and the post-alert signal (chime /
+# MDC1200 PTT-ID).  Kept short so the post-alert signaling follows promptly
+# after the End-of-Message, matching real radio behavior where PTT-ID fires
+# right at PTT release.  The standard 1.0 s end-of-message tail is still added
+# when no post-alert signal follows.
+POST_ALERT_SIGNAL_GAP_SECONDS = 0.25
+
 
 def _resolve_mdc1200_op_for_position(op_code: str, position: str) -> str:
     """Auto-pair MDC1200 PTT-ID Pre/Post when used as bookend chimes.
@@ -2817,7 +2824,6 @@ class EASAudioGenerator:
             eom_raw_samples.extend(terminator_samples)
             if burst_index < 2:
                 eom_raw_samples.extend(_generate_silence(1.0, self.sample_rate))
-        eom_raw_samples.extend(_generate_silence(1.0, self.sample_rate))
         samples.extend(eom_raw_samples)
 
         # Post-alert chime (system-level, configured per-station): plays
@@ -2837,8 +2843,11 @@ class EASAudioGenerator:
             mdc1200_target_unit_id=mdc1200_target_unit_id,
         )
         if post_chime_samples:
-            samples.extend(_generate_silence(1.0, self.sample_rate))
+            samples.extend(_generate_silence(POST_ALERT_SIGNAL_GAP_SECONDS, self.sample_rate))
             samples.extend(post_chime_samples)
+        else:
+            # End-of-message tail when no post-alert signal follows.
+            samples.extend(_generate_silence(1.0, self.sample_rate))
 
         wav_bytes = samples_to_wav_bytes(samples, self.sample_rate)
         try:
@@ -3119,8 +3128,6 @@ class EASAudioGenerator:
             if burst_index < 2:
                 eom_samples.extend(_generate_silence(1.0, self.sample_rate))
 
-        eom_samples.extend(_generate_silence(1.0, self.sample_rate))
-
         # Normalize uploaded pre/post alert audio
         norm_pre_alert = (
             _normalize_audio_amplitude(pre_alert_samples, amplitude * 0.7)
@@ -3195,8 +3202,11 @@ class EASAudioGenerator:
         composite_samples.extend(trailing_silence)
         composite_samples.extend(eom_samples)
         if post_chime_samples_list:
-            composite_samples.extend(chime_separator)
+            composite_samples.extend(_generate_silence(POST_ALERT_SIGNAL_GAP_SECONDS, self.sample_rate))
             composite_samples.extend(post_chime_samples_list)
+        else:
+            # End-of-message tail when no post-alert signal follows.
+            composite_samples.extend(_generate_silence(1.0, self.sample_rate))
 
         pre_chime_profile_norm = str(pre_chime_profile or 'none').lower()
         post_chime_profile_norm = str(post_chime_profile or 'none').lower()

--- a/templates/manual_eas_print.html
+++ b/templates/manual_eas_print.html
@@ -219,7 +219,7 @@
                                 <div>
                                     <h6 class="mb-1">{{ component_labels.get(key, key.replace('_', ' ').upper()) }}
                                         {%- if comp.profile and comp.profile != 'none' %}
-                                        <span class="badge bg-secondary fw-normal ms-1 text-lowercase">{{ comp.profile }}</span>
+                                        <span class="badge bg-secondary fw-normal ms-1 text-uppercase">{{ comp.profile }}</span>
                                         {%- endif %}
                                     </h6>
                                     <small class="text-muted">{{ comp.duration_seconds|default(0)|round(2) }} s · {{ comp.size_bytes|default(0) }} bytes</small>


### PR DESCRIPTION
The composite broadcast inserted two 1.0 s silences between the EOM
sequence and the post-alert signal (an unconditional tail baked into
the EOM samples plus a separate 1.0 s separator), leaving a ~2 s gap
before the post-alert chime / MDC1200 PTT-ID. Replace the redundant
double silence with a single short POST_ALERT_SIGNAL_GAP_SECONDS (0.25 s)
gap so post-alert signaling follows promptly after the End-of-Message,
while still emitting the standard 1.0 s end-of-message tail when no
post-alert signal follows.

Also fix the audio-component profile badge to render uppercase so
MDC1200 (and other profiles) display fully capitalized, matching the
pre/post-alert signal badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-alert signal timing for more realistic audio output characteristics.

* **Style**
  * Updated profile labels to display in uppercase format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->