### PR TITLE
fix(gps/rwt): keep holdover card populated and fix air-chain countdown anchor

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -532,6 +532,25 @@ class GPSManager:
             except Exception as exc:  # never let a Redis hiccup drop the fix
                 self._logger.debug("Failed to persist 3D-fix anchor: %s", exc)
 
+    @staticmethod
+    def _holdover_seconds(
+        last_3d: Optional[datetime],
+        fix_mode: Any,
+        now_utc: datetime,
+    ) -> Optional[float]:
+        """Seconds since the last 3D fix for the dashboard holdover timer.
+
+        ``None`` when we have never seen a 3D fix (nothing to measure from),
+        ``0.0`` while a 3D fix is currently held, otherwise the elapsed time
+        since the anchor.  Centralised so the live ``get_status()`` view and
+        the Redis-published blob never disagree.
+        """
+        if last_3d is None:
+            return None
+        if fix_mode == 3:
+            return 0.0
+        return round((now_utc - last_3d).total_seconds(), 2)
+
     def _load_persisted_3d_fix(self) -> None:
         """Restore the holdover anchor from Redis on startup, if present."""
         if self._last_3d_fix_at is not None or not self._redis:
@@ -650,18 +669,12 @@ class GPSManager:
 
         # Holdover timer — wall-clock seconds since the last 3D fix.
         # ``0`` while we currently hold a 3D fix; ``None`` when we have
-        # never seen one (e.g. cold start with no antenna).
-        if last_3d is None:
-            data["holdover_s"] = None
-            data["last_3d_fix_at"] = None
-        else:
-            data["last_3d_fix_at"] = last_3d.isoformat()
-            if data.get("fix_mode") == 3:
-                data["holdover_s"] = 0.0
-            else:
-                data["holdover_s"] = round(
-                    (now_utc - last_3d).total_seconds(), 2
-                )
+        # never seen one (e.g. cold start with no antenna).  Shared with
+        # _publish_current_fix() so the live and Redis-cached views agree.
+        data["holdover_s"] = self._holdover_seconds(
+            last_3d, data.get("fix_mode"), now_utc
+        )
+        data["last_3d_fix_at"] = last_3d.isoformat() if last_3d else None
 
         # Leap-second annunciator — Phase 2 will replace this with a
         # UBX-NAV-TIMELS poll; for now we surface a best-effort string
@@ -1527,6 +1540,17 @@ class GPSManager:
             with self._lock:
                 data = dict(self._fix)
                 data["recent_sentences"] = list(self._recent_sentences)
+                last_3d = self._last_3d_fix_at
+            # Derive the holdover timer here too — not just in get_status().
+            # Consumers that read this Redis blob (the /status fallback when
+            # the live manager handle isn't in their process, the trend
+            # sampler's cached path) would otherwise never see holdover_s and
+            # the dashboard's holdover card/tile would render blank while the
+            # receiver is in holdover.
+            data["holdover_s"] = self._holdover_seconds(
+                last_3d, data.get("fix_mode"), datetime.now(timezone.utc)
+            )
+            data["last_3d_fix_at"] = last_3d.isoformat() if last_3d else None
             self._redis.setex(REDIS_KEY, REDIS_TTL, json.dumps(data))
         except Exception as exc:
             self._logger.debug("Failed to publish GPS status to Redis: %s", exc)

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -78,6 +78,13 @@ _libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True
 REDIS_KEY = "gps:status"
 # TTL in seconds for the Redis key (refreshed every poll cycle)
 REDIS_TTL = 15
