### PR TITLE
feat(gps): expand u-blox status under gpsd — leap, time-accuracy, spoofing + GNSS tile fix

### DIFF
--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -1048,6 +1048,10 @@ class GPSManager:
             "jam_indicator": None,          # 0..255 broadband CW jamming
             "noise_level": None,            # raw 16-bit "noise per ms"
             "agc_count": None,              # raw 16-bit AGC count
+            "time_accuracy_ns": None,       # NAV-PVT tAcc — receiver's own
+                                            # 1σ time estimate (ns)
+            "spoof_state": None,            # NAV-STATUS spoofDetState:
+                                            # unknown|none|indicated|multiple
             "ubx_last_poll_at": None,       # ISO timestamp of last reply
             "ubx_poll_supported": None,     # True after first reply,
                                             # False after timeout or
@@ -1347,15 +1351,31 @@ class GPSManager:
         interval = self._ubx_poll_interval_s if self._ubx_poll_interval_s > 0 else 30.0
         while self._running and self._active_source == "gpsd":
             try:
-                fields = self._poll_mon_hw_via_ubxtool()
-                if fields:
-                    self._apply_ubx_fields(fields)
+                # One capture for MON-HW also sweeps up the streaming
+                # NAV-PVT, so we get tAcc (time-accuracy estimate) for
+                # free without a second ubxtool invocation.
+                raw = self._capture_ubxtool("MON-HW")
+                if raw:
+                    mon = self._scan_capture(
+                        raw, ubx.CLASS_MON, ubx.ID_MON_HW, ubx.parse_mon_hw)
+                    if mon:
+                        self._apply_ubx_fields(mon)
+                    pvt = self._scan_capture(
+                        raw, ubx.CLASS_NAV, ubx.ID_NAV_PVT, ubx.parse_nav_pvt)
+                    if pvt:
+                        self._apply_ubx_fields(pvt)
+                # NAV-TIMELS (leap) and NAV-STATUS (spoofing) don't stream
+                # by default, so poll each explicitly.
                 leap = self._run_ubxtool_poll(
                     "NAV-TIMELS", ubx.CLASS_NAV, ubx.ID_NAV_TIMELS,
-                    ubx.parse_nav_timels,
-                )
+                    ubx.parse_nav_timels)
                 if leap:
                     self._apply_ubx_fields(leap)
+                spoof = self._run_ubxtool_poll(
+                    "NAV-STATUS", ubx.CLASS_NAV, ubx.ID_NAV_STATUS,
+                    ubx.parse_nav_status)
+                if spoof:
+                    self._apply_ubx_fields(spoof)
             except Exception as exc:  # pragma: no cover - defensive
                 self._logger.debug("gpsd UBX poll error: %s", exc)
             # Sleep in small slices so stop() stays responsive.
@@ -1379,14 +1399,23 @@ class GPSManager:
     ) -> Optional[Dict[str, Any]]:
         """Poll one UBX message through gpsd via ubxtool and decode it.
 
-        ``ubxtool`` sends the ``preset`` poll over gpsd's control channel
-        and we capture the raw byte stream it sees with ``-R``.  Parsing
-        that capture with our own :py:func:`ubx.find_frame` + ``parser``
-        reuses the binary decoders rather than scraping ubxtool's
-        human-readable text (which varies across gpsd versions).
+        Thin convenience wrapper: capture the ``preset`` poll and scan
+        the result for the requested class/id.  Returns ``None`` when no
+        matching frame arrived.
+        """
+        raw = self._capture_ubxtool(preset)
+        if not raw:
+            return None
+        return self._scan_capture(raw, want_class, want_id, parser)
 
