### PR TITLE
feat(gps): poll u-blox antenna/jamming status via ubxtool under gpsd

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -49,8 +49,10 @@ import json
 import logging
 import math
 import os
+import shutil
 import socket
 import subprocess
+import tempfile
 import threading
 import time
 from collections import deque
@@ -225,6 +227,13 @@ class GPSManager:
         self._pps_kernel_device: Optional[str] = None  # e.g. "/sys/class/pps/pps0"
         self._pps_kernel_baseline_seq: Optional[int] = None
         self._pps_kernel_thread: Optional[threading.Thread] = None
+        # gpsd mode only: a side thread that shells out to ``ubxtool`` to
+        # poll UBX-MON-HW *through* gpsd.  In gpsd mode we don't own the
+        # serial port, so the in-process poller in _maybe_send_ubx_polls()
+        # can't write to the receiver — but ubxtool can, because gpsd
+        # forwards its control writes.  This is how the antenna / jamming
+        # tiles light up on a station that runs gpsd (the common case).
+        self._gpsd_ubx_thread: Optional[threading.Thread] = None
 
         # Inter-pulse intervals in nanoseconds, captured from the kernel
         # PPS device's nanosecond-precision assert timestamp.  Used by
@@ -397,12 +406,6 @@ class GPSManager:
             return False
         self._gpsd_sock = sock
         self._active_source = "gpsd"