+# Redis key persisting the wall-clock instant of the last 3D fix.  The
+# holdover timer is measured from this anchor; keeping it in Redis (rather
+# than memory only) means a manager/service restart *during* a holdover
+# period no longer resets it to "unknown" — which is what left the
+# dashboard's holdover card blank while the receiver was still coasting.
+# No TTL: it is overwritten on every 3D fix and is meaningless to expire.
+REDIS_LAST_3D_KEY = "gps:last_3d_fix_at"
 
 # NMEA fix quality codes
 _FIX_QUALITY = {
@@ -229,8 +236,11 @@ class GPSManager:
         self._pps_interval_ns: Deque[int] = deque(maxlen=16384)
         # Captured at last 3D fix (from GSA fix_mode==3) so the dashboard
         # can compute a holdover timer when the receiver loses lock but
-        # we're still steering chrony from the host clock.
+        # we're still steering chrony from the host clock.  Restored from
+        # Redis so the holdover timer survives a manager restart instead of
+        # blanking the dashboard card mid-holdover.
         self._last_3d_fix_at: Optional[datetime] = None
+        self._load_persisted_3d_fix()
 
         # UBX poll cadence (seconds).  30 s is well below the ~100 ms
         # NMEA cycle the dashboard reads at, so the antenna and leap
@@ -502,6 +512,45 @@ class GPSManager:
             self._ser = None
         self._active_source = "stopped"
         self._logger.info("GPS reader stopped")
+
+    def _mark_3d_fix(self) -> None:
+        """Record the current instant as the holdover anchor and persist it.
+
+        Called from both the NMEA and gpsd reader paths whenever a 3D fix is
+        observed.  Persisting to Redis (best-effort, never fatal) lets the
+        holdover timer survive a manager/service restart — without it the
+        in-memory anchor reset to ``None`` on restart and the dashboard's
+        holdover card went blank even while the receiver was still in
+        holdover.  Acquires no lock: it mirrors the prior inline assignment,
+        whose callers already hold ``self._lock``.
+        """
+        now = datetime.now(timezone.utc)
+        self._last_3d_fix_at = now
+        if self._redis:
+            try:
+                self._redis.set(REDIS_LAST_3D_KEY, now.isoformat())
+            except Exception as exc:  # never let a Redis hiccup drop the fix
+                self._logger.debug("Failed to persist 3D-fix anchor: %s", exc)
+
+    def _load_persisted_3d_fix(self) -> None:
+        """Restore the holdover anchor from Redis on startup, if present."""
+        if self._last_3d_fix_at is not None or not self._redis:
+            return
+        try:
+            raw = self._redis.get(REDIS_LAST_3D_KEY)
+        except Exception as exc:
+            self._logger.debug("Failed to read persisted 3D-fix anchor: %s", exc)
+            return
+        if not raw:
+            return
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", "replace")
+        try:
+            self._last_3d_fix_at = datetime.fromisoformat(raw)
+        except (ValueError, TypeError) as exc:
+            self._logger.debug(
+                "Ignoring malformed persisted 3D-fix anchor %r: %s", raw, exc
+            )
 
     def get_status(self) -> Dict[str, Any]:
         """Return the most-recently parsed GPS fix as a dictionary.
@@ -1435,7 +1484,7 @@ class GPSManager:
                             # lock.  We capture at any 3D fix in the stream
                             # so even brief reacquisitions reset the timer.
                             if mode_int == 3:
-                                self._last_3d_fix_at = datetime.now(timezone.utc)
+                                self._mark_3d_fix()
                         except (ValueError, TypeError):
                             pass
                     # Position dilution of precision
@@ -1661,7 +1710,7 @@ class GPSManager:
             self._fix["fix_mode"] = mode if mode in (1, 2, 3) else None
             if mode == 3:
                 # Mirror the NMEA path's holdover anchor in gpsd mode.
-                self._last_3d_fix_at = datetime.now(timezone.utc)
+                self._mark_3d_fix()
             if isinstance(obj.get("lat"), (int, float)):
                 self._fix["latitude"] = float(obj["lat"])
             if isinstance(obj.get("lon"), (int, float)):

--- a/app_core/rwt_scheduler.py
+++ b/app_core/rwt_scheduler.py
@@ -234,6 +234,22 @@ def _drive_rwt_airchain(
         # request returns rather than waiting for this thread to schedule past
         # GPIO initialisation.  We only release it (clear_broadcast_active) in
         # the finally block below once the relay is actually relinquished.
+        #
+        # That synchronous start_ts, however, predates the GPIO setup above —
+        # on a Pi the blocking GPIO C calls can take a second or more, so the
+        # countdown anchored to the request thread would reach 0:00 (and flip to
+        # "END OF MESSAGE") while the relay is still asserted and the audio is
+        # still playing, leaving the overlay stuck at 0:00 after the alert.
+        # Re-anchor the marker to the *actual* playout start now that GPIO is
+        # ready: the frontend re-syncs when start_ts shifts (templates/base.html
+        # ~L509), so the countdown finishes exactly when the relay is released
+        # in the finally block below and the overlay no longer lingers.
+        set_broadcast_active(
+            event_code=event_code,
+            label='Required Weekly Test',
+            duration_seconds=playback_duration,
+            source='automated_rwt',
+        )
 
         audio_player_cmd = eas_config.get('audio_player_cmd')
         playout_start = time.monotonic()

--- a/app_utils/gps_hat.py
+++ b/app_utils/gps_hat.py
@@ -837,32 +837,93 @@ def _build_actions(report: Dict[str, Any]) -> List[Dict[str, Any]]:
         # isn't tracking yet there are bigger fish to fry.
         if chrony_run.get("tracking_ok"):
             current_stratum = chrony_run.get("stratum")
-            stratum_note = (
-                f" (currently stratum {current_stratum} via internet NTP)"
-                if current_stratum is not None else ""
+            sources = chrony_run.get("sources") or []
+            # Is chrony currently disciplined by a reference clock (PPS / GPS /
+            # NMEA — mode "#") rather than an internet peer?  The selected
+            # source carries state "*"; we also match the tracking reference
+            # name against the configured refclock names as a fallback.  This
+            # distinction matters: a station can have PPS reaching chrony fine
+            # (stratum 1, reference clock) while a *second* refclock — the
+            # coarse NMEA/GPS source gpsd would feed — sits at Reach=0 because
+            # EAS Station owns the serial port.  Without this check the old
+            # logic mislabelled that healthy state as "stratum N via internet
+            # NTP" and claimed PPS wasn't reaching when it was.
+            refclock_names = {
+                s.get("name") for s in sources if s.get("mode") == "#"
+            }
+            selected_src = next(
+                (s for s in sources if s.get("state") == "*"), None
             )
-            actions.append({
-                "id": "refclocks_unreached",
-                "severity": "info",
-                "label": (
-                    "GPS / PPS refclocks aren't reaching chrony "
-                    + stratum_note
-                ),
-                "reason": (
-                    f"chrony has the {' / '.join(unreached)} refclock(s) configured "
-                    "but Reach=0 — no samples have ever arrived. The most common "
-                    "cause is gpsd not being able to open the GPS serial port "
-                    "because EAS Station's hardware service holds it. Until the "
-                    "gpsd-as-NMEA-source feature lands, the workaround is to "
-                    "uncheck 'Enable GPS Receiver' under Admin → Hardware "
-                    "Settings → GPS, save, and let gpsd own the port. You'll "
-                    "lose the live GPS card but gain stratum-1 PPS time."
-                ),
-                "command": (
-                    "# Check who owns the serial port:\n"
-                    "sudo lsof /dev/ttyAMA10 /dev/ttyAMA0 /dev/serial0 2>/dev/null"
-                ),
-            })
+            selected_name = chrony_run.get("selected_source")
+            synced_to_refclock = bool(
+                (selected_src and selected_src.get("mode") == "#")
+                or (selected_name and selected_name in refclock_names)
+            )
+            serial_owner_cmd = (
+                "# Check who owns the serial port:\n"
+                "sudo lsof /dev/ttyAMA10 /dev/ttyAMA0 /dev/serial0 2>/dev/null"
+            )
+
+            if synced_to_refclock:
+                # A reference clock IS reaching chrony — that is what gives you
+                # reference-clock time.  Only the coarse NMEA/GPS source is
+                # starved, which is expected while EAS Station holds the serial
+                # port for the live GPS card.  Report it as the informational
+                # non-event it is; do NOT claim a fall-back to internet NTP.
+                ref_label = selected_name or "a reference clock"
+                stratum_note = (
+                    f"time is stratum {current_stratum} via {ref_label}"
+                    if current_stratum is not None
+                    else f"locked to {ref_label}"
+                )
+                actions.append({
+                    "id": "refclocks_unreached",
+                    "severity": "info",
+                    "label": (
+                        f"Coarse GPS/NMEA source isn't reaching chrony — "
+                        f"{stratum_note}"
+                    ),
+                    "reason": (
+                        f"chrony has the {' / '.join(unreached)} refclock(s) "
+                        "configured but Reach=0, so no samples are arriving from "
+                        f"them.  Your clock is fine — it is disciplined by the "
+                        f"{ref_label} reference clock.  This only means the coarse "
+                        "NMEA/GPS source gpsd would provide is starved, because "
+                        "EAS Station's hardware service holds the serial port to "
+                        "drive the live GPS card.  No action is required unless "
+                        "you want gpsd to own the port instead: until the "
+                        "gpsd-as-NMEA-source feature lands you can uncheck 'Enable "
+                        "GPS Receiver' under Admin → Hardware Settings → GPS to "
+                        "hand gpsd the port (you'll lose the live GPS card)."
+                    ),
+                    "command": serial_owner_cmd,
+                })
+            else:
+                # No refclock is selected — chrony has genuinely fallen back to
+                # an internet peer at stratum ≥ 2.
+                stratum_note = (
+                    f" (currently stratum {current_stratum} via internet NTP)"
+                    if current_stratum is not None else ""
+                )
+                actions.append({
+                    "id": "refclocks_unreached",
+                    "severity": "info",
+                    "label": (
+                        "GPS / PPS refclocks aren't reaching chrony"
+                        + stratum_note
+                    ),
+                    "reason": (
+                        f"chrony has the {' / '.join(unreached)} refclock(s) configured "
+                        "but Reach=0 — no samples have ever arrived. The most common "
+                        "cause is gpsd not being able to open the GPS serial port "
+                        "because EAS Station's hardware service holds it. Until the "
+                        "gpsd-as-NMEA-source feature lands, the workaround is to "
+                        "uncheck 'Enable GPS Receiver' under Admin → Hardware "
+                        "Settings → GPS, save, and let gpsd own the port. You'll "
+                        "lose the live GPS card but gain stratum-1 PPS time."
+                    ),
+                    "command": serial_owner_cmd,
+                })
 
     return actions
 

--- a/tests/test_gps_hat_refclock_action.py
+++ b/tests/test_gps_hat_refclock_action.py
@@ -1,0 +1,97 @@
+"""Tests for the GPS HAT "refclocks aren't reaching chrony" suggestion.
+
+Regression coverage for the false-positive where a station with PPS
+disciplining chrony (stratum 1, reference clock) was told its refclocks
+weren't reaching chrony and that it had fallen back to "internet NTP" —
+when in fact only the coarse NMEA/GPS source gpsd would feed was starved.
+
+The suggestion must now distinguish two states:
+
+* chrony is synced to a reference clock (PPS/GPS/NMEA) but a *second*
+  refclock is at Reach=0 — informational, never claims internet NTP; and
+* no refclock is selected at all — chrony has genuinely fallen back to an
+  internet peer, which keeps the original wording.
+"""
+
+from app_utils.gps_hat import _build_actions
+
+
+def _report(sources, selected_source, stratum, unreached):
+    """Minimal probe report exercising only the refclock action branch."""
+    return {
+        "expected_pps_pin": 18,
+        "rtc": {
+            "detected_chip": None,
+            "expected_overlay": None,
+            "chip_label": None,
+            "porf_set": False,
+        },
+        "packages": {"items": []},
+        "gpsd_config": {},
+        "chrony_config": {"has_pps_refclock": True, "has_shm_refclock": True},
+        "config_txt": {
+            "path": "/boot/firmware/config.txt",
+            "pps_gpio_overlay_line": "dtoverlay=pps-gpio,gpiopin=18",
+            "i2c_rtc_overlay_line": None,
+        },
+        "pps": {"devices": [{"name": "pps0"}]},
+        "serial": {"exists": True, "expected_baud": 9600},
+        "chrony_runtime": {
+            "tool_present": True,
+            "tracking_ok": True,
+            "stratum": stratum,
+            "selected_source": selected_source,
+            "sources": sources,
+            "refclocks_unreached": unreached,
+        },
+    }
+
+
+def _refclock_action(report):
+    actions = _build_actions(report)
+    return next(
+        (a for a in actions if a["id"] == "refclocks_unreached"), None
+    )
+
+
+def test_pps_locked_does_not_claim_internet_ntp():
+    """PPS reaching (stratum 1) + NMEA starved must not say 'internet NTP'."""
+    sources = [
+        {"mode": "#", "state": "*", "name": "PPS", "stratum": 0, "reach": 377},
+        {"mode": "#", "state": "?", "name": "NMEA", "stratum": 0, "reach": 0},
+        {"mode": "^", "state": "+", "name": "203.0.113.1", "stratum": 2, "reach": 377},
+    ]
+    action = _refclock_action(_report(sources, "PPS", 1, ["NMEA"]))
+
+    assert action is not None, "an informational note should still surface"
+    assert action["severity"] == "info"
+    assert "internet NTP" not in action["label"]
+    assert "stratum 1 via PPS" in action["label"]
+    # The reason reassures the operator their clock is fine.
+    assert "Your clock is fine" in action["reason"]
+
+
+def test_no_refclock_selected_keeps_internet_ntp_wording():
+    """When chrony has genuinely fallen back to a network peer, keep wording."""
+    sources = [
+        {"mode": "#", "state": "?", "name": "PPS", "stratum": 0, "reach": 0},
+        {"mode": "#", "state": "?", "name": "GPS", "stratum": 0, "reach": 0},
+        {"mode": "^", "state": "*", "name": "203.0.113.1", "stratum": 1, "reach": 377},
+    ]
+    action = _refclock_action(_report(sources, "203.0.113.1", 2, ["PPS", "GPS"]))
+
+    assert action is not None
+    assert "currently stratum 2 via internet NTP" in action["label"]
+
+
+def test_refclock_match_falls_back_to_tracking_name():
+    """A refclock selected by name (no '*' row) is still treated as locked."""
+    sources = [
+        {"mode": "#", "state": "+", "name": "PPS", "stratum": 0, "reach": 17},
+        {"mode": "#", "state": "?", "name": "GPS", "stratum": 0, "reach": 0},
+    ]
+    action = _refclock_action(_report(sources, "PPS", 1, ["GPS"]))
+
+    assert action is not None
+    assert "internet NTP" not in action["label"]
+    assert "stratum 1 via PPS" in action["label"]

--- a/tests/test_gps_holdover_anchor.py
+++ b/tests/test_gps_holdover_anchor.py
@@ -1,0 +1,79 @@
+"""Tests for the GPS holdover anchor surviving a manager restart.
+
+Regression coverage for the dashboard's holdover card going blank: the
+"last 3D fix" anchor that holdover is measured from used to live only in
+memory, so a GPS-service restart *during* a holdover period reset it to
+None and the dashboard rendered "—" / "unknown" even though the receiver
+was still coasting. The anchor is now persisted to Redis and restored on
+construction.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app_core.gps.gps_manager import GPSManager, REDIS_LAST_3D_KEY
+
+
+class FakeRedis:
+    """Minimal Redis stand-in covering the get/set the manager uses."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        return self.store.get(key)
+
+
+def _manager(redis):
+    # Empty config → all defaults; __init__ does not open the serial port or
+    # start any threads, so this is safe to construct in a unit test.
+    return GPSManager(config={}, redis_client=redis)
+
+
+def test_anchor_persists_to_redis_on_3d_fix():
+    redis = FakeRedis()
+    mgr = _manager(redis)
+    assert mgr._last_3d_fix_at is None
+
+    mgr._mark_3d_fix()
+
+    assert REDIS_LAST_3D_KEY in redis.store
+    assert mgr._last_3d_fix_at is not None
+
+
+def test_anchor_restored_after_restart_mid_holdover():
+    redis = FakeRedis()
+    # A previous process recorded a 3D fix 42 s ago, then the service
+    # restarted while the receiver is still without a fix.
+    redis.store[REDIS_LAST_3D_KEY] = (
+        datetime.now(timezone.utc) - timedelta(seconds=42)
+    ).isoformat()
+
+    mgr = _manager(redis)
+
+    assert mgr._last_3d_fix_at is not None, "anchor must restore from Redis"
+    # Holdover is measured from the restored anchor, so it is a real
+    # duration rather than the old blank/None.
+    elapsed = (datetime.now(timezone.utc) - mgr._last_3d_fix_at).total_seconds()
+    assert 41.0 <= elapsed <= 120.0
+
+
+def test_malformed_persisted_anchor_is_ignored():
+    redis = FakeRedis()
+    redis.store[REDIS_LAST_3D_KEY] = "not-a-timestamp"
+
+    mgr = _manager(redis)
+
+    assert mgr._last_3d_fix_at is None
+
+
+def test_no_redis_is_tolerated():
+    mgr = _manager(None)
+    assert mgr._last_3d_fix_at is None
+    # Must not raise even though there is nowhere to persist.
+    mgr._mark_3d_fix()
+    assert mgr._last_3d_fix_at is not None

--- a/tests/test_gps_holdover_anchor.py
+++ b/tests/test_gps_holdover_anchor.py
@@ -8,20 +8,22 @@ was still coasting. The anchor is now persisted to Redis and restored on
 construction.
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
-from app_core.gps.gps_manager import GPSManager, REDIS_LAST_3D_KEY
+from app_core.gps.gps_manager import GPSManager, REDIS_KEY, REDIS_LAST_3D_KEY
 
 
 class FakeRedis:
-    """Minimal Redis stand-in covering the get/set the manager uses."""
+    """Minimal Redis stand-in covering the get/set/setex the manager uses."""
 
     def __init__(self):
         self.store = {}
 
     def set(self, key, value):
+        self.store[key] = value
+
+    def setex(self, key, ttl, value):
         self.store[key] = value
 
     def get(self, key):
@@ -77,3 +79,40 @@ def test_no_redis_is_tolerated():
     # Must not raise even though there is nowhere to persist.
     mgr._mark_3d_fix()
     assert mgr._last_3d_fix_at is not None
+
+
+def test_holdover_seconds_helper():
+    now = datetime.now(timezone.utc)
+    assert GPSManager._holdover_seconds(None, None, now) is None
+    assert GPSManager._holdover_seconds(now, 3, now) == 0.0
+    assert GPSManager._holdover_seconds(
+        now - timedelta(seconds=30), 1, now
+    ) == 30.0
+    # No fix_mode key at all (lost-fix payload) still yields a duration.
+    assert GPSManager._holdover_seconds(
+        now - timedelta(seconds=30), None, now
+    ) == 30.0
+
+
+def test_published_blob_includes_holdover():
+    """The Redis blob (status fallback / trend source) must carry holdover_s.
+
+    Regression: the published blob used to be the raw fix dict, omitting the
+    derived holdover_s — so any reader served from Redis rendered the
+    holdover card blank during holdover.
+    """
+    redis = FakeRedis()
+    mgr = _manager(redis)
+    mgr._mark_3d_fix()
+    # Simulate the receiver having lost its 3D fix.
+    with mgr._lock:
+        mgr._fix["fix_mode"] = 1
+        mgr._fix["has_fix"] = False
+
+    mgr._publish_current_fix(force=True)
+
+    blob = json.loads(redis.store[REDIS_KEY])
+    assert "holdover_s" in blob
+    assert isinstance(blob["holdover_s"], (int, float))
+    assert blob["holdover_s"] >= 0
+    assert blob.get("last_3d_fix_at") is not None


### PR DESCRIPTION
## Summary

Four related fixes for the GPS/timing dashboard and the RWT air-chain countdown. The headline issue: the **HOLDOVER tile and Holdover Timer card render blank** even while the app is running and the receiver has previously held a 3D fix.

## What was wrong & the fixes

**1. `fix(rwt)` — air-chain countdown re-anchored to actual playout start** (`ee401d6`)
The countdown was anchored to scheduling time rather than when audio actually hit the air, so the displayed hold duration drifted from reality.

**2. `fix(gps)` — don't mislabel a PPS-locked clock as "internet NTP"** (`00959e0`)
The GPS-HAT suggestion logic flagged a healthy PPS-disciplined clock as falling back to internet NTP. Corrected the detection so a locked refclock isn't misreported.

**3. `fix(gps)` — persist the holdover anchor across restarts** (`90758c8`)
`_last_3d_fix_at` lived only in memory, so a process restart during holdover reset the timer to "never seen a fix" and blanked the card. The anchor is now persisted to/restored from Redis so the card survives restarts. (Defensive — covers the reboot case.)

**4. `fix(gps)` — include `holdover_s` in the published status blob** (`a4e5ba5`) — *the root cause of the blank card with the app running*
`holdover_s` / `last_3d_fix_at` were derived **only** in `get_status()`. `_publish_current_fix()` wrote the **raw fix dict** to Redis without them, so any reader served from the Redis blob — the `/api/hardware/gps/status` fallback when the live manager handle isn't in that process, plus cached trend paths — received **no `holdover_s` at all**, blanking both the HOLDOVER tile and the Timer during holdover. Locked state showed "NONE" only because that came through the live path.

The calculation is now centralized in a shared `_holdover_seconds()` helper used by **both** `get_status()` and `_publish_current_fix()`, so the live and Redis-cached views always agree and `holdover_s` is present on every status path.

## Tests
- `tests/test_gps_holdover_anchor.py` — persistence/restore, the `_holdover_seconds()` helper, and a regression test asserting the published Redis blob carries `holdover_s` after a lost fix.
- `tests/test_gps_hat_refclock_action.py` — refclock/NTP labelling.

> ⚠️ The Python suite couldn't be executed in the dev sandbox (its `cryptography`/`geoalchemy2` stack is broken there); GPS logic was verified via isolated checks. These tests run in CI.

## Verifying the headline fix on-device
During a holdover:
```
curl -s http://127.0.0.1:<gps-svc-port>/api/hardware/gps/status | python -m json.tool | grep -i holdover
```
`holdover_s` should now be a number on every path.

https://claude.ai/code/session_01EBMpHMvXWueJZjaHrTWA2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBMpHMvXWueJZjaHrTWA2h)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPS status display inconsistencies by persisting and restoring the last valid 3D fix timestamp, ensuring holdover duration is calculated consistently across all views.
  * Fixed broadcast countdown UI reaching "END OF MESSAGE" while audio was still playing due to GPIO initialization delays.
  * Improved diagnostic messages to better distinguish between GPS signal starvation and internet NTP fallback scenarios.

* **Tests**
  * Added regression tests for GPS holdover persistence and diagnostic logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->