-        Returns the most recent matching field dict in the capture, or
-        ``None`` when no frame of the requested class/id arrived.
+    def _capture_ubxtool(self, preset: str) -> Optional[bytes]:
+        """Send a ``preset`` poll through gpsd and return the raw stream.
+
+        ``ubxtool`` writes the poll over gpsd's control channel and we
+        capture the raw bytes it sees with ``-R``.  A single capture also
+        contains whatever else streams during the ~2 s window (e.g.
+        NAV-PVT), so callers can scan it for more than one message.
+        Returns ``None`` on timeout / spawn failure / empty capture.
         """
         wait_s = 2.0
         # gpsd needs the device named when several are attached (tty +
@@ -1409,12 +1438,16 @@ class GPSManager:
                 "-R", raw_path,       # save the raw device stream here
                 target,               # gpsd host:port[:device]
             ]
-            subprocess.run(
-                cmd,
-                capture_output=True,
-                timeout=wait_s + 5.0,
-                check=False,
-            )
+            try:
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    timeout=wait_s + 5.0,
+                    check=False,
+                )
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                self._logger.debug("ubxtool %s poll failed: %s", preset, exc)
+                return None
             with open(raw_path, "rb") as fh:
                 raw = fh.read()
         finally:
@@ -1422,11 +1455,22 @@ class GPSManager:
                 os.unlink(raw_path)
             except OSError:
                 pass
+        return raw or None
 
-        if not raw:
-            return None
+    @staticmethod
+    def _scan_capture(
+        raw: bytes,
+        want_class: int,
+        want_id: int,
+        parser,
+    ) -> Optional[Dict[str, Any]]:
+        """Scan a raw UBX capture for the freshest matching frame.
 
-        # Scan the capture for matching frames; keep the last (freshest).
+        Decodes with our own :py:func:`ubx.find_frame` + ``parser`` so we
+        reuse the tested binary decoders rather than scraping ubxtool's
+        version-dependent text.  Returns the last matching field dict, or
+        ``None`` when no frame of the requested class/id is present.
+        """
         buf = bytearray(raw)
         latest: Optional[Dict[str, Any]] = None
         while True:

--- a/app_core/gps/gps_manager.py
+++ b/app_core/gps/gps_manager.py
@@ -1334,13 +1334,15 @@ class GPSManager:
         self._gpsd_ubx_thread.start()
 
     def _gpsd_ubx_poll_loop(self) -> None:
-        """Poll UBX-MON-HW via ubxtool on the same cadence as serial mode.
+        """Poll UBX-MON-HW + NAV-TIMELS via ubxtool on the serial cadence.
 
         Runs only while the manager is up and gpsd is the active source.
         A failed/empty poll is non-fatal: we leave ``ubx_poll_supported``
         as-is (None → the dashboard keeps showing "polling…") and retry
         on the next tick, so a transient gpsd hiccup doesn't latch the
-        tile into an error state.
+        tile into an error state.  MON-HW feeds the antenna/jamming
+        tiles; NAV-TIMELS feeds the leap-second fields — mirroring what
+        serial mode polls in :py:meth:`_maybe_send_ubx_polls`.
         """
         interval = self._ubx_poll_interval_s if self._ubx_poll_interval_s > 0 else 30.0
         while self._running and self._active_source == "gpsd":
@@ -1348,6 +1350,12 @@ class GPSManager:
                 fields = self._poll_mon_hw_via_ubxtool()
                 if fields:
                     self._apply_ubx_fields(fields)
+                leap = self._run_ubxtool_poll(
+                    "NAV-TIMELS", ubx.CLASS_NAV, ubx.ID_NAV_TIMELS,
+                    ubx.parse_nav_timels,
+                )
+                if leap:
+                    self._apply_ubx_fields(leap)
             except Exception as exc:  # pragma: no cover - defensive
                 self._logger.debug("gpsd UBX poll error: %s", exc)
             # Sleep in small slices so stop() stays responsive.
@@ -1357,16 +1365,28 @@ class GPSManager:
                 slept += 0.5
 
     def _poll_mon_hw_via_ubxtool(self) -> Optional[Dict[str, Any]]:
-        """Poll UBX-MON-HW through gpsd and return decoded fields.
+        """Poll UBX-MON-HW (antenna/jamming) through gpsd."""
+        return self._run_ubxtool_poll(
+            "MON-HW", ubx.CLASS_MON, ubx.ID_MON_HW, ubx.parse_mon_hw
+        )
 
