### PR TITLE
Strip AWIPS product identifier from TTS narration

### DIFF
--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1621,37 +1621,36 @@ def _strip_awips_identifier(description: str, parameters: Dict[str, object]) -> 
     The identifier is an internal routing code, not narratable content, so it
     should not be spoken in the TTS voiceover.  This removes it when present.
 
-    Two detection strategies are used, in order:
-
-    1. The exact value from the CAP ``AWIPSidentifier`` parameter (most
-       reliable) when the description begins with it.
-    2. A conservative generic fallback: a first line consisting solely of
-       4-6 uppercase letters followed by a blank line — the AWIPS identifier
-       shape — when no parameter value is available or it did not match.
+    Stripping is driven solely by the exact value from the CAP
+    ``AWIPSidentifier`` parameter, and only when the description actually
+    begins with it on its own line.  Many alerts have no AWIPS identifier (and
+    some legitimately begin with a short all-caps line), so no shape-based
+    heuristic is applied — that would risk deleting real content from messages
+    that never carried an identifier.  When the parameter is absent or does not
+    match the start of the description, the text is returned unchanged.
     """
     if not description:
         return description
 
-    import re as _re
+    if not isinstance(parameters, dict):
+        return description
 
-    awips_val = parameters.get('AWIPSidentifier') if isinstance(parameters, dict) else None
+    awips_val = parameters.get('AWIPSidentifier')
     if isinstance(awips_val, list):
         awips_val = awips_val[0] if awips_val else None
+    if not awips_val:
+        return description
 
-    # Strategy 1: strip the exact identifier from the parameter when the
-    # description starts with it on its own line.
-    if awips_val:
-        awips = str(awips_val).strip()
-        if awips:
-            pattern = r'^\s*' + _re.escape(awips) + r'[ \t]*\r?\n'
-            stripped = _re.sub(pattern, '', description, count=1, flags=_re.IGNORECASE)
-            if stripped != description:
-                return stripped.lstrip('\r\n')
+    awips = str(awips_val).strip()
+    if not awips:
+        return description
 
-    # Strategy 2: generic AWIPS-shaped first line (4-6 uppercase letters)
-    # followed by a blank line.  The blank line requirement keeps this from
-    # matching legitimate short all-caps words at the start of a sentence.
-    stripped = _re.sub(r'^[ \t]*[A-Z]{4,6}[ \t]*\r?\n\r?\n', '', description, count=1)
+    import re as _re
+
+    # Strip the identifier only when the description opens with it on its own
+    # line (optional trailing spaces, then a newline).
+    pattern = r'^\s*' + _re.escape(awips) + r'[ \t]*\r?\n'
+    stripped = _re.sub(pattern, '', description, count=1, flags=_re.IGNORECASE)
     if stripped != description:
         return stripped.lstrip('\r\n')
 

--- a/app_utils/eas.py
+++ b/app_utils/eas.py
@@ -1605,6 +1605,59 @@ def _normalize_text_for_tts(text: str) -> str:
     return result
 
 
+def _strip_awips_identifier(description: str, parameters: Dict[str, object]) -> str:
+    """Strip the leading AWIPS product identifier from an NWS description.
+
+    NWS warning products begin the CAP ``<description>`` with the internal
+    AWIPS product identifier on its own line (e.g. ``"SVRCLE"`` for a Severe
+    Thunderstorm Warning from the Cleveland office), followed by a blank line
+    and the human-readable text::
+
+        SVRCLE
+
+        The National Weather Service in Cleveland has issued a
+        ...
+
+    The identifier is an internal routing code, not narratable content, so it
+    should not be spoken in the TTS voiceover.  This removes it when present.
+
+    Two detection strategies are used, in order:
+
+    1. The exact value from the CAP ``AWIPSidentifier`` parameter (most
+       reliable) when the description begins with it.
+    2. A conservative generic fallback: a first line consisting solely of
+       4-6 uppercase letters followed by a blank line — the AWIPS identifier
+       shape — when no parameter value is available or it did not match.
+    """
+    if not description:
+        return description
+
+    import re as _re
+
+    awips_val = parameters.get('AWIPSidentifier') if isinstance(parameters, dict) else None
+    if isinstance(awips_val, list):
+        awips_val = awips_val[0] if awips_val else None
+
+    # Strategy 1: strip the exact identifier from the parameter when the
+    # description starts with it on its own line.
+    if awips_val:
+        awips = str(awips_val).strip()
+        if awips:
+            pattern = r'^\s*' + _re.escape(awips) + r'[ \t]*\r?\n'
+            stripped = _re.sub(pattern, '', description, count=1, flags=_re.IGNORECASE)
+            if stripped != description:
+                return stripped.lstrip('\r\n')
+
+    # Strategy 2: generic AWIPS-shaped first line (4-6 uppercase letters)
+    # followed by a blank line.  The blank line requirement keeps this from
+    # matching legitimate short all-caps words at the start of a sentence.
+    stripped = _re.sub(r'^[ \t]*[A-Z]{4,6}[ \t]*\r?\n\r?\n', '', description, count=1)
+    if stripped != description:
+        return stripped.lstrip('\r\n')
+
+    return description
+
+
 def _compose_message_text(alert: object, payload: Optional[Dict[str, object]] = None) -> str:
     """Build the TTS narration text from the alert body.
 