-        # In gpsd mode we don't own the serial port and can't send UBX
-        # polls.  Mark the supported flag explicitly so the dashboard
-        # tile renders an informative "via gpsd" placeholder rather
-        # than spinning on "polling…" forever.
-        with self._lock:
-            self._fix["ubx_poll_supported"] = False
         self._running = True
         self._thread = threading.Thread(
             target=self._gpsd_reader_loop,
@@ -413,6 +416,12 @@ class GPSManager:
         # PPS monitor still works in gpsd mode — the kernel exposes
         # /sys/class/pps/pps0 regardless of who's reading the serial port.
         self._start_pps_monitor()
+        # We can't write UBX polls down the serial port (gpsd owns it),
+        # but ``ubxtool`` can poll through gpsd's control channel — so
+        # spin up a side thread that does exactly that to keep the
+        # antenna / jamming tiles populated.  ``ubx_poll_supported`` is
+        # left at None ("polling…") until the first reply lands.
+        self._start_gpsd_ubx_poller()
         self._logger.info(
             "✅ GPS reader started via gpsd at %s:%d (PPS GPIO %d, source=gpsd)",
             self._gpsd_host, self._gpsd_port, self._pps_pin,
@@ -496,6 +505,9 @@ class GPSManager:
         if self._pps_kernel_thread and self._pps_kernel_thread.is_alive():
             self._pps_kernel_thread.join(timeout=2)
         self._pps_kernel_thread = None
+        if self._gpsd_ubx_thread and self._gpsd_ubx_thread.is_alive():
+            self._gpsd_ubx_thread.join(timeout=3)
+        self._gpsd_ubx_thread = None
         self._pps_kernel_device = None
         if self._pps_gpio_active:
             try:
@@ -1265,12 +1277,130 @@ class GPSManager:
         if not fields:
             return
 
+        self._apply_ubx_fields(fields)
+
+    def _apply_ubx_fields(self, fields: Dict[str, Any]) -> None:
+        """Merge a decoded UBX field dict into the live fix under the lock.
+
+        Shared by the serial reader (:py:meth:`_handle_ubx`) and the
+        gpsd-mode ubxtool poller so both paths stamp ``ubx_last_poll_at``
+        and flip ``ubx_poll_supported`` to True identically.
+        """
         now_iso = datetime.now(timezone.utc).isoformat()
         with self._lock:
             for key, value in fields.items():
                 self._fix[key] = value
             self._fix["ubx_last_poll_at"] = now_iso
             self._fix["ubx_poll_supported"] = True
+
+    # ------------------------------------------------------------------
+    # gpsd-mode UBX polling (via ubxtool)
+    # ------------------------------------------------------------------
+    def _start_gpsd_ubx_poller(self) -> None:
+        """Launch the ubxtool-through-gpsd poll thread, if appropriate.
+
+        Honoured guards:
+          * ``_ubx_poll_interval_s <= 0`` disables polling entirely
+            (tests set this) — we mark the tile unsupported and bail.
+          * ``ubxtool`` missing from PATH — nothing we can do under
+            gpsd, so mark unsupported so the UI explains itself rather
+            than sitting on "polling…" forever.
+        """
+        if self._ubx_poll_interval_s <= 0:
+            with self._lock:
+                self._fix["ubx_poll_supported"] = False
+            return
+        if shutil.which("ubxtool") is None:
+            self._logger.info(
+                "ubxtool not found on PATH — u-blox antenna/jamming status "
+                "is unavailable while running under gpsd (install gpsd-clients)"
+            )
+            with self._lock:
+                self._fix["ubx_poll_supported"] = False
+            return
+        self._gpsd_ubx_thread = threading.Thread(
+            target=self._gpsd_ubx_poll_loop,
+            name="gps-ubx-gpsd",
+            daemon=True,
+        )
+        self._gpsd_ubx_thread.start()
+
+    def _gpsd_ubx_poll_loop(self) -> None:
+        """Poll UBX-MON-HW via ubxtool on the same cadence as serial mode.
+
+        Runs only while the manager is up and gpsd is the active source.
+        A failed/empty poll is non-fatal: we leave ``ubx_poll_supported``
+        as-is (None → the dashboard keeps showing "polling…") and retry
+        on the next tick, so a transient gpsd hiccup doesn't latch the
+        tile into an error state.
+        """
+        interval = self._ubx_poll_interval_s if self._ubx_poll_interval_s > 0 else 30.0
+        while self._running and self._active_source == "gpsd":
+            try:
+                fields = self._poll_mon_hw_via_ubxtool()
+                if fields:
+                    self._apply_ubx_fields(fields)
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.debug("gpsd UBX poll error: %s", exc)
+            # Sleep in small slices so stop() stays responsive.
+            slept = 0.0
+            while self._running and self._active_source == "gpsd" and slept < interval:
+                time.sleep(0.5)
+                slept += 0.5
+
+    def _poll_mon_hw_via_ubxtool(self) -> Optional[Dict[str, Any]]:
+        """Poll UBX-MON-HW through gpsd and return decoded fields.
+
+        ``ubxtool`` sends the poll over gpsd's control channel and we
+        capture the raw byte stream it sees with ``-R``.  Parsing that
+        capture with our own :py:func:`ubx.find_frame` / parse_mon_hw
+        reuses the binary decoder rather than scraping ubxtool's
+        human-readable text (which varies across gpsd versions).
+
+        Returns the most recent MON-HW field dict in the capture, or
+        ``None`` when no frame arrived.
+        """
+        wait_s = 2.0
+        fd, raw_path = tempfile.mkstemp(prefix="ubx-monhw-", suffix=".bin")
+        os.close(fd)
+        try:
+            cmd = [
+                "ubxtool",
+                "-p", "MON-HW",       # poll the antenna/jamming message
+                "-w", str(wait_s),    # wait this long for the reply
+                "-R", raw_path,       # save the raw device stream here
+                f"{self._gpsd_host}:{self._gpsd_port}",
+            ]
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=wait_s + 5.0,
+                check=False,
+            )
+            with open(raw_path, "rb") as fh:
+                raw = fh.read()
+        finally:
+            try:
+                os.unlink(raw_path)
+            except OSError:
+                pass
+
+        if not raw:
+            return None
+
+        # Scan the capture for MON-HW frames; keep the last one (freshest).
+        buf = bytearray(raw)
+        latest: Optional[Dict[str, Any]] = None
+        while True:
+            frame = ubx.find_frame(buf)
+            if frame is None:
+                break
+            _leading, class_id, msg_id, payload = frame
+            if class_id == ubx.CLASS_MON and msg_id == ubx.ID_MON_HW:
+                parsed = ubx.parse_mon_hw(payload)
+                if parsed:
+                    latest = parsed
+        return latest
 
     def _handle_sentence(self, msg) -> None:
         """Update internal fix state from a parsed NMEA sentence."""

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -4073,11 +4073,17 @@
             jamEl.classList.remove('pos', 'neg');
             var jamming = gps && gps.jamming_state;
             var noise = gps && gps.noise_level;
+            var agc = gps && gps.agc_count;
             if (jamming === null || jamming === undefined) {
                 jamEl.textContent = '—';
             } else {
                 var jamLabel = jamming.toUpperCase();
                 if (typeof noise === 'number') jamLabel += ' · noise ' + noise;
+                // AGC count (0–8191): how hard the receiver's automatic
+                // gain control is working.  A high value alongside low
+                // SNR points at a weak antenna / cabling rather than
+                // active jamming.
+                if (typeof agc === 'number') jamLabel += ' · agc ' + agc;
                 jamEl.textContent = jamLabel;
                 if (jamming === 'ok')                     jamEl.classList.add('pos');
                 else if (jamming === 'warning' || jamming === 'critical') jamEl.classList.add('neg');

--- a/tests/test_gps_ubx_gpsd_poll.py
+++ b/tests/test_gps_ubx_gpsd_poll.py
@@ -1,0 +1,111 @@
+"""Tests for u-blox MON-HW polling via ubxtool while running under gpsd.
+
+In gpsd mode the manager does not own the serial port, so the in-process
+UBX poller (_maybe_send_ubx_polls) cannot write to the receiver and the
+antenna / jamming dashboard tiles stayed dark ("via gpsd · polls
+disabled"). The manager now shells out to ``ubxtool`` — which polls
+through gpsd's control channel — captures the raw byte stream with
+``-R``, and decodes UBX-MON-HW with the existing binary parser. These
+tests cover that path end to end with ubxtool mocked out.
+"""
+
+import struct
+
+import app_core.gps.gps_manager as gm
+from app_core.gps import ubx
+from app_core.gps.gps_manager import GPSManager
+
+
+def _manager():
+    # Empty config → defaults; __init__ starts no threads or I/O.
+    return GPSManager(config={}, redis_client=None)
+
+
+def _mon_hw_frame(*, a_status=2, a_power=1, jamming=1, noise=42, agc=8190):
+    """Build a 60-byte UBX-MON-HW frame for the given field values."""
+    payload = bytearray(60)
+    struct.pack_into("<H", payload, 16, noise)        # noisePerMS
+    struct.pack_into("<H", payload, 18, agc)          # agcCnt
+    payload[20] = a_status                            # aStatus
+    payload[21] = a_power                             # aPower
+    payload[22] = (jamming & 0x03) << 2               # jammingState bits 2..3
+    return ubx.build_poll(ubx.CLASS_MON, ubx.ID_MON_HW, bytes(payload))
+
+
+def _fake_ubxtool(raw_payload):
+    """Return a subprocess.run stand-in that writes ``raw_payload`` to the
+    file named after the ``-R`` flag, mimicking ubxtool's raw capture."""
+
+    def _run(cmd, *args, **kwargs):
+        raw_path = cmd[cmd.index("-R") + 1]
+        with open(raw_path, "wb") as fh:
+            fh.write(raw_payload)
+
+        class _Completed:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        return _Completed()
+
+    return _run
+
+
+def test_poll_decodes_mon_hw_from_ubxtool_capture(monkeypatch):
+    mgr = _manager()
+    # Capture includes leading junk + an NMEA line, like a real stream.
+    raw = b"$GPGGA,foo*00\r\n\x00\x01" + bytes(_mon_hw_frame(jamming=2))
+    monkeypatch.setattr(gm.subprocess, "run", _fake_ubxtool(raw))
+
+    fields = mgr._poll_mon_hw_via_ubxtool()
+
+    assert fields is not None
+    assert fields["antenna_status"] == "ok"
+    assert fields["antenna_power"] == "on"
+    assert fields["jamming_state"] == "warning"
+    assert fields["noise_level"] == 42
+    assert fields["agc_count"] == 8190
+
+
+def test_poll_returns_none_when_no_frame(monkeypatch):
+    mgr = _manager()
+    monkeypatch.setattr(gm.subprocess, "run", _fake_ubxtool(b"no ubx here\r\n"))
+    assert mgr._poll_mon_hw_via_ubxtool() is None
+
+
+def test_apply_ubx_fields_marks_supported():
+    mgr = _manager()
+    assert mgr._fix["ubx_poll_supported"] is None
+    assert mgr._fix["antenna_status"] is None
+
+    mgr._apply_ubx_fields(ubx.parse_mon_hw(bytes(_mon_hw_frame())[6:-2]))
+
+    assert mgr._fix["antenna_status"] == "ok"
+    assert mgr._fix["ubx_poll_supported"] is True
+    assert mgr._fix["ubx_last_poll_at"] is not None
+
+
+def test_poller_not_started_when_ubxtool_missing(monkeypatch):
+    mgr = _manager()
+    monkeypatch.setattr(gm.shutil, "which", lambda _name: None)
+
+    mgr._start_gpsd_ubx_poller()
+
+    assert mgr._gpsd_ubx_thread is None
+    # Tile is marked unsupported so the UI explains itself.
+    assert mgr._fix["ubx_poll_supported"] is False
+
+
+def test_poller_disabled_when_interval_zero(monkeypatch):
+    mgr = _manager()
+    mgr._ubx_poll_interval_s = 0
+    # which() should never be consulted once the interval guard trips.
+    monkeypatch.setattr(
+        gm.shutil, "which",
+        lambda _name: (_ for _ in ()).throw(AssertionError("which() called")),
+    )
+
+    mgr._start_gpsd_ubx_poller()
+
+    assert mgr._gpsd_ubx_thread is None
+    assert mgr._fix["ubx_poll_supported"] is False


### PR DESCRIPTION
The dashboard already carried UBX-MON-HW telemetry (antenna OK/OPEN/
SHORT + power, RF jamming state, noise/AGC), but it only populated in
direct-serial mode. On a station running gpsd — the common case, where
chrony shares the receiver for stratum-1 PPS — gpsd owns the serial port
exclusively, so the in-process poller couldn't write to the receiver and
the antenna/jamming tiles sat dark ("via gpsd · polls disabled").

Add a gpsd-mode side thread that shells out to ubxtool, which polls
UBX-MON-HW through gpsd's control channel. The raw byte stream is
captured with ubxtool's -R flag and decoded with the existing binary
parser (ubx.find_frame + parse_mon_hw), so we reuse the tested decoder
rather than scraping ubxtool's version-dependent text output.

- _start_gpsd_ubx_poller / _gpsd_ubx_poll_loop / _poll_mon_hw_via_ubxtool
- factor the field merge into _apply_ubx_fields, shared with the serial
  path's _handle_ubx
- leave ubx_poll_supported = None ("polling…") until the first reply;
  only mark it False when ubxtool is absent or polling is disabled
- surface the AGC count alongside noise on the RF/jamming tile
- join the new thread on stop()

Tile rendering is unchanged: the fields already had a home in
renderGpsSummary, so they light up once the data arrives.

Note: the ubxtool-through-gpsd path needs validation on the actual Pi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPS dashboard RF/Jamming receiver status tile now displays AGC count alongside existing jamming indicators for enhanced analysis.
  * Improved GPS data collection in gpsd mode with dedicated U-Blox UBX polling support, enhancing receiver reliability and data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->