-        ``ubxtool`` sends the poll over gpsd's control channel and we
-        capture the raw byte stream it sees with ``-R``.  Parsing that
-        capture with our own :py:func:`ubx.find_frame` / parse_mon_hw
-        reuses the binary decoder rather than scraping ubxtool's
+    def _run_ubxtool_poll(
+        self,
+        preset: str,
+        want_class: int,
+        want_id: int,
+        parser,
+    ) -> Optional[Dict[str, Any]]:
+        """Poll one UBX message through gpsd via ubxtool and decode it.
+
+        ``ubxtool`` sends the ``preset`` poll over gpsd's control channel
+        and we capture the raw byte stream it sees with ``-R``.  Parsing
+        that capture with our own :py:func:`ubx.find_frame` + ``parser``
+        reuses the binary decoders rather than scraping ubxtool's
         human-readable text (which varies across gpsd versions).
 
-        Returns the most recent MON-HW field dict in the capture, or
-        ``None`` when no frame arrived.
+        Returns the most recent matching field dict in the capture, or
+        ``None`` when no frame of the requested class/id arrived.
         """
         wait_s = 2.0
         # gpsd needs the device named when several are attached (tty +
@@ -1379,12 +1399,12 @@ class GPSManager:
         if self._gpsd_ubx_device:
             target += f":{self._gpsd_ubx_device}"
 
-        fd, raw_path = tempfile.mkstemp(prefix="ubx-monhw-", suffix=".bin")
+        fd, raw_path = tempfile.mkstemp(prefix="ubx-", suffix=".bin")
         os.close(fd)
         try:
             cmd = [
                 "ubxtool",
-                "-p", "MON-HW",       # poll the antenna/jamming message
+                "-p", preset,         # poll this message
                 "-w", str(wait_s),    # wait this long for the reply
                 "-R", raw_path,       # save the raw device stream here
                 target,               # gpsd host:port[:device]
@@ -1406,7 +1426,7 @@ class GPSManager:
         if not raw:
             return None
 
-        # Scan the capture for MON-HW frames; keep the last one (freshest).
+        # Scan the capture for matching frames; keep the last (freshest).
         buf = bytearray(raw)
         latest: Optional[Dict[str, Any]] = None
         while True:
@@ -1414,8 +1434,8 @@ class GPSManager:
             if frame is None:
                 break
             _leading, class_id, msg_id, payload = frame
-            if class_id == ubx.CLASS_MON and msg_id == ubx.ID_MON_HW:
-                parsed = ubx.parse_mon_hw(payload)
+            if class_id == want_class and msg_id == want_id:
+                parsed = parser(payload)
                 if parsed:
                     latest = parsed
         return latest

--- a/app_core/gps/ubx.py
+++ b/app_core/gps/ubx.py
@@ -56,8 +56,18 @@ UBX_SYNC_2 = 0x62
 CLASS_NAV = 0x01
 CLASS_MON = 0x0A
 
+ID_NAV_STATUS = 0x03
+ID_NAV_PVT = 0x07
 ID_NAV_TIMELS = 0x26
 ID_MON_HW = 0x09
+
+# UBX-NAV-STATUS flags2 spoofing-detection state (bits 3..4).
+_SPOOF_STATE = {
+    0: "unknown",   # detection deactivated / not available
+    1: "none",      # no spoofing indicated
+    2: "indicated", # spoofing indicated
+    3: "multiple",  # multiple spoofing indications
+}
 
 # UBX-MON-HW antenna-status enum (aStatus byte at offset 20 in the
 # 60-byte payload).  Mapped to the strings the dashboard renders.
@@ -243,6 +253,36 @@ def parse_nav_timels(payload: bytes) -> Dict[str, Any]:
         "leap_event_gps_week": int(date_wn) if event_valid else None,
         "leap_event_gps_dow": int(date_dn) if event_valid else None,
     }