@@ -1709,6 +1762,11 @@ def _compose_message_text(alert: object, payload: Optional[Dict[str, object]] = 
 
         description = str(getattr(alert, 'description', '') or '').strip()
         instruction = str(getattr(alert, 'instruction', '') or '').strip()
+
+        # Strip the leading AWIPS product identifier (e.g. "SVRCLE") that NWS
+        # places on the first line of warning descriptions — it is an internal
+        # routing code, not narratable content.
+        description = _strip_awips_identifier(description, parameters)
 
         if description:
             body_parts.append(description)

--- a/tests/test_ecig_compliance.py
+++ b/tests/test_ecig_compliance.py
@@ -364,12 +364,22 @@ class TestAwipsIdentifierStripped(unittest.TestCase):
         self.assertFalse(out.startswith('SVRCLE'))
         self.assertTrue(out.startswith('The National Weather Service'))
 
-    def test_strip_helper_generic_fallback(self):
-        # No parameter supplied — the generic AWIPS-shaped first line is removed.
+    def test_no_parameter_leaves_text_untouched(self):
+        # Without the AWIPSidentifier parameter we must NOT guess: even an
+        # AWIPS-shaped first line is preserved, because many messages have no
+        # identifier and stripping would delete real content.
         desc = 'SVRCLE\n\nThe National Weather Service in Cleveland has issued a'
         out = self.eas_mod._strip_awips_identifier(desc, {})
-        self.assertFalse(out.startswith('SVRCLE'))
-        self.assertTrue(out.startswith('The National Weather Service'))
+        self.assertEqual(out, desc)
+
+    def test_parameter_present_but_no_match_left_untouched(self):
+        # Parameter exists but the description does not begin with it — leave
+        # the body intact rather than stripping the wrong line.
+        desc = 'The National Weather Service in Cleveland has issued a warning.'
+        out = self.eas_mod._strip_awips_identifier(
+            desc, {'AWIPSidentifier': ['SVRCLE']}
+        )
+        self.assertEqual(out, desc)
 
     def test_narration_omits_awips_identifier(self):
         text = self._construct(
@@ -381,11 +391,13 @@ class TestAwipsIdentifierStripped(unittest.TestCase):
         self.assertNotIn('svrcle', text.lower())
         self.assertIn('national weather service', text.lower())
 
-    def test_narration_strips_without_parameter(self):
+    def test_narration_keeps_text_without_parameter(self):
+        # No AWIPSidentifier parameter — the body is narrated as-is.  We do not
+        # guess, because not every message carries an identifier.
         text = self._construct(
             'SVRCLE\n\nThe National Weather Service in Cleveland has issued a',
         )
-        self.assertNotIn('svrcle', text.lower())
+        self.assertIn('svrcle', text.lower())
 
     def test_legitimate_text_not_stripped(self):
         # A description that does not start with an AWIPS-shaped line must be

--- a/tests/test_ecig_compliance.py
+++ b/tests/test_ecig_compliance.py
@@ -328,6 +328,82 @@ class TestDefaultOriginator(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# AWIPS identifier stripped from narration body
+# ---------------------------------------------------------------------------
+
+class TestAwipsIdentifierStripped(unittest.TestCase):
+    """NWS warning descriptions begin with the internal AWIPS product
+    identifier (e.g. "SVRCLE") on its own line.  It is a routing code, not
+    narratable content, and must not be spoken in the TTS voiceover."""
+
+    def setUp(self):
+        from app_utils import eas as eas_mod
+        self.eas_mod = eas_mod
+
+    def _construct(self, description, parameters=None):
+        alert = SimpleNamespace(
+            event='Severe Thunderstorm Warning',
+            description=description,
+            instruction='',
+            sent=None,
+            expires=None,
+            source='NOAA',
+        )
+        props = {'senderName': 'NWS Cleveland OH'}
+        if parameters is not None:
+            props['parameters'] = parameters
+        payload = {'raw_json': {'properties': props}, 'source': 'NOAA'}
+        with patch.object(self.eas_mod, '_load_pronunciation_rules', return_value=[]):
+            return self.eas_mod._compose_message_text(alert, payload)
+
+    def test_strip_helper_uses_parameter(self):
+        desc = 'SVRCLE\n\nThe National Weather Service in Cleveland has issued a'
+        out = self.eas_mod._strip_awips_identifier(
+            desc, {'AWIPSidentifier': ['SVRCLE']}
+        )
+        self.assertFalse(out.startswith('SVRCLE'))
+        self.assertTrue(out.startswith('The National Weather Service'))
+
+    def test_strip_helper_generic_fallback(self):
+        # No parameter supplied — the generic AWIPS-shaped first line is removed.
+        desc = 'SVRCLE\n\nThe National Weather Service in Cleveland has issued a'
+        out = self.eas_mod._strip_awips_identifier(desc, {})
+        self.assertFalse(out.startswith('SVRCLE'))
+        self.assertTrue(out.startswith('The National Weather Service'))
+
+    def test_narration_omits_awips_identifier(self):
+        text = self._construct(
+            'SVRCLE\n\nThe National Weather Service in Cleveland has issued a\n\n'
+            '* Severe Thunderstorm Warning for...',
+            parameters={'AWIPSidentifier': ['SVRCLE']},
+        )
+        # Lowercased by the normalizer; the identifier must not appear.
+        self.assertNotIn('svrcle', text.lower())
+        self.assertIn('national weather service', text.lower())
+
+    def test_narration_strips_without_parameter(self):
+        text = self._construct(
+            'SVRCLE\n\nThe National Weather Service in Cleveland has issued a',
+        )
+        self.assertNotIn('svrcle', text.lower())
+
+    def test_legitimate_text_not_stripped(self):
+        # A description that does not start with an AWIPS-shaped line must be
+        # left intact (no blank-line-delimited 4-6 letter code at the top).
+        out = self.eas_mod._strip_awips_identifier(
+            'The National Weather Service has issued a warning.', {}
+        )
+        self.assertTrue(out.startswith('The National Weather Service'))
+
+    def test_short_caps_word_without_blank_line_preserved(self):
+        # "TAKE cover now" — a single newline (not a blank line) after a caps
+        # word is normal prose, not an AWIPS header, so it is preserved.
+        desc = 'TAKE\ncover now and stay away from windows.'
+        out = self.eas_mod._strip_awips_identifier(desc, {})
+        self.assertEqual(out, desc)
+
+
+# ---------------------------------------------------------------------------
 # §3.8 — msgType filtering (Cancel/Ack/Error not aired; Alert/Update aired)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
NWS warning descriptions begin with the internal AWIPS product
identifier (e.g. "SVRCLE") on its own line, followed by a blank line
and the human-readable text. This is a routing code, not narratable
content, so it should not be spoken in the voiceover.

_compose_message_text now runs the description through a new
_strip_awips_identifier helper, which removes the identifier using the
CAP AWIPSidentifier parameter when available, falling back to a
conservative generic match (a 4-6 uppercase-letter first line followed
by a blank line).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where internal routing codes were being included in weather alert voice narration, improving audio clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->