### PR TITLE
Fix Alpha M-Protocol implementation: checksum, speed, attributes

### DIFF
--- a/docs/reference/protocols/ALPHA_M_PROTOCOL.md
+++ b/docs/reference/protocols/ALPHA_M_PROTOCOL.md
@@ -1,0 +1,269 @@
+# Alpha Sign Communications Protocol — Reference & Conformance Audit
+
+**Implementation:** `scripts/led_sign_controller.py`
+(`LEDSignController = Alpha9120CController`, line 2439)
+**Authoritative source:** *Alpha® Sign Communications Protocol*, document
+**9708‑8061F** (March 10, 2006) — in this repo at `bugs/M-Protocol.pdf`.
+**Target hardware:** Alpha 9120C, **Alpha 2.0 protocol generation ("version 2")**.
+
+> Page numbers below refer to the printed page of the manual. Line numbers
+> refer to `scripts/led_sign_controller.py`.
+
+Status legend: ✅ conformant · ⚠️ partial / misleading · ❌ non‑conformant
+(wire bug) · ⬜ not implemented.
+
+---
+
+## 1. Transmission packet structure
+
+The protocol's *Standard packet* (a.k.a. "1‑byte"/"^A" format, p.9) has two
+relevant variations — **without** a checksum and **with** a checksum:
+
+```
+without checksum:  <NUL×5> <SOH> <TT> <AAAA> <STX> <cmd><data> <EOT>
+with    checksum:  <NUL×5> <SOH> <TT> <AAAA> <STX> <cmd><data> <ETX> <CK CK CK CK> <EOT>
+```
+
+* `<NUL×5>` — five 0x00 wake‑up bytes for autobauding (p.9). ✅ implemented (`WAKEUP`, line 304).
+* `<SOH>` 0x01, `<STX>` 0x02, `<ETX>` 0x03, `<EOT>` 0x04. ✅
+* `TT` — Type Code (1 char; `Z` = all sign types). ✅ (`type_code`, default `Z`).
+* `AAAA` — two‑char sign address (`00` = broadcast). ✅ (`sign_id`).
+* **Sending `<ETX>` commits the frame to checksum mode** — *"If an `<ETX>`
+  character is transmitted before the `<EOT>`, the sign will expect a
+  Checksum"* (p.11). Our builder **always** appends `<ETX>` + checksum
+  (`_build_frame_from_payload`, line 962), so the checksum **must** be correct.
+
+### 1.1 Checksum — ❌ NON‑CONFORMANT (critical)
+
+> **Manual (p.11, Table 7):** *"Four ASCII digits that represent a **16‑bit
+> hexadecimal summation** of all transmitted data from the previous `<STX>`
+> through the previous `<ETX>` inclusive. The most significant digit is first."*
+
+Worked example (p.60): `…<STX>"AAHELLO"<ETX>"01FB"<EOT>`
+`sum(0x02,'A','A','H','E','L','L','O',0x03) = 0x01FB` → **`"01FB"`** (STX *and*
+ETX included; 4 hex digits).
+
+**Our implementation** (`_calculate_checksum`, line 954) computes an **XOR** and
+returns **2** hex digits, over `payload + ETX` (STX excluded):
+
+```python
+checksum = 0
+for byte in payload:        # XOR, not summation
+    checksum ^= byte
+return f"{checksum:02X}"     # 2 digits, should be 4
+```
+
+Wrong on three counts: **XOR vs SUM**, **2 vs 4 digits**, **STX excluded**.
+Because we transmit `<ETX>`, the sign expects a valid checksum and, per the
+manual, *"when a sign receives an invalid Checksum, the associated data will
+not be processed."* → **every checksummed frame is rejected.**
+
+**Fix:** sum bytes from `<STX>` through `<ETX>` inclusive, 16‑bit, 4 hex digits:
+
+```python
+def _calculate_checksum(self, data: bytes) -> str:
+    return f"{sum(data) & 0xFFFF:04X}"
+# include STX in the summed range when building the frame
+```
+
+(Alternative: omit `<ETX>`+checksum entirely and use the no‑checksum Standard
+packet. Adding the *correct* checksum is preferred for error detection.)
+
+---
+
+## 2. Command codes (byte after `<STX>`)
+
+| Code | Meaning | Implemented |
+|---|---|---|
+| `A` 0x41 | Write TEXT file | ✅ `_build_message` (817) |
+| `B` 0x42 | Read TEXT file | ✅ `read_text_file` (2213) |
+| `E` 0x45 | Write SPECIAL FUNCTION | ✅ (see §4) |
+| `F` 0x46 | Read SPECIAL FUNCTION | ✅ `read_*` (1751‑1896) |
+| `G` 0x47 | Write STRING file | ⬜ |
+| `H` 0x48 | Read STRING file | ⬜ |
+| `I` 0x49 | Write SMALL DOTS PICTURE | ⚠️ `send_dots_graphic` (2296) — see §5 |
+| `J` 0x4A | Read SMALL DOTS PICTURE | ⬜ |
+| `K`/`L` | Write/Read RGB DOTS PICTURE | ⬜ |
+| `M`/`N` | Write/Read LARGE DOTS PICTURE | ⬜ |
+| `O` | Write ALPHAVISION | ⬜ |
+| `T` 0x54 | Set Timeout Message | ⬜ |
+
+---
+
+## 3. TEXT‑file inline control codes (within Write TEXT `A`)
+
+### 3.1 Colour — ✅ `0x1C` + code (manual p.81)
+
+`Color` enum (line 122) matches exactly: `1`Red `2`Green `3`Amber `4`DimRed
+`5`DimGreen `6`Brown `7`Orange `8`Yellow `9`Rainbow1 `A`Rainbow2 `B`ColorMix
+`C`Autocolor. RGB `0x1C`+`Z`+`RRGGBB` is **Alpha 3.0 only** (we emit it via
+`COLOR_CMD+'Z'+rgb`; harmless on 2.0 if unused). ✅
+
+### 3.2 Font / character set — ⚠️ codes valid, names misleading
+
+`0x1A` + selector (p.81). The selector **bytes** we send (`1`–`9`,`:`) are
+valid, but the `Font` enum **names** (line 138) misrepresent them, e.g.
+`FONT_15x7='6'` actually selects *Ten‑high standard*, `FONT_32x16=':'` selects
+*Seven‑shadow‑fancy*. Wire‑safe, but the names should be corrected to the
+manual's font list to avoid operator confusion.
+
+### 3.3 Display mode — ✅ `<ESC>` + position + mode (p.88)
+
+`DisplayMode` enum (line 152) uses `a`–`v` (0x61‑0x76) and the `n`+digit
+"special/string" modes (0x6E + 0x30…), which match the manual. ✅
+*(Display‑position byte mapping `0x20–0x27` (`LINE_POSITION_MAP`, 291) should be
+spot‑checked against the sign's row semantics, but is not a framing error.)*
+
+### 3.4 Speed — ❌ NON‑CONFORMANT
+
+> **Manual (p.36/81):** speed is a **single** control byte:
+> `0x15`=Speed 1 (slow) … `0x19`=Speed 5 (fast); `0x09`=No‑hold.
+
+**Our code** emits `SPEED_CMD (0x15)` **+** an ASCII digit (`'1'`–`'5'`)
+(`_build_message`, line 917; `SPEED_CMD`, 361; `Speed` enum, 197). The sign
+therefore reads `0x15` (always **Speed 1**) followed by a **literal digit
+character that prints on the sign**.
+
+**Fix:** emit one byte `0x14 + N` (Speed N), no trailing digit. e.g. Speed 3 →
+`0x17`.
+
+### 3.5 Character attributes / "special functions" — ❌ NON‑CONFORMANT
+
+The manual defines these as distinct codes (p.80‑81):
+
+| Attribute | Manual code |
+|---|---|
+| Wide characters off / on | `0x11` / `0x12` (single byte) |
+| Double‑height off / on | `0x05` + `'0'`/`'1'` |
+| True descenders off / on | `0x06` + `'0'`/`'1'` |
+| **Character flash off / on** | `0x07` + `'0'`/`'1'` |
+| Char spacing: proportional / fixed | `0x1E` + `'0'` / `'1'` |
+| Wide/double/fancy set | `0x1D` + type + `'0'`/`'1'` |
+
+**Our `SpecialFunction` enum (line 206) routes *everything* through
+`SPECIAL_CMD = 0x1E`** (line 362, used at 921‑923) with digits `0`–`7`:
+
+| Our enum | We emit | Actually means on the wire |
+|---|---|---|
+| `WIDE_CHAR_ON='0'` | `0x1E 0x30` | char spacing → proportional |
+| `WIDE_CHAR_OFF='1'` | `0x1E 0x31` | char spacing → fixed |
+| `TRUE_DESC_ON='2'` | `0x1E 0x32` | invalid arg for 0x1E |
+| `CHAR_FLASH_ON='4'` | `0x1E 0x34` | invalid arg for 0x1E |
+| `FIXED_WIDTH='6'` | `0x1E 0x36` | invalid arg for 0x1E |
+
+→ Wide/descender/flash/fixed‑width all do the wrong thing. **Notably,
+`send_flashing_message()` and `emergency_override()` rely on `CHAR_FLASH_ON`,
+so emergency‑alert flashing does not work.**
+
+**Fix:** map each attribute to its real code (flash → `0x07`+`'1'`, wide →
+`0x12`, descenders → `0x06`+`'1'`, fixed/proportional → `0x1E`+`'1'`/`'0'`).
+
+### 3.6 Call Time / Call Date — ⚠️ partial
+
+* Call **Time** = `0x13` (`TIME_CMD`, line 363). ✅ code correct.
+* Call **Date** = `0x0B` + format digit `'0'`–`'9'` (p.80). ⬜ **not implemented**
+  — `send_time_display()` emits a literal `{TIME}` string and a pre‑formatted
+  date string instead of the live `0x13`/`0x0B` fields.
+
+---
+
+## 4. Write SPECIAL FUNCTION (`E` / 0x45) — Table 15 (manual p.21‑26)
+
+Verified label → behaviour, with our implementation status:
+
+| Label | Hex | Function | Status / notes |
+|---|---|---|---|
+| `␠` | **0x20** | Set Time of Day — 4 digits `HhMm` (24h) | ❌ `set_time_and_date` (1925) sends `"HH:MM:SS\rMM/DD/YY"` — wrong format; date is a *separate* command |
+| `!` | **0x21** | Speaker — `"00"`=enable `"FF"`=disable | ❌ `set_speaker` (2136) uses code **0x23** and data `'E'`/`'D'` |
+| `$` | **0x24** | Clear Memory (`E$`) / Set Memory Config (`FTPSIZEQQQQ`×N) | ⬜ not implemented as such — **but `set_brightness` emits `E$` (see below)** |
+| `&` | **0x26** | Set Day of Week — `'1'`Sun…`'7'`Sat | ❌ `set_day_of_week` (1980) uses code **0x22** and data `'0'`–`'6'` |
+| `'` | **0x27** | Set Time Format — `'S'`=am/pm, `'M'`=24h | ⚠️ code ✅ but `set_time_format` (2027) is **inverted** (sends `'S'` for 24h) |
+| `(` | **0x28** | Generate Speaker Tone — `A`/`B`/`0`/`1`/`2`+`FFDR` | ⚠️ `beep()` (2179) uses BEL in a text file instead |
+| `)` | **0x29** | Set Run Time Table — `FQQQQ` | ⬜ |
+| `+` | 0x2B | Display Text at XY (ALPHAVISION) | ⬜ |
+| `,` | **0x2C** | **Soft Reset** (no data; non‑destructive) | ⬜ |
+| `.` | **0x2E** | Set Run Sequence — `KPF` | ❌ `set_run_mode` (2066) misuses this code as an auto/manual toggle (no such command exists) |
+| `/` | **0x2F** | Set Dimming Register — `WWww` (**Solar signs only**) | ⬜ (see brightness) |
+| `2` | **0x32** | Set Run Day Table — `FSs` | ⬜ |
+| `5` | **0x35** | Set Counter | ⬜ |
+| `7` | **0x37** | **Set Serial Address** — 2 hex chars | ⬜ |
+| `8` | **0x38** | Set LARGE DOTS PICTURE Memory Config | ⬜ |
+| `;` | **0x3B** | Set Date — `mmddyy` | ⬜ (date is currently baked into a text string) |
+| `@` | **0x40** | Set Dimming Control Register (Alpha 2.0/3.0, AlphaEclipse) | ⬜ |
+
+### 4.1 `set_brightness` — ❌ DANGEROUS
+
+`set_brightness` (line 1486) builds `payload = f"E${level:X}"`. But **`E$` is
+*Clear Memory / Set Memory Configuration*** (0x24), **not** brightness. So every
+brightness call pokes the memory‑configuration command with malformed data.
+The real brightness control is **Set Dimming Register `E/` (0x2F)** with
+`WWww` (`WW`=light threshold, `ww`=`00`=100% … `04`=44%), and it is **only
+effective on Solar signs**; AlphaEclipse signs use `E@` (0x40). A plain 9120C
+may have **no** M‑Protocol brightness control. **Fix:** stop emitting `E$`;
+emit `E/ WWww` per spec (and document the sign‑type limitation).
+
+### 4.2 Existing `WriteSpecialExtCommand` enum (line 239) vs manual
+
+| Enum member | Enum value | Manual code | Verdict |
+|---|---|---|---|
+| `SET_TIME_DATE` | 0x20 | 0x20 (time only) | ⚠️ code ok, data/format wrong |
+| `SET_DAY_OF_WEEK` | 0x22 | **0x26** | ❌ wrong |
+| `SET_SPEAKER` | 0x23 | **0x21** | ❌ wrong |
+| `SET_TIME_FORMAT` | 0x27 | 0x27 | ✅ code (logic inverted) |
+| `SET_RUN_MODE` | 0x2E | 0x2E = Set Run **Sequence** | ❌ misused |
+| `SET_BRIGHTNESS` | 0x30 | dimming = **0x2F** | ❌ wrong (and method ignores the enum, uses `E$`) |
+
+---
+
+## 5. SMALL DOTS PICTURE (`I` / 0x49) — ⚠️ unverified format
+
+`send_dots_graphic` (line 2296) builds `I<label><colour><WWWW><HH><hex rows…>`
+using ASCII hex‑pair row encoding. The manual's SMALL/LARGE DOTS picture
+formats and the **memory‑allocation prerequisite** (a DOTS file must be
+allocated via Set Memory Configuration `E$`/`E8` first) differ from this
+encoding. Treat as **unverified** until bench‑tested; likely needs the
+dimensions/dot‑data format and a preceding memory‑config write.
+
+---
+
+## 6. Not implemented (vs full protocol)
+
+* **STRING files** (`G`/`H`) + **Call String** `0x10` — the standard way to
+  live‑update a field without rewriting the layout (and without the display
+  blanking). p.37.
+* **Counters** (`E5`) and counter field insertion.
+* **Call Date** `0x0B` inline field.
+* **Large / RGB DOTS** picture files (`K`–`N`) and DOTS read‑back (`J`).
+* **Set Memory Configuration write** (`E$ FTPSIZEQQQQ`) — required before using
+  non‑default file labels, STRING files, or DOTS files.
+* **Scheduling:** Set Run Time Table (`E)`), Run Day Table (`E2`), Run
+  Sequence (`E.`).
+* **Housekeeping:** Soft Reset (`E,`), Set Serial Address (`E7`),
+  Set Date (`E;`), Set Timeout Message (`T`).
+
+---
+
+## 7. Prioritised remediation plan
+
+1. **P0 — Checksum** (`_calculate_checksum`, 954): 16‑bit SUM, STX→ETX
+   inclusive, 4 hex digits. Validate against the p.60 worked example
+   (`AAHELLO` → `01FB`). *Without this, checksummed frames are rejected.*
+2. **P0 — `set_brightness`**: stop emitting `E$` (Clear Memory). Re‑point to
+   `E/` (0x2F) `WWww`; document Solar‑only.
+3. **P1 — Speed**: single byte `0x15`–`0x19`.
+4. **P1 — Character flash / attributes**: real codes (flash `0x07`+`'1'`,
+   wide `0x11/0x12`, descenders `0x06`+`'1'`, spacing `0x1E`+`'0'/'1'`). Fixes
+   emergency‑alert flashing.
+5. **P1 — Special‑function codes/data**: DOW → `E&` data `'1'`–`'7'`; Speaker
+   → `E!` data `'00'`/`'FF'`; Time format → fix inversion; split time/date into
+   `E␠`(`HhMm`) and `E;`(`mmddyy`); replace `set_run_mode` with Run
+   Sequence/Time‑table commands.
+6. **P2 — Housekeeping (new):** Soft Reset `E,`; Set Serial Address `E7` (2 hex);
+   Set Memory Configuration `E$ FTPSIZEQQQQ` (guard destructive `E$`-clear
+   behind explicit confirm); Run Time `E)` / Run Day `E2` tables.
+7. **P3 — Font enum names**; STRING files + Call String; Call Date `0x0B`.
+
+---
+
+*Sources: Alpha® Sign Communications Protocol 9708‑8061F (March 10, 2006),
+pp. 9‑11, 18‑26, 36, 50‑60, 80‑89, 117‑118 — `bugs/M-Protocol.pdf`.*

--- a/docs/reference/protocols/ALPHA_M_PROTOCOL.md
+++ b/docs/reference/protocols/ALPHA_M_PROTOCOL.md
@@ -12,6 +12,13 @@
 Status legend: ✅ conformant · ⚠️ partial / misleading · ❌ non‑conformant
 (wire bug) · ⬜ not implemented.
 
+> **Remediation status (June 2026):** the P0–P2 issues called out below have
+> been fixed in `scripts/led_sign_controller.py` and are covered by
+> `tests/test_alpha_mprotocol.py` (checksum verified against the p.60
+> `AAHELLO → 01FB` example). The ❌/⚠️ entries below are retained as the
+> historical audit and to document *why* each change was made; the "what it
+> used to do" descriptions refer to the pre‑fix code.
+
 ---
 
 ## 1. Transmission packet structure
@@ -243,25 +250,32 @@ dimensions/dot‑data format and a preceding memory‑config write.
 
 ---
 
-## 7. Prioritised remediation plan
+## 7. Remediation status
 
-1. **P0 — Checksum** (`_calculate_checksum`, 954): 16‑bit SUM, STX→ETX
-   inclusive, 4 hex digits. Validate against the p.60 worked example
-   (`AAHELLO` → `01FB`). *Without this, checksummed frames are rejected.*
-2. **P0 — `set_brightness`**: stop emitting `E$` (Clear Memory). Re‑point to
-   `E/` (0x2F) `WWww`; document Solar‑only.
-3. **P1 — Speed**: single byte `0x15`–`0x19`.
-4. **P1 — Character flash / attributes**: real codes (flash `0x07`+`'1'`,
-   wide `0x11/0x12`, descenders `0x06`+`'1'`, spacing `0x1E`+`'0'/'1'`). Fixes
-   emergency‑alert flashing.
-5. **P1 — Special‑function codes/data**: DOW → `E&` data `'1'`–`'7'`; Speaker
-   → `E!` data `'00'`/`'FF'`; Time format → fix inversion; split time/date into
-   `E␠`(`HhMm`) and `E;`(`mmddyy`); replace `set_run_mode` with Run
-   Sequence/Time‑table commands.
-6. **P2 — Housekeeping (new):** Soft Reset `E,`; Set Serial Address `E7` (2 hex);
-   Set Memory Configuration `E$ FTPSIZEQQQQ` (guard destructive `E$`-clear
-   behind explicit confirm); Run Time `E)` / Run Day `E2` tables.
-7. **P3 — Font enum names**; STRING files + Call String; Call Date `0x0B`.
+| # | Item | Status |
+|---|---|---|
+| P0 | **Checksum** → 16‑bit SUM over STX→ETX inclusive, 4 hex digits (`_calculate_checksum`) | ✅ done (test: `AAHELLO → 01FB`) |
+| P0 | **`set_brightness`** no longer emits `E$` (Clear Memory); now `E/` `WWww` | ✅ done |
+| P1 | **Speed** → single byte `0x15`–`0x19` | ✅ done |
+| P1 | **Character attributes** → flash `0x07`+`'1'`, wide `0x11/0x12`, descenders `0x06`+`'1'`, spacing `0x1E`+`'0'/'1'` (fixes alert flashing) | ✅ done |
+| P1 | **Day of Week** → `E&` data `'1'`–`'7'` | ✅ done |
+| P1 | **Speaker** → `E!` data `'00'`/`'FF'` | ✅ done |
+| P1 | **Time format** inversion fixed (`'M'`=24h, `'S'`=am/pm) | ✅ done |
+| P1 | **Time/date** split into Set Time of Day `E␠`(`HhMm`) + Set Date `E;`(`mmddyy`) | ✅ done |
+| P1 | **`set_run_mode`** no longer emits a malformed `0x2E` frame (now a logged no‑op) | ✅ done |
+| P2 | **Soft Reset** `E,` | ✅ done |
+| P2 | **Set Serial Address** `E7` (2 hex) | ✅ done |
+| P2 | **Set Memory Configuration** `E$ FTPSIZEQQQQ` + guarded **Clear Memory** | ✅ done |
+| P2 | **Run Time Table** `E)` / **Run Day Table** `E2` | ✅ done |
+| P3 | Font enum names; STRING files + Call String; Call Date `0x0B`; counters; large/RGB dots | ⬜ deferred |
+
+Implemented in `scripts/led_sign_controller.py`; verified by
+`tests/test_alpha_mprotocol.py`.
+
+> **Hardware note:** the brightness/dimming register (`E/`) is, per the
+> manual, only effective on Solar signs; a standard 9120C may ignore it.
+> The SMALL DOTS picture format (§5) remains **unverified** against the spec
+> and should be bench‑tested before relying on it.
 
 ---
 

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -15,6 +15,7 @@ protocol support. Operator-facing setup instructions live under
 |---|---|---|---|
 | **SAME** — Specific Area Message Encoding (FCC 47 CFR §11.31, NRSC-4-B §4) | [SAME.md](SAME.md) | AFSK · 520.83 baud · 2083.33 / 1562.5 Hz | `app_utils/eas_fsk.py`, `app_utils/eas.py`, `app_utils/eas_decode.py`, `app_utils/eas_demod.py` |
 | **MDC1200** — Motorola 1200-baud FFSK selective calling | [MDC1200.md](MDC1200.md) | FFSK · 1200 baud · 1200 / 1800 Hz | `app_utils/mdc1200.py` |
+| **Alpha M-Protocol** — Alpha Sign Communications Protocol (9708-8061F) for the Alpha 9120C LED sign | [ALPHA_M_PROTOCOL.md](ALPHA_M_PROTOCOL.md) | RS-232/RS-485 or TCP · framed serial | `scripts/led_sign_controller.py` |
 
 For the broader RBDS Annex-D treatment of SAME (as embedded in NRSC-4-B for
 FM broadcasters), see also [`../NRSC4B_SAME_STANDARD.md`](../NRSC4B_SAME_STANDARD.md).

--- a/scripts/led_sign_controller.py
+++ b/scripts/led_sign_controller.py
@@ -204,15 +204,22 @@ class Speed(Enum):
 
 
 class SpecialFunction(Enum):
-    """Special Functions (1EH + character)"""
-    WIDE_CHAR_ON = '0'  # Wide character on
-    WIDE_CHAR_OFF = '1'  # Wide character off
-    TRUE_DESC_ON = '2'  # True descender on
-    TRUE_DESC_OFF = '3'  # True descender off
-    CHAR_FLASH_ON = '4'  # Character flash on
-    CHAR_FLASH_OFF = '5'  # Character flash off
-    FIXED_WIDTH = '6'  # Fixed width font
-    PROP_WIDTH = '7'  # Proportional width font
+    """Character attribute control sequences (Alpha protocol ASCII table, p.80-81).
+
+    Each value is the *complete* control sequence emitted inline in a TEXT
+    file — these are distinct control codes, NOT all ``1EH`` + a digit.  The
+    earlier revision routed every attribute through ``1EH`` (character spacing)
+    with the wrong argument, so wide/descender/flash all did the wrong thing and
+    emergency-alert flashing never worked.
+    """
+    WIDE_CHAR_ON = '\x12'        # 12H = enable wide characters
+    WIDE_CHAR_OFF = '\x11'       # 11H = disable wide characters (default)
+    TRUE_DESC_ON = '\x06\x31'    # 06H + '1' = true descenders on
+    TRUE_DESC_OFF = '\x06\x30'   # 06H + '0' = true descenders off (default)
+    CHAR_FLASH_ON = '\x07\x31'   # 07H + '1' = character flash on
+    CHAR_FLASH_OFF = '\x07\x30'  # 07H + '0' = character flash off (default)
+    FIXED_WIDTH = '\x1e\x31'     # 1EH + '1' = fixed-width characters
+    PROP_WIDTH = '\x1e\x30'      # 1EH + '0' = proportional characters (default)
 
 
 class TimeFormat(Enum):
@@ -237,13 +244,27 @@ class ReadSpecialExtCommand(Enum):
 
 
 class WriteSpecialExtCommand(Enum):
-    """Type E - Write Special Functions (Extended)"""
-    SET_TIME_DATE = 0x20       # Set time and date
-    SET_DAY_OF_WEEK = 0x22     # Set day of week
-    SET_SPEAKER = 0x23         # Set speaker on/off
-    SET_TIME_FORMAT = 0x27     # Set 12h/24h time format
-    SET_RUN_MODE = 0x2E        # Set run mode (auto/manual)
-    SET_BRIGHTNESS = 0x30      # Set brightness level
+    """Write SPECIAL FUNCTION labels — the byte after ``E`` (manual Table 15).
+
+    Codes verified against Alpha Sign Communications Protocol 9708-8061F,
+    pp.21-26.  See docs/reference/protocols/ALPHA_M_PROTOCOL.md.
+    """
+    SET_TIME_OF_DAY = 0x20     # " "  Set Time of Day (HhMm, 24-hour)
+    SET_SPEAKER = 0x21         # "!"  Enable/Disable speaker ("00"/"FF")
+    SET_MEMORY = 0x24          # "$"  Clear Memory / Set Memory Configuration
+    SET_DAY_OF_WEEK = 0x26     # "&"  Set Day of Week ("1"=Sun .. "7"=Sat)
+    SET_TIME_FORMAT = 0x27     # "'"  Set Time Format ("S"=am/pm, "M"=24h)
+    SET_RUN_TIME_TABLE = 0x29  # ")"  Set Run Time Table (FQQQQ)
+    SOFT_RESET = 0x2C          # ","  Soft Reset (no data, non-destructive)
+    SET_RUN_SEQUENCE = 0x2E    # "."  Set Run Sequence (KPF)
+    SET_DIMMING = 0x2F         # "/"  Set Dimming Register (WWww, Solar signs)
+    SET_RUN_DAY_TABLE = 0x32   # "2"  Set Run Day Table (FSs)
+    SET_COUNTER = 0x35         # "5"  Set Counter
+    SET_SERIAL_ADDRESS = 0x37  # "7"  Set Serial Address (two hex chars)
+    SET_DATE = 0x3B            # ";"  Set Date (mmddyy)
+
+    # Backwards-compatibility alias: older callers referenced SET_TIME_DATE.
+    SET_TIME_DATE = 0x20
 
 
 class ReadTextCommand(Enum):
@@ -358,8 +379,12 @@ class Alpha9120CController:
         self.COLOR_CMD = '\x1C'  # Color command prefix
         self.FONT_CMD = '\x1A'  # Font command prefix
         self.MODE_CMD = '\x1B'  # Display mode command prefix
-        self.SPEED_CMD = '\x15'  # Speed command prefix
-        self.SPECIAL_CMD = '\x1E'  # Special function prefix
+        # NOTE: speed and character attributes are NOT a prefix + arg — speed is
+        # a single byte 0x15-0x19 and each attribute has its own code (see the
+        # Speed/SpecialFunction enums).  These two constants are retained only
+        # for backwards reference and are no longer used to build frames.
+        self.SPEED_CMD = '\x15'  # (legacy) Speed 1 control byte
+        self.SPECIAL_CMD = '\x1E'  # (legacy) character-spacing control code
         self.TIME_CMD = '\x13'  # Time format prefix
         self.POSITION_CMD = '\x1F'  # Position command prefix
 
@@ -915,12 +940,23 @@ class Alpha9120CController:
                         state.position = position_char
 
                     if effective_speed and state.speed != effective_speed:
-                        segment_builder += self.SPEED_CMD + effective_speed.value
+                        # Speed is a single control byte: 0x15 = Speed 1 (slow)
+                        # … 0x19 = Speed 5 (fast) — see the protocol ASCII table
+                        # (manual p.36/81).  The Speed enum values are "1".."5",
+                        # so the byte is 0x14 + N.  (The previous code emitted
+                        # 0x15 followed by the ASCII digit, which always selected
+                        # Speed 1 and printed a stray digit on the sign.)
+                        segment_builder += chr(0x14 + int(effective_speed.value))
                         state.speed = effective_speed
 
                     if combined_specials:
                         for func in combined_specials:
-                            segment_builder += self.SPECIAL_CMD + func.value
+                            # Each SpecialFunction.value is the full, correct
+                            # control sequence for that attribute (e.g. flash =
+                            # 0x07+'1', wide = 0x12); see the SpecialFunction
+                            # enum.  Do NOT prefix with 0x1E — that code is only
+                            # for character spacing.
+                            segment_builder += func.value
 
                     segment_builder += segment_text
                     content_parts.append(segment_builder)
@@ -933,7 +969,7 @@ class Alpha9120CController:
             # Complete message body
             message_body = f"{cmd}{file_label}{content}"
 
-            # Complete frame with header and checksum (checksum is XOR of bytes between STX and ETX)
+            # Complete frame with header and checksum (16-bit sum over STX..ETX)
             frame = self._build_frame_from_payload(message_body)
 
             self.logger.debug(
@@ -951,13 +987,20 @@ class Alpha9120CController:
         """Validate RGB color format (RRGGBB)"""
         return bool(re.match(r'^[0-9A-Fa-f]{6}$', rgb_color))
 
-    def _calculate_checksum(self, payload: bytes) -> str:
-        """Checksum is calculated as an XOR of bytes between STX and ETX."""
+    def _calculate_checksum(self, data: bytes) -> str:
+        """Compute the Alpha-protocol Checksum over ``data``.
 
-        checksum = 0
-        for byte in payload:
-            checksum ^= byte
-        return f"{checksum:02X}"
+        Per the manual (9708-8061F, p.11): *"Four ASCII digits that represent a
+        16-bit hexadecimal summation of all transmitted data from the previous
+        <STX> through the previous <ETX> inclusive. The most significant digit
+        is first."*  Verified against the worked example on p.60:
+        ``<STX>"AAHELLO"<ETX>`` → ``"01FB"``.
+
+        ``data`` must therefore be the bytes from ``<STX>`` through ``<ETX>``
+        inclusive.  (The previous implementation XOR'd the bytes and emitted
+        only two hex digits, which the sign rejects as an invalid checksum.)
+        """
+        return f"{sum(data) & 0xFFFF:04X}"
 
     def _build_frame_from_payload(self, payload: str) -> bytes:
         """Wrap a raw payload as a fully-compliant M-Protocol transmission.
@@ -969,15 +1012,16 @@ class Alpha9120CController:
 
         Where the leading NULLs wake up the sign's UART, ``TT`` is the
         single-character type code (e.g. ``Z`` for all signs), ``AAAA`` is
-        the two-character sign address, and ``CC`` is the two-hex-digit
-        XOR checksum of the bytes between ``STX`` (exclusive) and ``ETX``
-        (inclusive).
+        the two-character sign address, and ``CC`` is the four-hex-digit
+        16-bit summation checksum of the bytes from ``STX`` through ``ETX``
+        inclusive (see ``_calculate_checksum``).
         """
 
         payload_bytes = payload.encode("latin-1")
+        stx_bytes = self.STX.encode("latin-1")
         etx_bytes = self.ETX.encode("latin-1")
-        # Checksum is XOR of every byte after STX up to and including ETX.
-        checksum = self._calculate_checksum(payload_bytes + etx_bytes)
+        # Checksum covers <STX> through <ETX> inclusive (manual p.11/60).
+        checksum = self._calculate_checksum(stx_bytes + payload_bytes + etx_bytes)
         header = f"{self.SOH}{self.type_code}{self.sign_id}{self.STX}".encode("latin-1")
         return (
             self.WAKEUP
@@ -1484,25 +1528,50 @@ class Alpha9120CController:
             return False
 
     def set_brightness(self, level: int, auto: bool = False) -> bool:
-        """Set display brightness via the M-Protocol ``E$`` sub-command.
+        """Set sign dimming via the Set Dimming Register (``E/``, 0x2F).
 
-        The Alpha M-Protocol expresses brightness as a single hex digit
-        ``0``-``F`` (16 discrete steps) plus an automatic photocell mode
-        signalled with ``E$A``.  Some callers (and the legacy web UI)
-        pass values in the inclusive range 1-16; we accept either the
-        spec range 0-15 or 1-16 by clamping.
+        Format ``WWww`` (manual p.23):
+
+        * ``WW`` — when to dim: ``"00"`` = no dimming, ``"01"`` (dark) … ``"15"``
+          (bright) selects the ambient-light threshold at which the sign dims.
+        * ``ww`` — dimmed brightness level: ``"00"`` = 100%, ``"01"`` = 86%,
+          ``"02"`` = 72%, ``"03"`` = 58%, ``"04"`` = 44%.
+
+        ``level`` is mapped onto those five steps.  Both the 1-16 range used by
+        the web UI and a 0-100 percentage (used by the diagnostic scripts) are
+        accepted.  ``auto=True`` enables ambient-light dimming (``WW="07"``);
+        otherwise ``WW="00"``.
+
+        .. important::
+           Per the protocol this register is **only effective on Solar signs**
+           (AlphaEclipse signs use ``E@``; a standard 9120C may ignore it).
+           This replaces the previous implementation, which emitted ``E$`` —
+           the **Clear Memory / Set Memory Configuration** command — and so
+           never actually set brightness and risked corrupting the sign's
+           memory configuration.
         """
-
         try:
-            if auto:
-                payload = "E$A"
+            # Normalise the incoming level to a 0..100 percentage.
+            if level <= 16:
+                pct = max(0, min(100, round((level / 16) * 100)))
             else:
-                if level == 16:
-                    level = 15  # 1-16 → 0-15 fold-back for legacy callers
-                if not 0 <= level <= 15:
-                    raise ValueError("Brightness level must be between 0 and 15")
+                pct = max(0, min(100, int(level)))
 
-                payload = f"E${level:X}"
+            # Map percentage to the five documented brightness steps.
+            # Higher percentage -> lower dim-step number (00 = brightest).
+            if pct >= 90:
+                ww = "00"
+            elif pct >= 75:
+                ww = "01"
+            elif pct >= 60:
+                ww = "02"
+            elif pct >= 45:
+                ww = "03"
+            else:
+                ww = "04"
+
+            ww_threshold = "07" if auto else "00"
+            payload = f"E/{ww_threshold}{ww}"
             frame = self._build_frame_from_payload(payload)
             return self._send_raw_message(frame)
 
@@ -1922,87 +1991,89 @@ class Alpha9120CController:
         
         return diagnostics
 
-    def set_time_and_date(self, dt: Optional[datetime] = None) -> bool:
-        """
-        Set sign time and date (M-Protocol Type E, Function 0x20).
-        
-        Args:
-            dt: datetime object to set. If None, uses current system time.
-            
-        Returns:
-            True if successful, False otherwise
-            
-        Example:
-            >>> led = Alpha9120CController(host='192.168.8.122', port=10001)
-            >>> from datetime import datetime
-            >>> led.set_time_and_date(datetime(2025, 12, 13, 15, 30, 0))
-            True
-            
-        Note:
-            Time format is 10 bytes ASCII: HH:MM:SS\rMM/DD/YY
-            Example: "15:30:00\r12/13/25"
+    def set_time_of_day(self, dt: Optional[datetime] = None) -> bool:
+        """Set the sign's time-of-day clock (Write Special Function ``E␠``, 0x20).
+
+        Per the manual (p.21) the data is exactly four ASCII digits ``HhMm`` in
+        24-hour format (e.g. ``"1530"`` for 3:30 pm).
         """
         if dt is None:
             dt = datetime.now()
-            
-        if not self.connected or not self.socket:
-            self.logger.warning("Not connected to sign")
-            return False
-            
+
         try:
-            # Format time and date
-            # Format: HH:MM:SS\rMM/DD/YY (10 bytes)
-            time_str = dt.strftime("%H:%M:%S")
-            date_str = dt.strftime("%m/%d/%y")
-            time_date = f"{time_str}\r{date_str}"
-
-            # Build Type E (Write Special Function Extended) frame.
-            data = bytes([WriteSpecialExtCommand.SET_TIME_DATE.value]) + time_date.encode('ascii')
+            data = bytes([WriteSpecialExtCommand.SET_TIME_OF_DAY.value]) + dt.strftime("%H%M").encode("ascii")
             frame = self._build_command_frame("E", data)
-
-            self.logger.debug(f"Sent set time/date command: {time_date}")
             ack = self._send_command_and_read_ack(frame)
-
             if ack == self.ACK:
-                self.logger.info(f"Time and date set successfully: {time_date}")
+                self.logger.info("Time of day set: %s", dt.strftime("%H:%M"))
                 return True
-            elif ack == self.NAK:
-                self.logger.error("Sign returned NAK for set time/date")
-                return False
-            else:
-                self.logger.error("No acknowledgement received for set time/date")
-                return False
-
-        except Exception as e:
-            self.logger.error(f"Error setting time and date: {e}")
+            self.logger.error("Set time of day not acknowledged (ack=%r)", ack)
             return False
+        except Exception as e:
+            self.logger.error(f"Error setting time of day: {e}")
+            return False
+
+    def set_date(self, dt: Optional[datetime] = None) -> bool:
+        """Set the sign's date (Write Special Function ``E;``, 0x3B).
+
+        Per the manual (p.26) the data is six ASCII digits ``mmddyy``.
+        """
+        if dt is None:
+            dt = datetime.now()
+
+        try:
+            data = bytes([WriteSpecialExtCommand.SET_DATE.value]) + dt.strftime("%m%d%y").encode("ascii")
+            frame = self._build_command_frame("E", data)
+            ack = self._send_command_and_read_ack(frame)
+            if ack == self.ACK:
+                self.logger.info("Date set: %s", dt.strftime("%m/%d/%y"))
+                return True
+            self.logger.error("Set date not acknowledged (ack=%r)", ack)
+            return False
+        except Exception as e:
+            self.logger.error(f"Error setting date: {e}")
+            return False
+
+    def set_time_and_date(self, dt: Optional[datetime] = None) -> bool:
+        """Set both the sign's time-of-day clock and its date.
+
+        The Alpha protocol uses two *separate* Write Special Function commands
+        — Set Time of Day (``E␠``, 4 digits ``HhMm``) and Set Date (``E;``, 6
+        digits ``mmddyy``).  (The previous implementation sent a single
+        ``HH:MM:SS\\rMM/DD/YY`` string, which is not a valid data format.)
+        """
+        if dt is None:
+            dt = datetime.now()
+
+        ok_time = self.set_time_of_day(dt)
+        ok_date = self.set_date(dt)
+        return ok_time and ok_date
 
     def set_day_of_week(self, day: Optional[int] = None) -> bool:
-        """
-        Set sign day of week (M-Protocol Type E, Function 0x22).
-        
+        """Set the sign's day of week (Write Special Function ``E&``, 0x26).
+
         Args:
-            day: Day of week (0=Sunday, 1=Monday, ..., 6=Saturday)
-                 If None, uses current system day
-                 
-        Returns:
-            True if successful, False otherwise
+            day: 0=Sunday, 1=Monday, …, 6=Saturday. If None, uses today.
+
+        Per the manual (p.22) the data is one ASCII digit ``"1"``=Sunday …
+        ``"7"``=Saturday.  (The previous implementation used the wrong command
+        code 0x22 and sent ``"0"``-``"6"`` instead of ``"1"``-``"7"``.)
         """
         if day is None:
-            day = datetime.now().weekday()
-            # Convert Python weekday (0=Monday) to Alpha weekday (0=Sunday)
-            day = (day + 1) % 7
-            
+            # Python weekday(): 0=Monday … 6=Sunday → 0=Sunday … 6=Saturday.
+            day = (datetime.now().weekday() + 1) % 7
+
         if not 0 <= day <= 6:
             self.logger.error(f"Invalid day of week: {day} (must be 0-6)")
             return False
-            
+
         if not self.connected or not self.socket:
             self.logger.warning("Not connected to sign")
             return False
-            
+
         try:
-            data = bytes([WriteSpecialExtCommand.SET_DAY_OF_WEEK.value, ord('0') + day])
+            # Sign encoding is "1"=Sunday … "7"=Saturday, so add 1 to our index.
+            data = bytes([WriteSpecialExtCommand.SET_DAY_OF_WEEK.value, ord('1') + day])
             frame = self._build_command_frame("E", data)
 
             days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
@@ -2039,8 +2110,9 @@ class Alpha9120CController:
             return False
             
         try:
-            # 'S' for 24h, 'M' for 12h (per M-Protocol spec)
-            mode_byte = b'S' if format_24h else b'M'
+            # Manual p.22: "S" = Standard am/pm, "M" = 24-hour (military).
+            # (The previous code had this inverted — it sent "S" for 24-hour.)
+            mode_byte = b'M' if format_24h else b'S'
             data = bytes([WriteSpecialExtCommand.SET_TIME_FORMAT.value]) + mode_byte
             frame = self._build_command_frame("E", data)
 
@@ -2064,46 +2136,166 @@ class Alpha9120CController:
             return False
 
     def set_run_mode(self, auto: bool = True) -> bool:
+        """Deprecated — there is no auto/manual "run mode" command in the protocol.
+
+        The Alpha Sign Communications Protocol has no global auto/manual toggle;
+        scheduling is expressed through the Run Sequence (``E.``), Run Time
+        Table (``E)``) and Run Day Table (``E2``) instead.  The previous
+        implementation sent code ``0x2E`` (which is actually *Set Run Sequence*)
+        with the byte ``'A'``/``'M'``, producing a malformed frame.  This now
+        sends nothing and returns ``False`` so it can never put a bad frame on
+        the wire.  Use :meth:`set_run_time_table` / :meth:`set_run_day_table`.
         """
-        Set sign run mode to auto or manual (M-Protocol Type E, Function 0x2E).
-        
-        Args:
-            auto: True for auto mode (scheduled messages), False for manual mode
-            
-        Returns:
-            True if successful, False otherwise
-            
-        Note:
-            Auto mode allows the sign to display scheduled messages.
-            Manual mode keeps the sign displaying the current message.
+        self.logger.warning(
+            "set_run_mode() is not an M-Protocol command and is a no-op; "
+            "use set_run_time_table()/set_run_day_table() for scheduling."
+        )
+        return False
+
+    # ── Housekeeping (Write Special Function) ──────────────────────────────
+
+    def soft_reset(self) -> bool:
+        """Soft-reset the sign (Write Special Function ``E,``, 0x2C).
+
+        Causes the sign to run its power-up diagnostics.  **Non-destructive** —
+        memory is not cleared (manual p.22).
         """
-        if not self.connected or not self.socket:
-            self.logger.warning("Not connected to sign")
-            return False
-            
         try:
-            # 'A' for auto, 'M' for manual
-            mode_byte = b'A' if auto else b'M'
-            data = bytes([WriteSpecialExtCommand.SET_RUN_MODE.value]) + mode_byte
-            frame = self._build_command_frame("E", data)
-
-            mode_str = "auto" if auto else "manual"
-            self.logger.debug(f"Sent set run mode: {mode_str}")
-
+            frame = self._build_command_frame(
+                "E", bytes([WriteSpecialExtCommand.SOFT_RESET.value])
+            )
             ack = self._send_command_and_read_ack(frame)
-
-            if ack == self.ACK:
-                self.logger.info(f"Run mode set successfully: {mode_str}")
-                return True
-            elif ack == self.NAK:
-                self.logger.error("Sign returned NAK for set run mode")
-                return False
-            else:
-                self.logger.error("No acknowledgement received")
-                return False
-
+            ok = ack == self.ACK
+            self.logger.info("Soft reset %s", "acknowledged" if ok else f"not acknowledged (ack={ack!r})")
+            return ok
         except Exception as e:
-            self.logger.error(f"Error setting run mode: {e}")
+            self.logger.error(f"Error sending soft reset: {e}")
+            return False
+
+    def set_serial_address(self, address: str) -> bool:
+        """Set the sign's serial address (Write Special Function ``E7``, 0x37).
+
+        Args:
+            address: two ASCII hex characters, ``"00"``–``"FF"`` (manual p.26).
+
+        .. note::
+           After this succeeds the sign answers to the *new* address; update
+           ``self.sign_id`` / your configuration accordingly.  A hardware DIP
+           switch set to a non-``00`` address overrides this once power is
+           cycled.
+        """
+        addr = str(address).strip().upper()
+        if not re.fullmatch(r"[0-9A-F]{2}", addr):
+            self.logger.error("Invalid serial address %r (need two hex digits 00-FF)", address)
+            return False
+        try:
+            data = bytes([WriteSpecialExtCommand.SET_SERIAL_ADDRESS.value]) + addr.encode("ascii")
+            frame = self._build_command_frame("E", data)
+            ack = self._send_command_and_read_ack(frame)
+            ok = ack == self.ACK
+            if ok:
+                self.logger.info("Serial address set to %s", addr)
+            else:
+                self.logger.error("Set serial address not acknowledged (ack=%r)", ack)
+            return ok
+        except Exception as e:
+            self.logger.error(f"Error setting serial address: {e}")
+            return False
+
+    def set_run_time_table(self, file_label: str, start: int, stop: int) -> bool:
+        """Set a TEXT file's Run Time Table entry (``E)``, 0x29) — format ``FQQQQ``.
+
+        Args:
+            file_label: one-character TEXT file label.
+            start: start-time code (0x00–0xFF; see manual Appendix B).
+            stop:  stop-time code (0x00–0xFF).
+        """
+        label = (str(file_label) or "A")[:1]
+        if not (0 <= int(start) <= 0xFF and 0 <= int(stop) <= 0xFF):
+            self.logger.error("Run-time start/stop must be 0x00-0xFF")
+            return False
+        try:
+            payload = f"E)" + label + f"{int(start):02X}{int(stop):02X}"
+            frame = self._build_frame_from_payload(payload)
+            return self._send_raw_message(frame)
+        except Exception as e:
+            self.logger.error(f"Error setting run time table: {e}")
+            return False
+
+    def set_run_day_table(self, file_label: str, start_day: int, stop_day: int) -> bool:
+        """Set a TEXT file's Run Day Table entry (``E2``, 0x32) — format ``FSs``.
+
+        ``start_day``/``stop_day`` are single hex nibbles (manual p.24):
+        ``0``=Daily, ``1``=Sun … ``7``=Sat, ``8``=Mon-Fri, ``9``=Weekends,
+        ``A``=Always, ``B``=Never.
+        """
+        label = (str(file_label) or "A")[:1]
+        if not (0 <= int(start_day) <= 0xF and 0 <= int(stop_day) <= 0xF):
+            self.logger.error("Run-day start/stop must be a single hex nibble 0-F")
+            return False
+        try:
+            payload = f"E2" + label + f"{int(start_day):X}{int(stop_day):X}"
+            frame = self._build_frame_from_payload(payload)
+            return self._send_raw_message(frame)
+        except Exception as e:
+            self.logger.error(f"Error setting run day table: {e}")
+            return False
+
+    def set_memory_configuration(self, files: Sequence[Dict[str, Any]]) -> bool:
+        """Set the sign's Memory Configuration (``E$``, 0x24) — **destructive**.
+
+        Each entry in ``files`` allocates one file and must provide:
+        ``label`` (1 char), ``type`` (``"A"`` TEXT / ``"B"`` STRING /
+        ``"D"`` DOTS), ``protection`` (``"U"``/``"L"``, default ``"U"``),
+        ``size`` (int bytes, encoded as 4 hex digits), and ``qqqq`` (4-char
+        trailing field: TEXT = start+stop time e.g. ``"FF00"``; STRING =
+        ``"0000"``; DOTS = colour status).  Record format ``FTPSIZEQQQQ``
+        (manual p.21).
+
+        .. warning::
+           Writing a Memory Configuration **overwrites the previous table and
+           erases stored messages.**  Requires at least one file entry; call
+           :meth:`clear_memory` to wipe.
+        """
+        if not files:
+            self.logger.error("set_memory_configuration requires at least one file entry")
+            return False
+        try:
+            records = ""
+            for f in files:
+                label = str(f.get("label", "A"))[:1] or "A"
+                ftype = str(f.get("type", "A"))[:1].upper()
+                if ftype not in ("A", "B", "D"):
+                    self.logger.error("Invalid file type %r (A/B/D)", ftype)
+                    return False
+                prot = str(f.get("protection", "U"))[:1].upper()
+                prot = prot if prot in ("U", "L") else "U"
+                size = int(f.get("size", 0)) & 0xFFFF
+                qqqq = str(f.get("qqqq", "FF00" if ftype == "A" else "0000"))[:4].upper().ljust(4, "0")
+                records += f"{label}{ftype}{prot}{size:04X}{qqqq}"
+            frame = self._build_frame_from_payload("E$" + records)
+            return self._send_raw_message(frame)
+        except Exception as e:
+            self.logger.error(f"Error setting memory configuration: {e}")
+            return False
+
+    def clear_memory(self, confirm: bool = False) -> bool:
+        """Clear the sign's memory (``E$`` with no data) — **destructive**.
+
+        Erases all stored message files and the Memory Configuration table.
+        Guarded: pass ``confirm=True`` to actually send it.
+        """
+        if not confirm:
+            self.logger.warning("clear_memory() not sent — pass confirm=True (this erases the sign)")
+            return False
+        try:
+            frame = self._build_frame_from_payload("E$")
+            ok = self._send_raw_message(frame)
+            if ok:
+                self.logger.info("Clear Memory command sent")
+            return ok
+        except Exception as e:
+            self.logger.error(f"Error clearing memory: {e}")
             return False
 
     def sync_time_with_system(self) -> bool:
@@ -2134,26 +2326,22 @@ class Alpha9120CController:
         return True
 
     def set_speaker(self, enabled: bool = True) -> bool:
-        """
-        Enable or disable sign speaker/beep (M-Protocol Type E, Function 0x23).
-        
+        """Enable or disable the sign's speaker (Write Special Function ``E!``, 0x21).
+
         Args:
             enabled: True to enable speaker, False to disable
-            
-        Returns:
-            True if successful, False otherwise
-            
-        Note:
-            When enabled, sign will beep on message arrival.
-            Useful for audio alerts during emergencies.
+
+        Per the manual (p.21) the data is two ASCII characters: ``"00"`` =
+        enable, ``"FF"`` = disable.  (The previous implementation used the
+        wrong command code 0x23 and the bytes ``'E'``/``'D'``.)
         """
         if not self.connected or not self.socket:
             self.logger.warning("Not connected to sign")
             return False
-            
+
         try:
-            # 'E' for enable, 'D' for disable
-            state_byte = b'E' if enabled else b'D'
+            # "00" = enable speaker, "FF" = disable speaker.
+            state_byte = b'00' if enabled else b'FF'
             data = bytes([WriteSpecialExtCommand.SET_SPEAKER.value]) + state_byte
             frame = self._build_command_frame("E", data)
 

--- a/scripts/screen_manager.py
+++ b/scripts/screen_manager.py
@@ -149,6 +149,13 @@ class ScreenManager:
         self._last_led_update = datetime.min
         self._last_vfd_update = datetime.min
         self._last_oled_update = datetime.min
+        # Most recently rendered LED/VFD content, retained so the displays
+        # service can publish a faithful preview image of what each panel is
+        # currently showing (see services/displays/state.py).  LED keeps the
+        # ScreenRenderer output (lines + colour); VFD keeps the draw-command
+        # list that was sent to the panel.
+        self._last_led_render: Optional[Dict[str, Any]] = None
+        self._last_vfd_commands: Optional[List[Dict[str, Any]]] = None
         self._oled_button = None
         self._oled_button_actions: Deque[str] = deque()
         self._oled_button_lock = threading.Lock()
@@ -709,6 +716,9 @@ class ScreenManager:
             if not rendered:
                 return
 
+            # Retain for the live preview (see services/displays/state.py).
+            self._last_led_render = rendered
+
             # Send to LED display
             if led_module.led_controller:
                 lines = rendered.get('lines', [])
@@ -764,6 +774,9 @@ class ScreenManager:
 
             if not commands:
                 return
+
+            # Retain for the live preview (see services/displays/state.py).
+            self._last_vfd_commands = commands
 
             # Send to VFD display
             if vfd_module.vfd_controller:

--- a/services/displays/preview_render.py
+++ b/services/displays/preview_render.py
@@ -1,0 +1,372 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+from __future__ import annotations
+
+"""Server-side preview image renderers for the VFD and LED Network Sign.
+
+The Live Display Preview page used to draw hardcoded placeholder text for the
+VFD (always green "EAS STATION - VFD") and flat single-colour HTML for the LED
+sign, neither of which resembled the real hardware.  Following the same pattern
+the OLED already uses -- where the controller ships an actual rendered
+framebuffer as a base64 PNG -- these helpers render the *current* display
+content to an image so the preview shows what the hardware is really putting
+out:
+
+* VFD  -- Noritake GU140x32F-7000B: 140x32 graphical VFD with the
+  characteristic blue-green (CIG phosphor) glow on dark glass.  Rendered from
+  the same draw-command list that drives the panel.
+* LED  -- Alpha 9120C: 4 lines x 20 chars, dot-matrix, in the M-Protocol
+  colour the message was sent with.
+
+All functions are best-effort: if Pillow is unavailable or anything goes wrong
+they return ``None`` and the page falls back to a simple idle message, so a
+rendering problem can never take the preview API down.
+"""
+
+import base64
+import io
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - exercised wherever Pillow is installed
+    from PIL import Image, ImageChops, ImageDraw, ImageFilter
+    _PIL_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    Image = ImageChops = ImageDraw = ImageFilter = None  # type: ignore[assignment]
+    _PIL_AVAILABLE = False
+
+
+# ── Compact 5x7 dot-matrix font ───────────────────────────────────────────────
+# Uppercase letters, digits and the punctuation that shows up on EAS displays.
+# Each glyph is 7 rows of 5 bits, modelled on the classic 5x7 LED/VFD cell.
+_FONT_5x7: Dict[str, List[str]] = {
+    ' ': ["00000"] * 7,
+    'A': ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+    'B': ["11110", "10001", "11110", "10001", "10001", "10001", "11110"],
+    'C': ["01110", "10001", "10000", "10000", "10000", "10001", "01110"],
+    'D': ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
+    'E': ["11111", "10000", "11110", "10000", "10000", "10000", "11111"],
+    'F': ["11111", "10000", "11110", "10000", "10000", "10000", "10000"],
+    'G': ["01110", "10001", "10000", "10111", "10001", "10001", "01111"],
+    'H': ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+    'I': ["01110", "00100", "00100", "00100", "00100", "00100", "01110"],
+    'J': ["00111", "00010", "00010", "00010", "00010", "10010", "01100"],
+    'K': ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+    'L': ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+    'M': ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+    'N': ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
+    'O': ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+    'P': ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+    'Q': ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
+    'R': ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+    'S': ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
+    'T': ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+    'U': ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+    'V': ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
+    'W': ["10001", "10001", "10001", "10101", "10101", "11011", "10001"],
+    'X': ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+    'Y': ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
+    'Z': ["11111", "00001", "00010", "00100", "01000", "10000", "11111"],
+    '0': ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+    '1': ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+    '2': ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+    '3': ["11111", "00010", "00100", "00010", "00001", "10001", "01110"],
+    '4': ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+    '5': ["11111", "10000", "11110", "00001", "00001", "10001", "01110"],
+    '6': ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
+    '7': ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+    '8': ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+    '9': ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
+    ':': ["00000", "00100", "00100", "00000", "00100", "00100", "00000"],
+    '/': ["00001", "00001", "00010", "00100", "01000", "10000", "10000"],
+    '-': ["00000", "00000", "00000", "11111", "00000", "00000", "00000"],
+    '.': ["00000", "00000", "00000", "00000", "00000", "01100", "01100"],
+    ',': ["00000", "00000", "00000", "00000", "01100", "00100", "01000"],
+    '!': ["00100", "00100", "00100", "00100", "00100", "00000", "00100"],
+    '?': ["01110", "10001", "00001", "00010", "00100", "00000", "00100"],
+    '%': ["11001", "11010", "00010", "00100", "01000", "01011", "10011"],
+    '*': ["00000", "00100", "10101", "01110", "10101", "00100", "00000"],
+    '#': ["01010", "01010", "11111", "01010", "11111", "01010", "01010"],
+    '+': ["00000", "00100", "00100", "11111", "00100", "00100", "00000"],
+    "'": ["00100", "00100", "01000", "00000", "00000", "00000", "00000"],
+    '"': ["01010", "01010", "01010", "00000", "00000", "00000", "00000"],
+    '(': ["00010", "00100", "01000", "01000", "01000", "00100", "00010"],
+    ')': ["01000", "00100", "00010", "00010", "00010", "00100", "01000"],
+    '\xb0': ["01100", "10010", "10010", "01100", "00000", "00000", "00000"],
+}
+
+# Glyph cell metrics: 5 pixels wide + 1 spacing, 7 tall + 1 spacing.
+_CELL_W = 6
+_CELL_H = 8
+
+# M-Protocol colour name -> RGB for an illuminated LED.  Mirrors the Alpha
+# 9120C ``Color`` enum.  Effects that aren't a single solid colour fall back to
+# amber, the sign's default.
+_LED_COLORS: Dict[str, Tuple[int, int, int]] = {
+    'RED': (255, 40, 40),
+    'GREEN': (50, 255, 80),
+    'AMBER': (255, 176, 0),
+    'DIM_RED': (150, 28, 28),
+    'DIM_GREEN': (36, 150, 56),
+    'BROWN': (150, 96, 28),
+    'ORANGE': (255, 110, 0),
+    'YELLOW': (255, 230, 40),
+    'RAINBOW_1': (255, 176, 0),
+    'RAINBOW_2': (255, 176, 0),
+    'COLOR_MIX': (255, 176, 0),
+    'AUTO_COLOR': (255, 176, 0),
+}
+
+# Noritake CIG blue-green phosphor.
+_VFD_ON = (108, 236, 214)
+_VFD_BG = (2, 16, 14)
+
+_LED_BG = (10, 9, 8)
+_LED_OFF = (26, 22, 16)
+
+
+def _glyph(ch: str) -> List[str]:
+    return _FONT_5x7.get(ch.upper(), _FONT_5x7.get(ch, _FONT_5x7[' ']))
+
+
+def _blit_text(grid: List[List[int]], x: int, y: int, text: str) -> None:
+    """Stamp ``text`` into a 0/1 pixel ``grid`` at top-left pixel (x, y)."""
+    h = len(grid)
+    w = len(grid[0]) if h else 0
+    cx = x
+    for ch in str(text):
+        g = _glyph(ch)
+        for ry in range(7):
+            row = g[ry]
+            py = y + ry
+            if py < 0 or py >= h:
+                continue
+            for rx in range(5):
+                if row[rx] == '1':
+                    px = cx + rx
+                    if 0 <= px < w:
+                        grid[py][px] = 1
+        cx += _CELL_W
+
+
+def _encode_png(img: "Image.Image", colors: int = 64) -> Optional[str]:
+    """Encode a preview image as a base64 PNG data URI.
+
+    The glow/bloom produces smooth gradients that balloon a truecolour PNG
+    (and this gets published to Redis and polled by the browser every second),
+    so the image is quantised to an adaptive palette first.  At 64 colours the
+    glow is visually indistinguishable but the payload shrinks by ~10x.
+    """
+    try:
+        out = img.convert("P", palette=Image.ADAPTIVE, colors=colors)
+        buf = io.BytesIO()
+        out.save(buf, format="PNG", optimize=True)
+        return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode("ascii")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Failed to encode preview PNG: %s", exc)
+        return None
+
+
+def _normalise_led_lines(lines: Optional[Sequence[Any]]) -> List[str]:
+    """Coerce LED render output (strings or per-line dicts) to plain text rows."""
+    out: List[str] = []
+    for line in (lines or [])[:4]:
+        if isinstance(line, dict):
+            out.append(str(line.get('text', '')))
+        elif line is None:
+            out.append('')
+        else:
+            out.append(str(line))
+    while len(out) < 4:
+        out.append('')
+    return out
+
+
+def render_led_preview(
+    lines: Optional[Sequence[Any]],
+    color: str = 'AMBER',
+    cols: int = 20,
+    rows: int = 4,
+    scale: int = 8,
+) -> Optional[str]:
+    """Render the LED Network Sign content as a glowing dot-matrix PNG.
+
+    Returns a ``data:image/png;base64,...`` URI, or ``None`` if Pillow is
+    unavailable or rendering fails.
+    """
+    if not _PIL_AVAILABLE:
+        return None
+    try:
+        on_rgb = _LED_COLORS.get(str(color or 'AMBER').upper(), _LED_COLORS['AMBER'])
+        text_lines = _normalise_led_lines(lines)
+
+        cell_w, cell_h = _CELL_W, _CELL_H
+        gw, gh = cols * cell_w, rows * cell_h
+        grid = [[0] * gw for _ in range(gh)]
+        for i, line in enumerate(text_lines[:rows]):
+            _blit_text(grid, 0, i * cell_h, line[:cols])
+
+        W, H = gw * scale, gh * scale
+        radius = scale * 0.40
+        base = Image.new('RGB', (W, H), _LED_BG)
+        draw = ImageDraw.Draw(base)
+        glow = Image.new('RGB', (W, H), (0, 0, 0))
+        gdraw = ImageDraw.Draw(glow)
+        dim_glow = tuple(int(v * 0.55) for v in on_rgb)
+        for y in range(gh):
+            for x in range(gw):
+                cx = x * scale + scale / 2
+                cy = y * scale + scale / 2
+                if grid[y][x]:
+                    gdraw.ellipse(
+                        [cx - radius * 2, cy - radius * 2, cx + radius * 2, cy + radius * 2],
+                        fill=dim_glow,
+                    )
+                    draw.ellipse([cx - radius, cy - radius, cx + radius, cy + radius], fill=on_rgb)
+                else:
+                    draw.ellipse([cx - radius, cy - radius, cx + radius, cy + radius], fill=_LED_OFF)
+        glow = glow.filter(ImageFilter.GaussianBlur(scale * 0.45))
+        return _encode_png(ImageChops.screen(base, glow))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("LED preview render failed: %s", exc)
+        return None
+
+
+def _vfd_grid_from_commands(commands: Sequence[Dict[str, Any]], width: int, height: int) -> List[List[int]]:
+    """Execute the VFD draw-command list onto a 0/1 pixel grid."""
+    grid = [[0] * width for _ in range(height)]
+
+    def set_px(x: int, y: int) -> None:
+        if 0 <= x < width and 0 <= y < height:
+            grid[y][x] = 1
+
+    def line(x1: int, y1: int, x2: int, y2: int) -> None:
+        # Integer Bresenham so diagonal dividers render correctly.
+        dx = abs(x2 - x1)
+        dy = -abs(y2 - y1)
+        sx = 1 if x1 < x2 else -1
+        sy = 1 if y1 < y2 else -1
+        err = dx + dy
+        x, y = x1, y1
+        while True:
+            set_px(x, y)
+            if x == x2 and y == y2:
+                break
+            e2 = 2 * err
+            if e2 >= dy:
+                err += dy
+                x += sx
+            if e2 <= dx:
+                err += dx
+                y += sy
+
+    for cmd in commands or []:
+        ctype = cmd.get('type')
+        if ctype == 'clear':
+            grid = [[0] * width for _ in range(height)]
+        elif ctype == 'text':
+            _blit_text(grid, int(cmd.get('x', 0)), int(cmd.get('y', 0)), str(cmd.get('text', '')))
+        elif ctype == 'line':
+            line(int(cmd.get('x1', 0)), int(cmd.get('y1', 0)), int(cmd.get('x2', 0)), int(cmd.get('y2', 0)))
+        elif ctype == 'rectangle':
+            x1 = int(cmd.get('x1', 0)); y1 = int(cmd.get('y1', 0))
+            x2 = int(cmd.get('x2', 0)); y2 = int(cmd.get('y2', 0))
+            if cmd.get('filled'):
+                for yy in range(min(y1, y2), max(y1, y2) + 1):
+                    for xx in range(min(x1, x2), max(x1, x2) + 1):
+                        set_px(xx, yy)
+            else:
+                line(x1, y1, x2, y1)
+                line(x1, y2, x2, y2)
+                line(x1, y1, x1, y2)
+                line(x2, y1, x2, y2)
+    return grid
+
+
+def _render_vfd_grid(grid: List[List[int]], width: int, height: int, scale: int = 9) -> Optional[str]:
+    if not _PIL_AVAILABLE:
+        return None
+    try:
+        W, H = width * scale, height * scale
+        base = Image.new('RGB', (W, H), _VFD_BG)
+        draw = ImageDraw.Draw(base)
+        pad = max(0.0, scale * 0.06)
+        for y in range(height):
+            for x in range(width):
+                if grid[y][x]:
+                    x0 = x * scale + pad
+                    y0 = y * scale + pad
+                    draw.rectangle([x0, y0, x0 + scale - 2 * pad, y0 + scale - 2 * pad], fill=_VFD_ON)
+        glow = base.filter(ImageFilter.GaussianBlur(scale * 0.55))
+        glow = Image.eval(glow, lambda v: int(v * 0.8))
+        return _encode_png(ImageChops.screen(base, glow))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("VFD preview render failed: %s", exc)
+        return None
+
+
+def render_vfd_preview(
+    commands: Optional[Sequence[Dict[str, Any]]],
+    width: int = 140,
+    height: int = 32,
+    scale: int = 9,
+) -> Optional[str]:
+    """Render VFD draw-commands to a blue-green VFD PNG (data URI), or None."""
+    if not _PIL_AVAILABLE:
+        return None
+    try:
+        grid = _vfd_grid_from_commands(commands or [], width, height)
+        return _render_vfd_grid(grid, width, height, scale)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("VFD preview render failed: %s", exc)
+        return None
+
+
+def render_vfd_idle(
+    lines: Optional[Sequence[str]] = None,
+    width: int = 140,
+    height: int = 32,
+    scale: int = 9,
+) -> Optional[str]:
+    """Render a simple centred idle screen for the VFD (blue-green)."""
+    if not _PIL_AVAILABLE:
+        return None
+    try:
+        text_lines = list(lines or ["EAS STATION", "READY"])[:2]
+        grid = [[0] * width for _ in range(height)]
+        for i, line in enumerate(text_lines):
+            text = str(line)
+            text_w = len(text) * _CELL_W
+            x = max(0, (width - text_w) // 2)
+            y = 2 + i * (_CELL_H + 4)
+            _blit_text(grid, x, y, text)
+        return _render_vfd_grid(grid, width, height, scale)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("VFD idle render failed: %s", exc)
+        return None
+
+
+__all__ = [
+    "render_led_preview",
+    "render_vfd_preview",
+    "render_vfd_idle",
+]

--- a/services/displays/state.py
+++ b/services/displays/state.py
@@ -114,6 +114,20 @@ def publish_display_state(redis_client, screen_manager) -> None:
             # Only show as enabled if both database setting is true AND controller exists
             if vfd_enabled_in_db and vfd_controller:
                 state["vfd"]["enabled"] = True
+
+                # Render a faithful preview of the blue-green VFD from the
+                # draw-commands last sent to the panel (falling back to an idle
+                # screen when nothing has been displayed yet).
+                try:
+                    from services.displays.preview_render import (
+                        render_vfd_preview, render_vfd_idle,
+                    )
+                    commands = getattr(screen_manager, "_last_vfd_commands", None) if screen_manager else None
+                    preview = render_vfd_preview(commands) if commands else render_vfd_idle()
+                    if preview:
+                        state["vfd"]["preview_image"] = preview
+                except Exception as e:
+                    logger.debug(f"Failed to render VFD preview: {e}")
         except Exception as e:
             logger.debug(f"Error getting VFD state: {e}")
 
@@ -127,6 +141,29 @@ def publish_display_state(redis_client, screen_manager) -> None:
             # Only show as enabled if both database setting is true AND controller exists
             if led_enabled_in_db and led_module.led_controller:
                 state["led"]["enabled"] = True
+
+                # Render a faithful dot-matrix preview from the LED content last
+                # rendered by the rotation engine (lines + M-Protocol colour).
+                try:
+                    from services.displays.preview_render import render_led_preview
+                    led_render = getattr(screen_manager, "_last_led_render", None) if screen_manager else None
+                    if led_render:
+                        lines = led_render.get("lines") or []
+                        color = led_render.get("color", "AMBER")
+                        state["led"]["color"] = color
+                        state["led"]["current_message"] = {
+                            "lines": [
+                                (ln.get("text", "") if isinstance(ln, dict) else str(ln))
+                                for ln in lines
+                            ]
+                        }
+                        preview = render_led_preview(lines, color)
+                    else:
+                        preview = render_led_preview(["", "EAS STATION READY", "", ""], "AMBER")
+                    if preview:
+                        state["led"]["preview_image"] = preview
+                except Exception as e:
+                    logger.debug(f"Failed to render LED preview: {e}")
         except Exception as e:
             logger.debug(f"Error getting LED state: {e}")
 

--- a/templates/displays_preview.html
+++ b/templates/displays_preview.html
@@ -100,11 +100,18 @@
         max-width: 512px;
     }
 
+    /* VFD and LED previews are server-rendered, high-resolution images with
+       baked-in glow/dot-matrix detail, so they look best with smooth scaling
+       rather than the nearest-neighbour pixelation used for the native-res
+       OLED framebuffer. */
     .vfd-canvas {
-        max-width: 420px;
+        max-width: 460px;
+        image-rendering: auto;
     }
 
     .led-canvas {
+        max-width: 512px;
+        image-rendering: auto;
     }
 
     .refresh-indicator {
@@ -132,29 +139,6 @@
     .display-specs strong {
         color: var(--text-color);
     }
-
-    .led-preview {
-        background: transparent;
-        padding: 8px;
-        font-family: 'JetBrains Mono', 'Courier New', monospace;
-        line-height: 1.6;
-        min-height: 100px;
-        width: 100%;
-        overflow-x: auto;
-    }
-
-    .led-line {
-        display: block;
-        font-size: 1.1rem;
-        font-weight: bold;
-        text-shadow: 0 0 10px currentColor;
-    }
-
-    .led-color-amber { color: var(--warning-color); }
-    .led-color-red { color: var(--danger-color); }
-    .led-color-green { color: var(--success-color); }
-    .led-color-yellow { color: var(--warning-color); }
-    .led-color-orange { color: var(--secondary-color); }
 
     .page-header {
         background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
@@ -303,12 +287,7 @@
                 </div>
 
                 <div class="display-canvas-wrapper led-wrapper">
-                    <div id="led-preview" class="led-preview">
-                        <span class="led-line led-color-amber" id="led-line-0">--------------------</span>
-                        <span class="led-line led-color-amber" id="led-line-1">  LED SIGN READY    </span>
-                        <span class="led-line led-color-amber" id="led-line-2">   Awaiting Data    </span>
-                        <span class="led-line led-color-amber" id="led-line-3">--------------------</span>
-                    </div>
+                    <canvas id="led-canvas" class="display-canvas led-canvas" width="120" height="32"></canvas>
                 </div>
 
                 <div class="display-specs">
@@ -351,6 +330,33 @@ const oledCanvas = document.getElementById('oled-canvas');
 const oledCtx = oledCanvas.getContext('2d');
 const vfdCanvas = document.getElementById('vfd-canvas');
 const vfdCtx = vfdCanvas.getContext('2d');
+const ledCanvas = document.getElementById('led-canvas');
+const ledCtx = ledCanvas.getContext('2d');
+
+// Cache the last drawn preview-image data URI per panel so we only redraw
+// (and resize the canvas to the server-rendered image) when it actually
+// changes. Avoids flicker from re-decoding an identical image every poll.
+const lastPreviewImg = { vfd: null, led: null };
+
+// Draw a server-rendered preview image (data URI) into a canvas, sizing the
+// canvas to the image so the baked-in glow/dot-matrix detail is preserved.
+// The image is high-resolution already, so smoothing (not pixelation) gives
+// the cleanest scaled-down result in the responsive layout.
+function drawPreviewImage(canvas, ctx, key, dataUri) {
+    if (lastPreviewImg[key] === dataUri) return;
+    lastPreviewImg[key] = dataUri;
+    const img = new Image();
+    img.onload = function() {
+        if (canvas.width !== img.naturalWidth || canvas.height !== img.naturalHeight) {
+            canvas.width = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+        }
+        ctx.imageSmoothingEnabled = true;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    };
+    img.src = dataUri;
+}
 
 // Scale canvases for better visibility while keeping them responsive
 const oledScale = 4;
@@ -448,40 +454,50 @@ function renderOLED(state) {
     }
 }
 
-// Render VFD display
+// Render VFD display.
+// The displays service renders the real blue-green VFD output to an image
+// (services/displays/preview_render.py) and ships it as a data URI, exactly
+// like the OLED panel. When offline, show a simple cyan idle message.
 function renderVFD(state) {
-    // Clear canvas with VFD background (hardware simulation)
-    vfdCtx.fillStyle = getDisplayColor('--display-vfd-bg', '#001a00');
-    vfdCtx.fillRect(0, 0, 140, 32);
+    if (state && state.preview_image) {
+        drawPreviewImage(vfdCanvas, vfdCtx, 'vfd', state.preview_image);
+        return;
+    }
 
-    // VFD display text (hardware characteristic bright green)
-    vfdCtx.fillStyle = getDisplayColor('--display-vfd-text', '#00ff00');
-    vfdCtx.font = '10px monospace';
+    lastPreviewImg.vfd = null;
+    if (vfdCanvas.width !== 140 || vfdCanvas.height !== 32) {
+        vfdCanvas.width = 140; vfdCanvas.height = 32;
+    }
+    vfdCtx.fillStyle = '#021410';
+    vfdCtx.fillRect(0, 0, vfdCanvas.width, vfdCanvas.height);
+    vfdCtx.fillStyle = '#6cece0';
+    vfdCtx.font = '9px monospace';
     vfdCtx.textAlign = 'center';
-
-    // Show idle state
-    vfdCtx.fillText('EAS STATION - VFD', 70, 16);
+    vfdCtx.fillText('EAS STATION', 70, 14);
     vfdCtx.font = '8px monospace';
     vfdCtx.fillText('No Active Display', 70, 26);
 }
 
-// Render LED sign
+// Render LED Network Sign.
+// The displays service renders the dot-matrix output (in the message's
+// M-Protocol colour) to an image and ships it as a data URI. When offline,
+// show a simple amber idle message.
 function renderLED(state) {
-    const color = (state.color || 'AMBER').toLowerCase();
-    const colorClass = 'led-color-' + color;
-
-    for (let i = 0; i < 4; i++) {
-        const lineEl = document.getElementById(`led-line-${i}`);
-        if (lineEl) {
-            lineEl.className = `led-line ${colorClass}`;
-            // Show placeholder if no message
-            if (!state.current_message || !state.current_message.lines || !state.current_message.lines[i]) {
-                lineEl.textContent = '                    '; // 20 spaces
-            } else {
-                lineEl.textContent = state.current_message.lines[i].padEnd(20, ' ');
-            }
-        }
+    if (state && state.preview_image) {
+        drawPreviewImage(ledCanvas, ledCtx, 'led', state.preview_image);
+        return;
     }
+
+    lastPreviewImg.led = null;
+    if (ledCanvas.width !== 120 || ledCanvas.height !== 32) {
+        ledCanvas.width = 120; ledCanvas.height = 32;
+    }
+    ledCtx.fillStyle = '#0a0908';
+    ledCtx.fillRect(0, 0, ledCanvas.width, ledCanvas.height);
+    ledCtx.fillStyle = '#ffb000';
+    ledCtx.font = '8px monospace';
+    ledCtx.textAlign = 'center';
+    ledCtx.fillText('LED SIGN READY', 60, 18);
 }
 
 // Update display states from server

--- a/tests/test_alpha_mprotocol.py
+++ b/tests/test_alpha_mprotocol.py
@@ -1,0 +1,230 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""Alpha M-Protocol conformance tests for scripts/led_sign_controller.py.
+
+These assert the on-the-wire encoding against the Alpha Sign Communications
+Protocol manual (9708-8061F) — most importantly the checksum, which is verified
+against the worked example on p.60 (``<STX>"AAHELLO"<ETX>`` -> ``01FB``).
+See docs/reference/protocols/ALPHA_M_PROTOCOL.md.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from scripts.led_sign_controller import (
+    Alpha9120CController,
+    Color,
+    DisplayMode,
+    Font,
+    SpecialFunction,
+    Speed,
+)
+
+
+@pytest.fixture
+def ctrl():
+    """A controller whose connect()/init are stubbed (no network I/O), with the
+    two transmit paths patched to capture frames instead of sending them."""
+    with patch.object(Alpha9120CController, "connect", return_value=True), \
+         patch.object(Alpha9120CController, "_send_initialization", return_value=True):
+        c = Alpha9120CController("127.0.0.1", 10001, sign_id="00", type_code="Z")
+    c.connected = True
+    c.socket = object()  # truthy, satisfies the "connected" guards
+    c.sent = []
+    c._send_command_and_read_ack = lambda frame, timeout=2.0: (c.sent.append(frame), c.ACK)[1]
+    c._send_raw_message = lambda msg: (c.sent.append(msg), True)[1]
+    return c
+
+
+# ── frame parsing helpers ─────────────────────────────────────────────────────
+
+def _payload(frame: bytes) -> bytes:
+    """Bytes between <STX> and <ETX> (the command + data)."""
+    stx = frame.index(0x02)
+    etx = frame.rindex(0x03)
+    return frame[stx + 1:etx]
+
+
+def _checksum(frame: bytes) -> str:
+    etx = frame.rindex(0x03)
+    return frame[etx + 1:etx + 5].decode("ascii")
+
+
+def _assert_valid_checksum(frame: bytes):
+    """The 4-digit checksum must equal the 16-bit sum of STX..ETX inclusive."""
+    stx = frame.index(0x02)
+    etx = frame.rindex(0x03)
+    expected = sum(frame[stx:etx + 1]) & 0xFFFF
+    assert _checksum(frame) == f"{expected:04X}"
+    assert frame.endswith(b"\x04")  # EOT
+
+
+# ── checksum (the critical fix) ───────────────────────────────────────────────
+
+def test_checksum_matches_manual_example(ctrl):
+    # Manual p.60: <STX>"AAHELLO"<ETX> -> "01FB"
+    assert ctrl._calculate_checksum(b"\x02AAHELLO\x03") == "01FB"
+
+
+def test_build_frame_uses_4digit_sum_checksum(ctrl):
+    frame = ctrl._build_frame_from_payload("AAHELLO")
+    assert b"\x02AAHELLO\x03" in frame
+    assert _checksum(frame) == "01FB"
+    assert len(_checksum(frame)) == 4
+    _assert_valid_checksum(frame)
+
+
+def test_build_message_frame_is_self_consistent(ctrl):
+    frame = ctrl._build_message(["HELLO"], color=Color.GREEN, font=Font.FONT_7x9,
+                                mode=DisplayMode.HOLD, speed=Speed.SPEED_3)
+    assert frame is not None
+    _assert_valid_checksum(frame)
+
+
+# ── speed: single control byte 0x15-0x19, not 0x15 + digit ────────────────────
+
+def test_speed_is_single_control_byte(ctrl):
+    frame = ctrl._build_message(["HI"], speed=Speed.SPEED_5, color=Color.RED)
+    data = _payload(frame)
+    assert b"\x19" in data            # Speed 5
+    assert b"\x15\x35" not in data    # not the old 0x15 + ASCII '5'
+
+
+def test_speed_three_maps_to_0x17(ctrl):
+    frame = ctrl._build_message(["HI"], speed=Speed.SPEED_3, color=Color.RED)
+    assert b"\x17" in _payload(frame)
+
+
+# ── character attributes: correct control codes ───────────────────────────────
+
+def test_char_flash_uses_0x07(ctrl):
+    frame = ctrl._build_message(["HI"], color=Color.RED,
+                                special_functions=[SpecialFunction.CHAR_FLASH_ON])
+    data = _payload(frame)
+    assert b"\x07\x31" in data        # flash on = 07H + '1'
+    assert b"\x1e\x34" not in data    # not the old 1EH + '4'
+
+
+def test_wide_char_on_uses_0x12(ctrl):
+    frame = ctrl._build_message(["HI"], color=Color.RED,
+                                special_functions=[SpecialFunction.WIDE_CHAR_ON])
+    assert b"\x12" in _payload(frame)
+
+
+# ── colour / font codes match the manual ──────────────────────────────────────
+
+def test_colour_code_amber(ctrl):
+    frame = ctrl._build_message(["HI"], color=Color.AMBER)
+    assert b"\x1c3" in _payload(frame)  # 1CH + '3' = Amber
+
+
+# ── special-function commands ─────────────────────────────────────────────────
+
+def test_set_day_of_week_code_and_data(ctrl):
+    assert ctrl.set_day_of_week(0) is True          # Sunday
+    assert _payload(ctrl.sent[-1]) == b"E&1"         # E + 0x26 + '1'
+    ctrl.set_day_of_week(6)                          # Saturday
+    assert _payload(ctrl.sent[-1]) == b"E&7"
+
+
+def test_set_speaker_code_and_data(ctrl):
+    ctrl.set_speaker(True)
+    assert _payload(ctrl.sent[-1]) == b"E!00"        # enable
+    ctrl.set_speaker(False)
+    assert _payload(ctrl.sent[-1]) == b"E!FF"        # disable
+
+
+def test_set_time_format_not_inverted(ctrl):
+    ctrl.set_time_format(format_24h=True)
+    assert _payload(ctrl.sent[-1]) == b"E'M"         # 24-hour = 'M'
+    ctrl.set_time_format(format_24h=False)
+    assert _payload(ctrl.sent[-1]) == b"E'S"         # am/pm = 'S'
+
+
+def test_set_time_of_day_format(ctrl):
+    ctrl.set_time_of_day(datetime(2026, 6, 5, 15, 30, 0))
+    assert _payload(ctrl.sent[-1]) == b"E\x201530"   # E + 0x20 + 'HhMm'
+
+
+def test_set_date_format(ctrl):
+    ctrl.set_date(datetime(2026, 6, 5, 0, 0, 0))
+    assert _payload(ctrl.sent[-1]) == b"E;060526"    # E + 0x3B + 'mmddyy'
+
+
+def test_set_brightness_does_not_clear_memory(ctrl):
+    assert ctrl.set_brightness(8) is True
+    data = _payload(ctrl.sent[-1])
+    assert b"E$" not in data       # must NOT be the Clear Memory command
+    assert data.startswith(b"E/")  # Set Dimming Register
+
+
+def test_all_frames_have_valid_checksums(ctrl):
+    ctrl.set_speaker(True)
+    ctrl.set_brightness(10)
+    ctrl.set_day_of_week(2)
+    for frame in ctrl.sent:
+        _assert_valid_checksum(frame)
+
+
+# ── housekeeping (new) ────────────────────────────────────────────────────────
+
+def test_soft_reset_frame(ctrl):
+    assert ctrl.soft_reset() is True
+    assert _payload(ctrl.sent[-1]) == b"E,"          # E + 0x2C, no data
+
+
+def test_set_serial_address_valid_and_invalid(ctrl):
+    assert ctrl.set_serial_address("1F") is True
+    assert _payload(ctrl.sent[-1]) == b"E71F"        # E + 0x37 + '1F'
+    before = len(ctrl.sent)
+    assert ctrl.set_serial_address("ZZ") is False     # invalid -> nothing sent
+    assert len(ctrl.sent) == before
+
+
+def test_run_time_table_frame(ctrl):
+    assert ctrl.set_run_time_table("A", 0xFF, 0x00) is True
+    assert _payload(ctrl.sent[-1]) == b"E)AFF00"
+
+
+def test_run_day_table_frame(ctrl):
+    assert ctrl.set_run_day_table("A", 8, 9) is True
+    assert _payload(ctrl.sent[-1]) == b"E2A89"
+
+
+def test_set_memory_configuration_record(ctrl):
+    ok = ctrl.set_memory_configuration([
+        {"label": "A", "type": "A", "protection": "U", "size": 0x0800, "qqqq": "FF00"},
+    ])
+    assert ok is True
+    assert _payload(ctrl.sent[-1]) == b"E$AAU0800FF00"
+
+
+def test_clear_memory_is_guarded(ctrl):
+    assert ctrl.clear_memory() is False              # no confirm -> not sent
+    assert ctrl.sent == []
+    assert ctrl.clear_memory(confirm=True) is True
+    assert _payload(ctrl.sent[-1]) == b"E$"
+
+
+def test_set_run_mode_is_noop(ctrl):
+    assert ctrl.set_run_mode(auto=True) is False      # not a real command
+    assert ctrl.sent == []

--- a/tests/test_display_preview_render.py
+++ b/tests/test_display_preview_render.py
@@ -1,0 +1,127 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""Tests for the server-side VFD/LED preview image renderers.
+
+The module is loaded directly from its file so the test does not pull in the
+``services.displays`` package __init__ (which imports Flask and the rest of the
+displays subsystem).  Rendering requires Pillow; the whole module is skipped
+when it is unavailable.
+"""
+
+import base64
+import importlib.util
+import io
+import os
+
+import pytest
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "services", "displays", "preview_render.py",
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("preview_render_under_test", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pr = _load_module()
+
+pytestmark = pytest.mark.skipif(
+    not getattr(pr, "_PIL_AVAILABLE", False),
+    reason="Pillow not installed; preview rendering unavailable",
+)
+
+
+def _decode_data_uri(uri):
+    assert uri.startswith("data:image/png;base64,"), f"unexpected URI prefix: {uri[:32]}"
+    return base64.b64decode(uri.split(",", 1)[1])
+
+
+def _assert_png(uri, expected_w=None, expected_h=None):
+    from PIL import Image
+    data = _decode_data_uri(uri)
+    img = Image.open(io.BytesIO(data))
+    assert img.format == "PNG"
+    if expected_w is not None:
+        assert img.width == expected_w
+    if expected_h is not None:
+        assert img.height == expected_h
+    return img
+
+
+def test_led_preview_returns_png_data_uri():
+    uri = pr.render_led_preview(["SEVERE WEATHER", "TORNADO WARNING", "TAKE COVER", "NOW"], "RED")
+    _assert_png(uri)
+
+
+def test_led_preview_accepts_dict_lines():
+    # ScreenRenderer can emit per-line dicts ({'text': ..., 'color': ...}).
+    uri = pr.render_led_preview(
+        [{"text": "LINE ONE"}, {"text": "LINE TWO"}, "plain", None],
+        "AMBER",
+    )
+    _assert_png(uri)
+
+
+def test_led_preview_unknown_colour_falls_back():
+    # An effect colour like RAINBOW or garbage must not raise.
+    uri = pr.render_led_preview(["HELLO"], "NOT_A_REAL_COLOR")
+    _assert_png(uri)
+
+
+def test_led_preview_handles_empty_input():
+    uri = pr.render_led_preview([], "GREEN")
+    _assert_png(uri)
+
+
+def test_vfd_preview_from_commands():
+    commands = [
+        {"type": "clear"},
+        {"type": "text", "x": 4, "y": 2, "text": "EAS STATION"},
+        {"type": "line", "x1": 0, "y1": 15, "x2": 139, "y2": 15},
+        {"type": "rectangle", "x1": 2, "y1": 18, "x2": 60, "y2": 28, "filled": False},
+        {"type": "text", "x": 4, "y": 20, "text": "12:34"},
+    ]
+    img = _assert_png(pr.render_vfd_preview(commands))
+    # VFD is 140x32 native rendered at scale 9.
+    assert img.width == 140 * 9
+    assert img.height == 32 * 9
+
+
+def test_vfd_preview_clear_resets_grid():
+    # A clear after drawing must blank the panel.
+    drawn = pr.render_vfd_preview([{"type": "text", "x": 0, "y": 0, "text": "X"}])
+    cleared = pr.render_vfd_preview(
+        [{"type": "text", "x": 0, "y": 0, "text": "X"}, {"type": "clear"}]
+    )
+    assert _decode_data_uri(drawn) != _decode_data_uri(cleared)
+
+
+def test_vfd_idle_returns_png():
+    _assert_png(pr.render_vfd_idle(), expected_w=140 * 9, expected_h=32 * 9)
+
+
+def test_vfd_empty_commands_returns_blank_png():
+    # No commands -> blank panel image, not an exception or None.
+    _assert_png(pr.render_vfd_preview([]))


### PR DESCRIPTION
## Summary

This PR corrects critical non-conformance issues in the Alpha 9120C LED sign controller's M-Protocol implementation. The sign was rejecting all checksummed frames due to incorrect checksum calculation, and character attributes (flash, wide, descenders) were being sent with wrong control codes, rendering those features non-functional. Speed control was also broken, always selecting Speed 1 and printing stray digits.

## Key Changes

### Protocol Conformance Fixes

- **Checksum calculation** (`_calculate_checksum`): Changed from XOR of 2 hex digits to 16-bit summation of 4 hex digits, covering `<STX>` through `<ETX>` inclusive per manual p.11. Verified against the worked example on p.60 (`AAHELLO` → `01FB`).

- **Speed control** (`_build_message`): Changed from emitting `0x15` + ASCII digit (which always selected Speed 1 and printed a stray character) to emitting a single control byte `0x14 + N` (Speed N). Speed 3 now correctly emits `0x17` instead of `0x15 '3'`.

- **Character attributes** (`SpecialFunction` enum and `_build_message`): Corrected control codes to match the manual:
  - Wide characters: `0x12` (on) / `0x11` (off), not `0x1E + '0'/'1'`
  - Flash: `0x07 + '1'` (on) / `0x07 + '0'` (off), not `0x1E + '4'/'5'`
  - True descenders: `0x06 + '1'` (on) / `0x06 + '0'` (off), not `0x1E + '2'/'3'`
  - Fixed/proportional width: `0x1E + '1'` / `0x1E + '0'`, correctly unchanged
  
  This fixes emergency-alert flashing (`send_flashing_message()` and `emergency_override()`) which relied on the broken `CHAR_FLASH_ON`.

### API & Behavior Improvements

- **`set_brightness()` → `set_dimming()`**: Replaced incorrect `E$` (Clear Memory) command with correct `E/` (Set Dimming Register) per manual p.23. The old implementation risked corrupting the sign's memory configuration and never actually set brightness. New implementation maps 0–100% or 1–16 range to the five documented dimming steps and supports ambient-light threshold control.

- **`set_time_and_date()` → `set_time_of_day()`**: Split into two methods matching the protocol:
  - `set_time_of_day()`: Sets 24-hour clock via `E␠` (0x20) with 4-digit `HhMm` format
  - `set_date()`: New method sets date via `E;` (0x3B) with `mmddyy` format
  
  The old method sent a malformed 10-byte string that the sign rejected.

- **`WriteSpecialExtCommand` enum**: Corrected all command codes against manual Table 15 (p.21–26). Added backwards-compatibility alias `SET_TIME_DATE = 0x20` for legacy callers.

- **New `soft_reset()` method**: Implements the `E,` (0x2C) soft reset command.

### Testing & Documentation

- **New test suite** (`tests/test_alpha_mprotocol.py`): Comprehensive conformance tests verifying checksum calculation against the manual's worked example, speed encoding, character attribute codes, and all special-function commands.

- **Protocol audit document** (`docs/reference/protocols/ALPHA_M_PROTOCOL.md`): Detailed reference mapping the manual's requirements to implementation status, with historical notes on what was broken and why.

### Display Preview Rendering

- **New preview renderer** (`services/displays/preview_render.py`): Server-side image rendering for the Live Display Preview page, replacing hardcoded placeholders:
  - LED sign: 4×20

https://claude.ai/code/session_01EdwAJrpbS6CNknurTiZR2j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Alpha M-Protocol reference documentation with implementation audit, conformance notes, and known deferred features.

* **New Features**
  * Display previews now render realistic server-side graphics for LED dot-matrix and VFD displays with glow effects.
  * Enhanced LED sign control with improved time/date settings, brightness dimming, speaker management, and memory configuration.

* **Bug Fixes**
  * Corrected protocol-critical issues: 16-bit checksum calculation, speed command encoding, and special function sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->