### PR TITLE
feat(gps): surface u-blox jamInd and render unknown antenna state honestly

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -1045,6 +1045,7 @@ class GPSManager:
             "antenna_status": None,         # init|unknown|ok|short|open
             "antenna_power": None,          # off|on|unknown
             "jamming_state": None,          # unknown|ok|warning|critical
+            "jam_indicator": None,          # 0..255 broadband CW jamming
             "noise_level": None,            # raw 16-bit "noise per ms"
             "agc_count": None,              # raw 16-bit AGC count
             "ubx_last_poll_at": None,       # ISO timestamp of last reply

--- a/app_core/gps/ubx.py
+++ b/app_core/gps/ubx.py
@@ -148,11 +148,20 @@ def parse_mon_hw(payload: bytes) -> Dict[str, Any]:
        22     U1    flags        (bit 0=rtcCalib, 1=safeBoot,
                                    2..3=jammingState, 4=xtalAbsent)
        23     U1    reserved1
-       24..   …     pinIrq, pullH, pullL (unused here)
+       24     U4    usedMask
+       28     U1[17] VP
+       45     U1    jamInd       (0=no CW jamming … 255=strong)
+       46..   …     reserved2, pinIrq, pullH, pullL (unused here)
 
     Older firmware reports a 56-byte payload instead; we tolerate
     either by only reading what's present.  Returns ``{}`` if the
     payload is too short to contain ``aStatus``.
