### PR TITLE
fix(rwt): show air-chain control popup during RWT broadcasts

### DIFF
--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -228,12 +228,12 @@ def _drive_rwt_airchain(
                 activated_any = False
                 manager_handled = False
 
-        set_broadcast_active(
-            event_code=event_code,
-            label='Required Weekly Test',
-            duration_seconds=playback_duration,
-            source='automated_rwt',
-        )
+        # NOTE: the Redis broadcast-state marker that drives the global
+        # air-chain overlay is set *synchronously* by trigger_rwt_broadcast
+        # before this worker is dispatched, so the popup appears the moment the
+        # request returns rather than waiting for this thread to schedule past
+        # GPIO initialisation.  We only release it (clear_broadcast_active) in
+        # the finally block below once the relay is actually relinquished.
 
         audio_player_cmd = eas_config.get('audio_player_cmd')
         playout_start = time.monotonic()
@@ -547,6 +547,34 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
 
         log.info("RWT broadcast sent successfully: %s", identifier)
 
+        # Light the global air-chain control overlay *synchronously*, on the
+        # calling thread, before handing playback to the background worker.
+        #
+        # The overlay is driven by the Redis broadcast-state marker (read 1 Hz
+        # by the WebSocket push loop / the /api/broadcast/state poll).  When the
+        # marker was written from inside the daemon thread it only landed *after*
+        # GPIO initialisation, and on a Pi the blocking GPIO C calls can stall
+        # the gevent hub long enough that the popup never appeared during the
+        # short RWT broadcast.  Writing it here — mirroring the inline manual
+        # send path (webapp/eas/workflow.py:1382-1396) — guarantees the popup
+        # is visible the instant the request returns, independent of how soon
+        # the daemon thread is scheduled.  Compute the duration with the same
+        # truncation the worker applies so the countdown matches the airchain.
+        max_activation_seconds = int(eas_config.get('max_activation_seconds', 300) or 300)
+        broadcast_audio = composite_wav
+        if broadcast_audio and _wav_duration_seconds(broadcast_audio) > max_activation_seconds:
+            broadcast_audio = truncate_wav_to_max_seconds(
+                broadcast_audio, eom_wav, max_activation_seconds,
+            )
+        broadcast_duration = _wav_duration_seconds(broadcast_audio) if broadcast_audio else 0.0
+        if broadcast_duration > 0:
+            set_broadcast_active(
+                event_code='RWT',
+                label='Required Weekly Test',
+                duration_seconds=broadcast_duration,
+                source='automated_rwt',
+            )
+
         # Drive the airchain: hold GPIO and play the composite WAV for the
         # full duration so the encoder actually broadcasts the tones. The
         # manual send route (webapp/eas/workflow.py:1198-1357) does this for
@@ -558,7 +586,9 @@ def trigger_rwt_broadcast(config: RWTScheduleConfig, logger_instance=None) -> Di
         # This runs on a background thread so the caller returns immediately:
         # the manual "Send Test RWT" button fires a blocking fetch, and
         # holding the request open for the entire broadcast froze that button
-        # on "Sending..." while suppressing the air-chain-control overlay.
+        # on "Sending..." while suppressing the air-chain-control overlay.  The
+        # broadcast-state marker set above keeps the overlay/countdown alive for
+        # the full duration; the worker clears it when playback finishes.
         activation_id = activation_record.id
         _dispatch_rwt_airchain(
             app=current_app._get_current_object(),


### PR DESCRIPTION
## Problem

The global air-chain control overlay (`globalBroadcastingOverlay` in `base.html`) still did not appear when an RWT broadcast went out from the RWT page, despite the earlier fix that backgrounded the airchain playback.

## Root cause

The overlay is driven by a Redis "broadcast active" marker that the 1 Hz WebSocket push loop reads and emits to every page.

- The **manual send** path works because it writes that marker *inline, on the request thread* (`webapp/eas/workflow.py:1391`).
- The previous RWT fix moved playback onto a background daemon thread — but it also moved `set_broadcast_active()` into that thread, **after GPIO initialization** (`rwt_scheduler.py`).

On the Pi, the blocking GPIO C calls can stall the gevent hub long enough that the Redis marker landed late — or never within the short RWT window — so the popup never got its signal. The "Send Test RWT" button un-froze (that part of the earlier fix worked), but the overlay stayed hidden.

## Fix

Write the broadcast-state marker **synchronously in `trigger_rwt_broadcast`, before dispatching the background worker** — mirroring the working manual-send path. The duration is computed with the same truncation the worker applies, so the countdown matches the actual airchain. The background worker still holds the relay for the full duration and clears the marker when playback finishes.

Net effect: the popup appears the instant the request returns, independent of when the daemon thread is scheduled or how long GPIO init takes. Applies to both the manual **Send Test RWT** button and the automatic scheduled RWT.

## Testing notes

Validated by code parity with the manual-send path plus a syntax/compile check. This container has no Redis app dependencies installed and no GPIO hardware, so a live broadcast on real hardware is the real confirmation — triggering a Test RWT on the unit and watching for the overlay is the check that matters.

https://claude.ai/code/session_01KCYH3ogjmzPy3muFtuBAU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCYH3ogjmzPy3muFtuBAU9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved synchronization of the broadcast overlay active indicator—now set immediately when a broadcast starts for more reliable state tracking.
  * Fixed timing inconsistencies in broadcast duration calculations to ensure consistent behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->