### PR TITLE
Enable TCP keep-alive for serial-to-Ethernet adapter connections

### DIFF
--- a/app_utils/network.py
+++ b/app_utils/network.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import socket
 import subprocess
 from typing import Optional, Dict, Any, List, Tuple
 
@@ -22,6 +23,56 @@ logger = logging.getLogger(__name__)
 
 # Hostname validation pattern (RFC 1123)
 HOSTNAME_PATTERN = re.compile(r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$')
+
+
+def enable_tcp_keepalive(
+    sock: "socket.socket",
+    *,
+    idle: int = 30,
+    interval: int = 10,
+    count: int = 3,
+) -> bool:
+    """Turn on TCP keep-alive probes for a connected stream socket.
+
+    EAS Station talks to RS-232↔Ethernet adapters (LED signs, VFD
+    displays) as a TCP *client* and then holds that one connection open,
+    often idle for long stretches between alerts.  Without keep-alive,
+    a connection that silently goes half-open (adapter reboot, WiFi
+    blip, NAT idle-timeout) is only discovered on the *next* write — by
+    which point that frame is already lost.
+
+    Enabling ``SO_KEEPALIVE`` makes the OS probe the link during idle so
+    a dead adapter is detected within ``idle + interval * count`` seconds
+    and the controller can reconnect, while a healthy idle connection is
+    kept alive so the adapter never reaps it as stale.
+
+    The per-probe tuning options (``TCP_KEEPIDLE`` / ``TCP_KEEPINTVL`` /
+    ``TCP_KEEPCNT``) are Linux-specific; they are applied best-effort and
+    silently skipped on platforms that lack them.  Returns ``True`` if
+    ``SO_KEEPALIVE`` itself was set.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError as exc:
+        logger.debug("Could not enable SO_KEEPALIVE: %s", exc)
+        return False
+
+    # Linux-only fine-tuning; absence of any constant just means we keep
+    # the OS defaults for that knob.
+    for opt_name, value in (
+        ("TCP_KEEPIDLE", idle),
+        ("TCP_KEEPINTVL", interval),
+        ("TCP_KEEPCNT", count),
+    ):
+        opt = getattr(socket, opt_name, None)
+        if opt is None:
+            continue
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, opt, value)
+        except OSError as exc:  # pragma: no cover - platform dependent
+            logger.debug("Could not set %s: %s", opt_name, exc)
+
+    return True
 
 # Cached nmcli availability
 _nmcli_available: Optional[bool] = None

--- a/scripts/led_sign_controller.py
+++ b/scripts/led_sign_controller.py
@@ -738,6 +738,14 @@ class Alpha9120CController:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.settimeout(self.timeout)
                 self.socket.connect((self.host, self.port))
+                # Keep the (usually idle) link to the serial-to-Ethernet
+                # adapter alive so a half-open connection is detected and
+                # reconnected instead of silently swallowing the next frame.
+                try:
+                    from app_utils.network import enable_tcp_keepalive
+                    enable_tcp_keepalive(self.socket)
+                except Exception as exc:  # pragma: no cover - best effort
+                    self.logger.debug("TCP keep-alive not enabled: %s", exc)
                 self.connected = True
                 self.logger.info(
                     "Connected to Alpha 9120C at %s:%s", self.host, self.port

--- a/scripts/vfd_controller.py
+++ b/scripts/vfd_controller.py
@@ -146,6 +146,18 @@ class NoritakeVFDController:
                     stopbits=serial.STOPBITS_ONE,
                     timeout=self.timeout
                 )
+                # Enable TCP keep-alive on the underlying socket so a
+                # half-open link to the serial-to-Ethernet adapter is
+                # detected and reconnected rather than silently dropped.
+                # pyserial's socket:// handler exposes the raw socket as
+                # ``_socket``; guard in case that internal changes.
+                try:
+                    from app_utils.network import enable_tcp_keepalive
+                    raw_sock = getattr(self.serial, "_socket", None)
+                    if raw_sock is not None:
+                        enable_tcp_keepalive(raw_sock)
+                except Exception as exc:  # pragma: no cover - best effort
+                    logger.debug(f"TCP keep-alive not enabled for VFD: {exc}")
                 logger.info(f"Connecting to VFD via TCP socket: {self.port}")
             else:
                 # Traditional serial port connection

--- a/tests/test_tcp_keepalive.py
+++ b/tests/test_tcp_keepalive.py
@@ -1,0 +1,61 @@
+"""Tests for the TCP keep-alive helper used on serial-to-Ethernet links.
+
+EAS Station holds a long-lived, mostly-idle TCP connection to RS-232↔
+Ethernet adapters (LED signs / VFD displays).  ``enable_tcp_keepalive``
+turns on OS keep-alive probing so a half-open link is detected and
+reconnected instead of silently swallowing the next frame.
+"""
+
+import socket
+
+import pytest
+
+from app_utils.network import enable_tcp_keepalive
+
+
+@pytest.fixture
+def connected_tcp_socket():
+    """Yield the server-side end of a real loopback TCP connection."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    client = socket.create_connection(srv.getsockname())
+    conn, _ = srv.accept()
+    try:
+        yield conn
+    finally:
+        for s in (conn, client, srv):
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+def test_enables_so_keepalive(connected_tcp_socket):
+    assert enable_tcp_keepalive(connected_tcp_socket) is True
+    assert connected_tcp_socket.getsockopt(
+        socket.SOL_SOCKET, socket.SO_KEEPALIVE
+    ) == 1
+
+
+def test_applies_linux_tuning_when_available(connected_tcp_socket):
+    enable_tcp_keepalive(connected_tcp_socket, idle=42, interval=7, count=2)
+
+    expected = {
+        "TCP_KEEPIDLE": 42,
+        "TCP_KEEPINTVL": 7,
+        "TCP_KEEPCNT": 2,
+    }
+    for name, value in expected.items():
+        opt = getattr(socket, name, None)
+        if opt is None:  # platform without this knob — nothing to assert
+            continue
+        assert connected_tcp_socket.getsockopt(socket.IPPROTO_TCP, opt) == value
+
+
+def test_returns_false_when_keepalive_unsupported():
+    class _Stubborn:
+        def setsockopt(self, *_args, **_kwargs):
+            raise OSError("not supported")
+
+    assert enable_tcp_keepalive(_Stubborn()) is False


### PR DESCRIPTION
## Summary
Add TCP keep-alive support to detect and recover from half-open connections to serial-to-Ethernet adapters (LED signs and VFD displays) that are held open for long periods with intermittent idle time.

## Changes
- **New `enable_tcp_keepalive()` function** in `app_utils/network.py`:
  - Enables `SO_KEEPALIVE` socket option to detect dead connections during idle periods
  - Applies Linux-specific TCP tuning parameters (`TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`) with sensible defaults (30s idle, 10s interval, 3 probes)
  - Gracefully handles platforms that don't support these options
  - Returns `True` if keep-alive was successfully enabled, `False` otherwise

- **Integration in `scripts/led_sign_controller.py`**:
  - Calls `enable_tcp_keepalive()` after establishing TCP socket connection to the Alpha 9120C LED sign controller
  - Wrapped in try-except for best-effort application (non-critical failure)

- **Integration in `scripts/vfd_controller.py`**:
  - Calls `enable_tcp_keepalive()` on the underlying socket for pyserial's `socket://` handler
  - Safely accesses the internal `_socket` attribute with fallback handling

- **Comprehensive test coverage** in `tests/test_tcp_keepalive.py`:
  - Tests that `SO_KEEPALIVE` is properly enabled
  - Tests that Linux-specific TCP tuning parameters are applied when available
  - Tests graceful handling when keep-alive is unsupported

## Implementation Details
- The function uses keyword-only arguments for the tuning parameters to prevent accidental positional argument confusion
- Linux-specific socket options are accessed via `getattr()` with `None` default to support cross-platform compatibility
- All socket operations are wrapped in exception handling to prevent connection failures due to keep-alive setup issues
- Detailed docstring explains the motivation: detecting half-open connections (adapter reboot, WiFi blips, NAT timeouts) before the next frame is lost

https://claude.ai/code/session_01FRzSrDPHSLPtt5LK1X3Bmc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP keep-alive support to improve connection reliability for LED sign and VFD controllers, preventing unexpected connection drops.

* **Tests**
  * Added comprehensive test coverage for TCP keep-alive functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->