### PR TITLE
Fix phantom MDC1200 target unit ID shown for single-packet ops

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1849,6 +1849,50 @@ def _resolve_mdc1200_op_for_position(op_code: str, position: str) -> str:
     return op_code
 
 
+def _mdc1200_meta_target_unit_id(
+    op_code: Optional[str],
+    op_code_raw: Optional[int],
+    arg_raw: Optional[int],
+    target_unit_id: Optional[int],
+) -> Optional[int]:
+    """Return the target unit ID to advertise in signaling metadata, or ``None``.
+
+    The target unit ID is only carried on the wire by the **double-packet**
+    ops (Call Alert / Selective Call) — see ``MDC1200_DOUBLE_PACKET_OPS`` and
+    ``generate_mdc1200_samples``.  Single-packet ops (PTT-ID Pre/Post,
+    Emergency, Request-to-Talk, Remote Monitor) have no destination field, so
+    the encoder silently ignores any configured target.
+
+    This mirrors that behaviour for the UI / PDF / log: a target is only
+    surfaced when the resolved op-code actually transmits one.  Without this
+    gate the manual-activation page advertised a phantom destination (for
+    example ``PTT-ID → 65535`` / ``0xFFFF``) that never goes on air, which
+    misled operators into thinking PTT-ID had a destination.
+
+    Raw op/arg bytes (the ``custom`` preset) take precedence over the named
+    preset, matching the op/arg resolution in :func:`_generate_chime`.
+    """
+    from app_utils.mdc1200 import is_double_packet_op, resolve_op_preset
+
+    if op_code_raw is not None and arg_raw is not None:
+        try:
+            op = int(op_code_raw) & 0xFF
+            arg = int(arg_raw) & 0xFF
+        except (TypeError, ValueError):
+            op, arg = resolve_op_preset(op_code or '')
+    else:
+        op, arg = resolve_op_preset(op_code or '')
+
+    if not is_double_packet_op(op, arg):
+        return None
+    if target_unit_id in (None, 0):
+        return None
+    try:
+        return int(target_unit_id)
+    except (TypeError, ValueError):
+        return None
+
+
 # Standard DTMF tone-pair frequency map: digit -> (low Hz, high Hz).
 # Source: ITU-T Recommendation Q.23 / Q.24.
 _DTMF_FREQUENCIES: Dict[str, Tuple[float, float]] = {
@@ -3225,9 +3269,11 @@ class EASAudioGenerator:
         if pre_chime_profile_norm == 'mdc1200' or post_chime_profile_norm == 'mdc1200':
             signaling_meta['mdc1200'] = {
                 'unit_id': int(mdc1200_unit_id or 0),
-                'target_unit_id': (
-                    int(mdc1200_target_unit_id)
-                    if mdc1200_target_unit_id not in (None, 0) else None
+                'target_unit_id': _mdc1200_meta_target_unit_id(
+                    mdc1200_op_code,
+                    mdc1200_op_code_raw,
+                    mdc1200_arg_raw,
+                    mdc1200_target_unit_id,
                 ),
                 'op_code': mdc1200_op_code,
                 'op_code_raw': (

--- a/tests/test_mdc1200.py
+++ b/tests/test_mdc1200.py
@@ -324,6 +324,42 @@ def test_smart_pairing_handles_empty_and_case_insensitivity():
 
 
 # ---------------------------------------------------------------------------
+# Signaling-metadata target gating: a configured target unit ID must only be
+# advertised for double-packet ops (Call Alert / Selective Call).  PTT-ID and
+# the other single-packet ops have no destination field on the wire, so the
+# UI/PDF/log must not show a phantom target (e.g. "PTT-ID → 0xFFFF").
+# ---------------------------------------------------------------------------
+
+def test_meta_target_suppressed_for_single_packet_ops():
+    from app_utils.eas import _mdc1200_meta_target_unit_id
+    # PTT-ID Pre/Post and the other single-packet presets ignore the target
+    # on the wire, so the metadata must report None even when one is set.
+    for preset in ("ptt_id_pre", "ptt_id_post", "emergency",
+                   "request_to_talk", "remote_monitor"):
+        assert _mdc1200_meta_target_unit_id(preset, None, None, 0xFFFF) is None, preset
+        assert _mdc1200_meta_target_unit_id(preset, None, None, 0x1234) is None, preset
+
+
+def test_meta_target_kept_for_double_packet_ops():
+    from app_utils.eas import _mdc1200_meta_target_unit_id
+    # Call Alert / Selective Call genuinely carry the target on packet 2.
+    assert _mdc1200_meta_target_unit_id("call_alert", None, None, 0x2222) == 0x2222
+    assert _mdc1200_meta_target_unit_id("selective_call", None, None, 0xFFFF) == 0xFFFF
+    # A double-packet op with no target falls back to single-packet emission,
+    # so still nothing to advertise.
+    assert _mdc1200_meta_target_unit_id("call_alert", None, None, None) is None
+    assert _mdc1200_meta_target_unit_id("call_alert", None, None, 0) is None
+
+
+def test_meta_target_uses_raw_op_arg_bytes_for_custom_preset():
+    from app_utils.eas import _mdc1200_meta_target_unit_id
+    # Custom preset: raw op/arg bytes decide single vs double packet.
+    # 0x63/0x85 == Call Alert (double), 0x01/0x80 == PTT-ID Pre (single).
+    assert _mdc1200_meta_target_unit_id("custom", 0x63, 0x85, 0x2222) == 0x2222
+    assert _mdc1200_meta_target_unit_id("custom", 0x01, 0x80, 0x2222) is None
+
+
+# ---------------------------------------------------------------------------
 # Hex inputs (operators commonly copy MDC1200 unit IDs from Motorola CPS,
 # which displays them in 4-digit hex)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PTT-ID Pre/Post (and Emergency, Request-to-Talk, Remote Monitor) are
single-packet MDC1200 ops with no destination field on the wire — the
encoder ignores any configured target for them. But the signaling
metadata populated target_unit_id straight from the stored setting
regardless of op-code, so the manual-activation page (and the PDF/log)
advertised a phantom destination such as "PTT-ID -> 65535 (0xFFFF)"
that never gets transmitted.

Gate the displayed target on whether the resolved op-code is actually a
double-packet op (Call Alert / Selective Call), mirroring what
generate_mdc1200_samples emits. The decision is factored into a small
pure helper, _mdc1200_meta_target_unit_id, with unit tests covering the
single-packet, double-packet, and custom-raw-byte cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed MDC1200 target unit ID filtering in signaling metadata to correctly handle different operation types.

* **Tests**
  * Added test coverage for MDC1200 target unit ID metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->