+
+
+def parse_nav_pvt(payload: bytes) -> Dict[str, Any]:
+    """Decode the time-accuracy estimate from ``UBX-NAV-PVT``.
+
+    Only ``tAcc`` (U4 at offset 12, nanoseconds) is surfaced — it is the
+    receiver's own 1-sigma estimate of how good its time solution is,
+    which complements the PPS jitter / Allan deviation panels.  The rest
+    of the 92-byte message duplicates fix data we already get from NMEA.
+
+    Returns ``{}`` if the payload is too short to contain ``tAcc``.
+    """
+    if len(payload) < 16:
+        return {}
+    t_acc = struct.unpack_from("<I", payload, 12)[0]
+    return {"time_accuracy_ns": int(t_acc)}
+
+
+def parse_nav_status(payload: bytes) -> Dict[str, Any]:
+    """Decode the spoofing-detection state from ``UBX-NAV-STATUS``.
+
+    ``flags2`` (X1 at offset 7) carries ``spoofDetState`` in bits 3..4.
+    NMEA has no equivalent, so this is the only place spoofing awareness
+    surfaces.  Returns ``{}`` if the payload is too short.
+    """
+    if len(payload) < 8:
+        return {}
+    flags2 = payload[7]
+    spoof_bits = (flags2 >> 3) & 0x03
+    return {"spoof_state": _SPOOF_STATE.get(spoof_bits, "unknown")}
 
 
 def find_frame(buf: bytearray) -> Optional[Tuple[int, int, int, bytes]]:

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -1710,6 +1710,7 @@
                     <dt data-gps-help="holdover">Holdover</dt>         <dd id="g-holdover" class="num">—</dd>
                     <dt data-gps-help="speed-cog">Speed / COG</dt>      <dd id="g-speed" class="num">—</dd>
                     <dt data-gps-help="pps-backend">PPS backend</dt>      <dd id="g-pps-backend">—</dd>
+                    <dt data-gps-help="time-accuracy">Time accuracy</dt>    <dd id="g-tacc" class="num">—</dd>
                     <dt data-gps-help="antenna">Antenna</dt>          <dd id="g-antenna">—</dd>
                     <dt data-gps-help="rf-jamming">RF / jamming</dt>     <dd id="g-jamming">—</dd>
                     <dt data-gps-help="leap-state">Leap state</dt>       <dd id="g-leap-state">—</dd>
@@ -2113,6 +2114,7 @@
                     <span><span class="swatch" style="background:#f85149;"></span><span class="label">Noise</span> <span id="ts-jam-noise" class="value">—</span></span>
                     <span><span class="swatch" style="background:#d29922;"></span><span class="label">AGC</span> <span id="ts-jam-agc" class="value">—</span></span>
                     <span><span class="label">State</span> <span id="ts-jam-state" class="value">—</span></span>
+                    <span><span class="label">Spoofing</span> <span id="ts-spoof-state" class="value">—</span></span>
                 </div>
                 <div class="gps-chart-canvas-wrap">
                     <canvas id="ts-jam-canvas" width="600" height="120" aria-label="Jamming and spoofing time-series"></canvas>
@@ -4105,6 +4107,41 @@
                 jamEl.textContent = parts.length ? parts.join(' · ') : '—';
                 if (jamming === 'ok')                     jamEl.classList.add('pos');
                 else if (jamming === 'warning' || jamming === 'critical') jamEl.classList.add('neg');