+
+    ``jamInd`` is the broadband CW jamming indicator and is populated by
+    the receiver continuously — unlike the categorical ``jammingState``,
+    which only carries meaning once the ITFM monitor is enabled via
+    UBX-CFG-ITFM.  We surface both so the dashboard has a usable RF
+    figure even when ITFM is off (the common factory default).
     """
     if len(payload) < 23:
         return {}
@@ -163,11 +172,16 @@ def parse_mon_hw(payload: bytes) -> Dict[str, Any]:
     a_power = payload[21]
     flags = payload[22]
     jamming_bits = (flags >> 2) & 0x03
+    # jamInd lives at offset 45; absent on the short (56-byte) variant.
+    jam_indicator = payload[45] if len(payload) >= 46 else None
 
     return {
         "antenna_status": _ANT_STATUS.get(a_status, "unknown"),
         "antenna_power": _ANT_POWER.get(a_power, "unknown"),
         "jamming_state": _JAMMING_STATE.get(jamming_bits, "unknown"),
+        # Broadband CW jamming indicator, 0–255.  Live regardless of
+        # ITFM config, so it's the practical RF-health number.
+        "jam_indicator": int(jam_indicator) if jam_indicator is not None else None,
         "noise_level": int(noise),
         # AGC is a 16-bit count; receivers usually scale 8192 as the
         # nominal mid-point.  We expose the raw value and let the UI

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -4056,8 +4056,16 @@
             } else if (antStatus === null || antStatus === undefined) {
                 antEl.textContent = 'polling…';
             } else {
-                var label = antStatus.toUpperCase();
-                if (antPower) label += ' · ' + antPower.toUpperCase();
+                var label;
+                if (antStatus === 'unknown') {
+                    // The receiver's antenna supervisor isn't enabled, so
+                    // it can't report OK/OPEN/SHORT — say so plainly
+                    // rather than a bare alarming "UNKNOWN".
+                    label = 'unknown (supervisor off)';
+                } else {
+                    label = antStatus.toUpperCase();
+                    if (antPower && antPower !== 'unknown') label += ' · ' + antPower.toUpperCase();
+                }
                 antEl.textContent = label;
                 if (antStatus === 'ok')             antEl.classList.add('pos');
                 else if (antStatus === 'short' || antStatus === 'open') antEl.classList.add('neg');
@@ -4072,19 +4080,27 @@
         if (jamEl) {
             jamEl.classList.remove('pos', 'neg');
             var jamming = gps && gps.jamming_state;
+            var jamInd = gps && gps.jam_indicator;
             var noise = gps && gps.noise_level;
             var agc = gps && gps.agc_count;
-            if (jamming === null || jamming === undefined) {
+            if ((jamming === null || jamming === undefined) && typeof jamInd !== 'number') {
                 jamEl.textContent = '—';
             } else {
-                var jamLabel = jamming.toUpperCase();
-                if (typeof noise === 'number') jamLabel += ' · noise ' + noise;
+                var parts = [];
+                // The categorical ITFM state only means something once
+                // UBX-CFG-ITFM is enabled; when it reads "unknown" we
+                // lean on the raw CW indicator instead so the tile is
+                // still useful on a factory-default receiver.
+                if (jamming && jamming !== 'unknown') parts.push(jamming.toUpperCase());
+                // jamInd 0–255: broadband CW jamming indicator (live).
+                if (typeof jamInd === 'number') parts.push('jam ' + jamInd + '/255');
+                if (typeof noise === 'number') parts.push('noise ' + noise);
                 // AGC count (0–8191): how hard the receiver's automatic
                 // gain control is working.  A high value alongside low
                 // SNR points at a weak antenna / cabling rather than
                 // active jamming.
-                if (typeof agc === 'number') jamLabel += ' · agc ' + agc;
-                jamEl.textContent = jamLabel;
+                if (typeof agc === 'number') parts.push('agc ' + agc);
+                jamEl.textContent = parts.length ? parts.join(' · ') : '—';
                 if (jamming === 'ok')                     jamEl.classList.add('pos');
                 else if (jamming === 'warning' || jamming === 'critical') jamEl.classList.add('neg');
             }

--- a/tests/test_gps_ubx_gpsd_poll.py
+++ b/tests/test_gps_ubx_gpsd_poll.py
@@ -21,7 +21,7 @@ def _manager():
     return GPSManager(config={}, redis_client=None)
 
 
-def _mon_hw_frame(*, a_status=2, a_power=1, jamming=1, noise=42, agc=8190):
+def _mon_hw_frame(*, a_status=2, a_power=1, jamming=1, jam_ind=48, noise=42, agc=8190):
     """Build a 60-byte UBX-MON-HW frame for the given field values."""
     payload = bytearray(60)
     struct.pack_into("<H", payload, 16, noise)        # noisePerMS
@@ -29,7 +29,31 @@ def _mon_hw_frame(*, a_status=2, a_power=1, jamming=1, noise=42, agc=8190):
     payload[20] = a_status                            # aStatus
     payload[21] = a_power                             # aPower
     payload[22] = (jamming & 0x03) << 2               # jammingState bits 2..3
+    payload[45] = jam_ind                             # jamInd (0..255)
     return ubx.build_poll(ubx.CLASS_MON, ubx.ID_MON_HW, bytes(payload))
+
+
+def test_parse_surfaces_jam_indicator():
+    # Mirrors the real receiver: supervisor + ITFM off (status/jamming
+    # report "unknown") but jamInd / noise / agc are live.
+    fields = ubx.parse_mon_hw(bytes(_mon_hw_frame(
+        a_status=1, a_power=2, jamming=0, jam_ind=53, noise=99, agc=2730))[6:-2])
+    assert fields["antenna_status"] == "unknown"
+    assert fields["antenna_power"] == "unknown"
+    assert fields["jamming_state"] == "unknown"
+    assert fields["jam_indicator"] == 53
+    assert fields["noise_level"] == 99
+    assert fields["agc_count"] == 2730
+
+
+def test_parse_tolerates_short_payload_without_jam_indicator():
+    # A truncated payload (< 46 bytes) still yields the base fields but
+    # no jamInd — it must come back None rather than raising.
+    short = bytearray(24)
+    short[20] = 2  # aStatus ok
+    fields = ubx.parse_mon_hw(bytes(short))
+    assert fields["antenna_status"] == "ok"
+    assert fields["jam_indicator"] is None
 
 
 def _fake_ubxtool(raw_payload):


### PR DESCRIPTION
Follow-up to #2217 / #2218, which put the gpsd-mode `ubxtool` poller on `main`. That work is now **validated on the actual Pi** — a device-qualified poll (`ubxtool -p MON-HW 127.0.0.1:2947:/dev/ttyAMA0`) returns a live `UBX-MON-HW` block, and `gpsd -b` does **not** block it.

But the live values revealed a gap. On the receiver as shipped:

```
aStatus 1 (DONTKNOW)  aPower 2 (unknown)  flags 0x1 (jammingState=unknown)
noisePerMS 99  agcCnt 2730  jamInd 48
```

The **antenna supervisor and ITFM monitor are off by default**, so the categorical `antenna_status` and `jamming_state` both read "unknown". The numbers that *are* live and useful — `noisePerMS`, `agcCnt`, and especially `jamInd` (the 0–255 broadband CW jamming indicator) — include `jamInd`, which the parser wasn't extracting. So both tiles would have shown a bare, alarming "UNKNOWN".

## Changes

- `parse_mon_hw` now decodes **`jamInd`** (payload offset 45); `None` on truncated payloads.
- `jam_indicator` added to the published GPS status blob.
- **RF / jamming tile** leads with `jam N/255` when the categorical state is unknown, then `noise` / `agc` — so it's useful on a factory-default receiver instead of just "UNKNOWN".
- **Antenna tile** renders `unknown (supervisor off)` instead of a bare "UNKNOWN" when the supervisor isn't enabled, and drops the redundant `· UNKNOWN` power suffix.

## Notes

- This does **not** enable the supervisor/ITFM (`UBX-CFG-ANT` / `UBX-CFG-ITFM`) — that's a separate, opt-in change since it writes persistent config to the receiver and the antenna OK/OPEN/SHORT detect depends on board wiring.
- The earlier ms-scale timing-integrity "faults" were a post-reboot warm-up plus a few dropout outliers; they've since stabilized (receiver `tAcc` ~22 ns). Optional jitter-metric hardening (p99/MAD + outlier-reject) remains available as a separate change if desired.

## Tests

- 9 tests in `tests/test_gps_ubx_gpsd_poll.py` (jamInd decode, truncated-payload `None` path, device-qualified ubxtool target, `?DEVICES` discovery, field merge, ubxtool-missing/disabled guards).
- Full GPS suite green: 40 passed.

https://claude.ai/code/session_018KjWs8wFaPcBgCY7VFaMm5

---
_Generated by [Claude Code](https://claude.ai/code/session_018KjWs8wFaPcBgCY7VFaMm5)_