### PR TITLE
Fix stats dashboard scroll-jump caused by sticky quick-nav scroll-spy

### DIFF
--- a/templates/stats/_scripts.html
+++ b/templates/stats/_scripts.html
@@ -2673,7 +2673,19 @@ function buildQuickNav() {
                     const link = linkFor.get(entry.target.id);
                     if (link) {
                         link.classList.add('active');
-                        link.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+                        // Keep the active pill visible by scrolling the nav
+                        // horizontally only. Using link.scrollIntoView() here
+                        // would scroll the document instead: because the nav is
+                        // position: sticky, the browser yanks the whole page back
+                        // to the top, creating a scroll loop that makes the page
+                        // impossible to scroll.
+                        const navWidth = nav.clientWidth;
+                        const target = link.offsetLeft - navWidth / 2 + link.clientWidth / 2;
+                        const maxLeft = nav.scrollWidth - navWidth;
+                        nav.scrollTo({
+                            left: Math.max(0, Math.min(target, maxLeft)),
+                            behavior: 'smooth'
+                        });
                     }
                 }
             });


### PR DESCRIPTION
The scroll-spy IntersectionObserver called link.scrollIntoView() on the
active pill, which lives inside .stats-quicknav (position: sticky; top: 0).
scrollIntoView on a child of a sticky container scrolls the document
vertically to pull the container toward its in-flow origin (page top), so
scrolling down fired the observer, jumped to the top, and re-fired it in a
loop that made the page impossible to scroll.

Scroll the nav container horizontally only (nav.scrollTo) so the active
pill stays visible without ever moving the document scroll position.