+            }
+        }
+
+        // Time accuracy — the receiver's own 1σ estimate (NAV-PVT tAcc).
+        // Sub-100 ns is excellent for a GNSS-disciplined clock.
+        var taccEl = document.getElementById('g-tacc');
+        if (taccEl) {
+            taccEl.classList.remove('pos', 'neg');
+            var tacc = gps && gps.time_accuracy_ns;
+            if (typeof tacc === 'number') {
+                taccEl.textContent = (tacc < 1000)
+                    ? tacc + ' ns'
+                    : (tacc / 1000).toFixed(1) + ' µs';
+                if (tacc <= 100) taccEl.classList.add('pos');
+                else if (tacc > 1000) taccEl.classList.add('neg');
+            } else {
+                taccEl.textContent = '—';
+            }
+        }
+
+        // Spoofing-detection state (NAV-STATUS).  "none" is the healthy
+        // reading; "unknown" means the detector isn't reporting (not a
+        // fault); "indicated"/"multiple" are real warnings.
+        var spoofEl = document.getElementById('ts-spoof-state');
+        if (spoofEl) {
+            spoofEl.classList.remove('pos', 'neg');
+            var spoof = gps && gps.spoof_state;
+            if (!spoof || spoof === 'unknown') {
+                spoofEl.textContent = (spoof === 'unknown') ? 'not monitored' : '—';
+            } else if (spoof === 'none') {
+                spoofEl.textContent = 'none';
+                spoofEl.classList.add('pos');
+            } else {
+                spoofEl.textContent = spoof.toUpperCase();
+                spoofEl.classList.add('neg');
             }
         }
 

--- a/templates/admin/gps_dashboard.html
+++ b/templates/admin/gps_dashboard.html
@@ -3568,15 +3568,17 @@
             setStripTile('strip-pps', 'ok', 'LOCKED', ppsBackend + ' · ' + ppsAge.toFixed(1) + 's');
         }
 
-        // GNSS tile (fix mode + jamming).
+        // GNSS tile (fix mode + jamming).  A 3D fix is a healthy state;
+        // only an actual interference reading (warning/critical from the
+        // ITFM monitor) degrades it.  "unknown" means the monitor isn't
+        // enabled — that's "not measured", not a fault, so it stays green.
         var fixMode = gps.fix_mode;
         var jamming = gps.jamming_state;
         if (fixMode === 3) {
-            var sub = '3D fix';
-            if (jamming && jamming !== 'ok') sub = 'RF ' + jamming;
+            var rfBad = (jamming === 'warning' || jamming === 'critical');
             setStripTile('strip-gnss',
-                (jamming && jamming !== 'ok') ? 'warn' : 'ok',
-                '3D FIX', sub);
+                rfBad ? 'warn' : 'ok',
+                '3D FIX', rfBad ? 'RF ' + jamming : '3D fix');
         } else if (fixMode === 2) {
             setStripTile('strip-gnss', 'warn', '2D FIX', 'horizontal only');
         } else if (hasFix) {

--- a/tests/test_gps_ubx_gpsd_poll.py
+++ b/tests/test_gps_ubx_gpsd_poll.py
@@ -99,6 +99,33 @@ def test_poll_nav_timels_returns_leap_seconds(monkeypatch):
     assert fields["leap_source"] == "gps"
 
 
+def test_parse_nav_pvt_time_accuracy():
+    payload = bytearray(92)
+    struct.pack_into("<I", payload, 12, 22)  # tAcc = 22 ns
+    fields = ubx.parse_nav_pvt(bytes(payload))
+    assert fields["time_accuracy_ns"] == 22
+
+
+def test_parse_nav_status_spoof_state():
+    # flags2 bits 3..4 = spoofDetState; 1 = "none".
+    payload = bytearray(16)
+    payload[7] = 1 << 3
+    assert ubx.parse_nav_status(bytes(payload))["spoof_state"] == "none"
+    payload[7] = 2 << 3
+    assert ubx.parse_nav_status(bytes(payload))["spoof_state"] == "indicated"
+
+
+def test_scan_capture_extracts_nav_pvt_from_mixed_stream():
+    # tAcc must be recoverable from a capture taken for a MON-HW poll,
+    # since NAV-PVT streams alongside it.
+    pvt = bytearray(92)
+    struct.pack_into("<I", pvt, 12, 35)
+    raw = bytes(_mon_hw_frame()) + bytes(
+        ubx.build_poll(ubx.CLASS_NAV, ubx.ID_NAV_PVT, bytes(pvt)))
+    got = GPSManager._scan_capture(raw, ubx.CLASS_NAV, ubx.ID_NAV_PVT, ubx.parse_nav_pvt)
+    assert got == {"time_accuracy_ns": 35}
+
+
 def test_poll_decodes_mon_hw_from_ubxtool_capture(monkeypatch):
     mgr = _manager()
     mgr._gpsd_ubx_device = "/dev/ttyTEST"  # skip live gpsd discovery

--- a/tests/test_gps_ubx_gpsd_poll.py
+++ b/tests/test_gps_ubx_gpsd_poll.py
@@ -75,6 +75,30 @@ def _fake_ubxtool(raw_payload):
     return _run
 
 
+def _nav_timels_frame(*, curr_ls=18, valid=0x01, src=2):
+    """Build a 24-byte UBX-NAV-TIMELS frame (current leap seconds only)."""
+    payload = bytearray(24)
+    payload[8] = src                                 # srcOfCurrLs (2=gps)
+    struct.pack_into("<b", payload, 9, curr_ls)      # currLs (signed)
+    payload[23] = valid                              # bit0=currLsValid
+    return ubx.build_poll(ubx.CLASS_NAV, ubx.ID_NAV_TIMELS, bytes(payload))
+
+
+def test_poll_nav_timels_returns_leap_seconds(monkeypatch):
+    mgr = _manager()
+    mgr._gpsd_ubx_device = "/dev/ttyTEST"  # skip live gpsd discovery
+    raw = b"$GPGGA,foo*00\r\n" + bytes(_nav_timels_frame(curr_ls=18))
+    monkeypatch.setattr(gm.subprocess, "run", _fake_ubxtool(raw))
+
+    fields = mgr._run_ubxtool_poll(
+        "NAV-TIMELS", ubx.CLASS_NAV, ubx.ID_NAV_TIMELS, ubx.parse_nav_timels
+    )
+
+    assert fields is not None
+    assert fields["leap_seconds"] == 18
+    assert fields["leap_source"] == "gps"
+
+
 def test_poll_decodes_mon_hw_from_ubxtool_capture(monkeypatch):
     mgr = _manager()
     mgr._gpsd_ubx_device = "/dev/ttyTEST"  # skip live gpsd discovery


### PR DESCRIPTION
Builds on the gpsd-mode u-blox poller (#2217–#2219). Four related dashboard improvements:

**1. GNSS tile no longer warns on unknown RF**
The status-strip tile went amber on a healthy 3D fix because it degraded whenever `jamming_state !== 'ok'`, but the receiver reports `"unknown"` by default (ITFM monitor off). Now only `warning`/`critical` degrades it.

**2. Leap data under gpsd (`NAV-TIMELS`)**
"Leap (GPS-UTC)" was blank because leap seconds come from `NAV-TIMELS`, which wasn't polled. Now polled each cycle → shows `18 s`.

**3. Time-accuracy estimate (`NAV-PVT` `tAcc`)**
The receiver's own 1σ time estimate (ns) — the most timing-relevant u-blox value, complements the PPS jitter / Allan panels. Parsed opportunistically from the MON-HW capture (NAV-PVT streams alongside), so no extra poll. New "Time accuracy" row in Receiver Status; green at ≤100 ns.

**4. GNSS spoofing detection (`NAV-STATUS` `spoofDetState`)**
Fills the previously-empty spoofing half of the "Jamming & Spoofing" card: `none` green, `indicated`/`multiple` red, `unknown` = not monitored.

The poll path is refactored into `_capture_ubxtool()` + `_scan_capture()` so one capture can yield multiple messages.

Tests: parsers + poll/scan paths covered; GPS suite green (44 passed).

https://claude.ai/code/session_018KjWs8wFaPcBgCY7VFaMm5