### PR TITLE
Add rich HTML alert emails with inline coverage map and audio link

### DIFF
--- a/app_core/_models_settings.py
+++ b/app_core/_models_settings.py
@@ -807,6 +807,22 @@ class NotificationSettings(db.Model):
     email_attach_audio = db.Column(db.Boolean, nullable=False, default=False)
     # Attach composite EAS audio file to alert notification emails
 
+    email_html = db.Column(db.Boolean, nullable=False, default=True)
+    # Send a styled HTML body (multipart/alternative) in addition to plain text
+
+    email_include_map = db.Column(db.Boolean, nullable=False, default=True)
+    # Render and embed a coverage-map image of the affected area in HTML emails
+
+    email_audio_link = db.Column(db.Boolean, nullable=False, default=True)
+    # Include a "listen / download" link to the broadcast audio (needs public_base_url)
+
+    email_compress_audio = db.Column(db.Boolean, nullable=False, default=False)
+    # Transcode the attached composite audio from WAV to MP3 to shrink the attachment
+
+    public_base_url = db.Column(db.String(255), nullable=False, default='')
+    # Externally reachable base URL of this station (e.g. https://eas.example.com),
+    # used to build links in notifications. Empty disables link generation.
+
     # ========================================================================
     # SMS Notifications
     # ========================================================================
@@ -857,6 +873,11 @@ class NotificationSettings(db.Model):
             "compliance_alert_emails": self.compliance_alert_emails or [],
             "alert_emails": self.alert_emails or [],
             "email_attach_audio": self.email_attach_audio,
+            "email_html": self.email_html,
+            "email_include_map": self.email_include_map,
+            "email_audio_link": self.email_audio_link,
+            "email_compress_audio": self.email_compress_audio,
+            "public_base_url": self.public_base_url or "",
             "sms_enabled": self.sms_enabled,
             "sms_provider": self.sms_provider or "twilio",
             "sms_account_sid": self.sms_account_sid or "",

--- a/app_core/migrations/versions/20260608_add_email_rendering_media_to_notification_settings.py
+++ b/app_core/migrations/versions/20260608_add_email_rendering_media_to_notification_settings.py
@@ -1,0 +1,66 @@
+"""Add rich-email rendering / media columns to notification_settings.
+
+Adds operator controls for the upgraded EAS alert emails:
+
+  - email_html            BOOLEAN NOT NULL DEFAULT TRUE
+        Send a multipart/alternative message with a styled HTML body
+        (the existing plain-text body is retained as a fallback).
+  - email_include_map     BOOLEAN NOT NULL DEFAULT TRUE
+        Render a static coverage-map image of the affected area and
+        embed it inline in the HTML body.
+  - email_audio_link      BOOLEAN NOT NULL DEFAULT TRUE
+        Include a "listen / download" link to the broadcast audio in
+        the email body (requires public_base_url).
+  - email_compress_audio  BOOLEAN NOT NULL DEFAULT FALSE
+        Transcode the attached composite audio from WAV to MP3 to
+        shrink the attachment (falls back to WAV if encoding is
+        unavailable).
+  - public_base_url       VARCHAR(255) NOT NULL DEFAULT ''
+        Externally reachable base URL of this station (e.g.
+        https://eas.example.com) used to build links in notifications.
+
+Revision ID: 20260608_add_email_rendering_media
+Revises: 20260605_add_endec_feeds_to_eas_settings
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260608_add_email_rendering_media"
+down_revision = "20260605_add_endec_feeds_to_eas_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE notification_settings"
+        " ADD COLUMN IF NOT EXISTS email_html BOOLEAN NOT NULL DEFAULT TRUE"
+    )
+    op.execute(
+        "ALTER TABLE notification_settings"
+        " ADD COLUMN IF NOT EXISTS email_include_map BOOLEAN NOT NULL DEFAULT TRUE"
+    )
+    op.execute(
+        "ALTER TABLE notification_settings"
+        " ADD COLUMN IF NOT EXISTS email_audio_link BOOLEAN NOT NULL DEFAULT TRUE"
+    )
+    op.execute(
+        "ALTER TABLE notification_settings"
+        " ADD COLUMN IF NOT EXISTS email_compress_audio BOOLEAN NOT NULL DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE notification_settings"
+        " ADD COLUMN IF NOT EXISTS public_base_url VARCHAR(255) NOT NULL DEFAULT ''"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification_settings", "public_base_url")
+    op.drop_column("notification_settings", "email_compress_audio")
+    op.drop_column("notification_settings", "email_audio_link")
+    op.drop_column("notification_settings", "email_include_map")
+    op.drop_column("notification_settings", "email_html")

--- a/app_core/notifications/__init__.py
+++ b/app_core/notifications/__init__.py
@@ -62,21 +62,49 @@ def send_alert_notifications(
             return
 
         # ------------------------------------------------------------------
-        # Fetch composite audio if needed for email attachment
+        # Gather email media: composite audio, the linked CAP alert id (for
+        # the inline coverage map), and a public "listen" link.
         # ------------------------------------------------------------------
         audio_data: Optional[bytes] = None
         audio_filename: Optional[str] = None
+        cap_alert_id: Optional[int] = None
 
-        if record_id and settings.email_enabled and settings.email_attach_audio:
+        # Backwards/forwards compatible reads of the new settings columns.
+        email_html = bool(getattr(settings, "email_html", True))
+        email_include_map = bool(getattr(settings, "email_include_map", True))
+        email_audio_link = bool(getattr(settings, "email_audio_link", True))
+        email_compress_audio = bool(getattr(settings, "email_compress_audio", False))
+        public_base_url = (getattr(settings, "public_base_url", "") or "").strip()
+
+        if record_id and settings.email_enabled:
             try:
                 eas_msg = db_session.get(EASMessage, record_id)
-                if eas_msg and eas_msg.audio_data:
-                    audio_data = bytes(eas_msg.audio_data)
-                    audio_filename = eas_msg.audio_filename or "eas_alert.wav"
+                if eas_msg:
+                    cap_alert_id = getattr(eas_msg, "cap_alert_id", None)
+                    if settings.email_attach_audio and eas_msg.audio_data:
+                        audio_data = bytes(eas_msg.audio_data)
+                        audio_filename = eas_msg.audio_filename or "eas_alert.wav"
             except Exception as exc:
                 log.warning(
-                    "Could not fetch EASMessage audio for notification attachment: %s", exc
+                    "Could not fetch EASMessage for notification media: %s", exc
                 )
+
+        # Inline coverage-map image (HTML emails only).
+        map_image: Optional[bytes] = None
+        if settings.email_enabled and email_html and email_include_map and cap_alert_id:
+            try:
+                from app_core.notifications.alert_image import build_alert_image
+
+                map_image = build_alert_image(db_session, cap_alert_id, log)
+            except Exception as exc:
+                log.warning("Could not build alert coverage image: %s", exc)
+
+        # Public "listen / download" link for the broadcast audio.
+        audio_url: Optional[str] = None
+        if email_audio_link and public_base_url and record_id:
+            audio_url = (
+                f"{public_base_url.rstrip('/')}/eas_messages/{record_id}/audio?download=1"
+            )
 
         # ------------------------------------------------------------------
         # Email
@@ -103,6 +131,10 @@ def send_alert_notifications(
                         smtp_security=settings.smtp_security or "starttls",
                         audio_data=audio_data if settings.email_attach_audio else None,
                         audio_filename=audio_filename,
+                        html=email_html,
+                        map_image=map_image,
+                        audio_url=audio_url,
+                        compress_audio=email_compress_audio,
                     )
                 except Exception as exc:
                     log.error("Alert email notification failed: %s", exc)

--- a/app_core/notifications/alert_image.py
+++ b/app_core/notifications/alert_image.py
@@ -1,0 +1,98 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""Build a coverage-map / alert-summary image for notification emails.
+
+Reuses the same share-card renderer that powers the alert detail page's
+"Export image" feature (``app_utils.image_export.generate_alert_image``)
+so notification emails carry the identical, already-tested visual: an
+event-themed header, the coverage map with the affected polygon drawn on
+top, and the headline / affected areas / description pulled from the CAP
+alert.
+
+The renderer self-fetches the PostGIS geometry and reads every text field
+straight off the ``CAPAlert`` row, so no request context or web-only
+enrichment helpers are needed here. Any failure (Pillow unavailable, no
+geometry, offline tile fetch, …) degrades to ``None`` and the email is
+simply sent without the image.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def build_alert_image(
+    db_session,
+    cap_alert_id: Optional[int],
+    log: Optional[logging.Logger] = None,
+) -> Optional[bytes]:
+    """Render a PNG share card for the CAP alert behind a broadcast.
+
+    Args:
+        db_session:   Active SQLAlchemy session used to load the CAPAlert.
+        cap_alert_id: Primary key of the CAPAlert to render. ``None`` skips.
+        log:          Optional logger override.
+
+    Returns:
+        PNG bytes on success, or ``None`` if the image could not be built.
+    """
+    out = log or logger
+    if not cap_alert_id:
+        return None
+
+    try:
+        from app_core.models import CAPAlert
+        from app_utils.image_export import generate_alert_image
+
+        alert = db_session.get(CAPAlert, cap_alert_id)
+        if alert is None:
+            out.debug("build_alert_image: CAPAlert %s not found", cap_alert_id)
+            return None
+
+        # Location settings drive the county label on the card; optional.
+        location_settings = None
+        try:
+            from app_core.location import get_location_settings
+
+            location_settings = get_location_settings()
+        except Exception:
+            location_settings = None
+
+        # coverage_data / ipaws_data are pure enrichment — the renderer
+        # tolerates empty/None and still draws the map + headline + areas
+        # straight from the CAPAlert row.
+        return generate_alert_image(
+            alert,
+            {},
+            None,
+            location_settings,
+            aspect_ratio="landscape",
+            image_format="png",
+        )
+
+    except Exception as exc:  # pragma: no cover - defensive
+        out.warning(
+            "Could not build alert image for CAP alert %s: %s", cap_alert_id, exc
+        )
+        return None
+
+
+__all__ = ["build_alert_image"]

--- a/app_core/notifications/email.py
+++ b/app_core/notifications/email.py
@@ -19,15 +19,93 @@ Repository: https://github.com/KR8MER/eas-station
 
 """Email notification sender for EAS alerts."""
 
+import io
 import logging
+import os
 import smtplib
 from email.message import EmailMessage
+from email.utils import make_msgid
 from typing import Any, Dict, List, Optional, Tuple
 
 from app_utils.event_codes import EVENT_CODE_REGISTRY
 from app_utils.fips_codes import get_extended_same_lookup
 
 logger = logging.getLogger(__name__)
+
+# Standalone Jinja2 environment for rendering email bodies. Alert emails are
+# sent from the broadcast worker (no Flask request context), so we load the
+# templates directly from the project ``templates/email`` directory rather
+# than going through Flask's ``render_template``.
+_TEMPLATE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "templates",
+    "email",
+)
+_jinja_env = None
+
+
+def _get_template(name: str):
+    """Return a compiled Jinja2 template from ``templates/email`` (cached env)."""
+    global _jinja_env
+    if _jinja_env is None:
+        from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+        _jinja_env = Environment(
+            loader=FileSystemLoader(_TEMPLATE_DIR),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
+    return _jinja_env.get_template(name)
+
+
+# Header accent colour keyed off the event's product class in the SAME event
+# registry: WRN=Warning, WCH=Watch, ADV=Advisory/Statement, TEST=Test.
+# Falls back to a neutral blue for unrecognised codes.
+_PRODUCT_ACCENTS = {
+    "WRN": ("#c0392b", "Warning"),
+    "WCH": ("#e67e22", "Watch"),
+    "ADV": ("#2c6fb0", "Advisory"),
+    "TEST": ("#5d6d7e", "Test"),
+}
+_DEFAULT_ACCENT = ("#2c6fb0", "")
+
+
+def _event_accent(event_code: str) -> Tuple[str, str]:
+    """Return ``(accent_hex, severity_label)`` for a SAME event code.
+
+    Uses the ``default_product`` class from EVENT_CODE_REGISTRY (WRN/WCH/
+    ADV/TEST) rather than guessing from the code letters, since SAME codes
+    are 3-letter mnemonics (e.g. TOR, SVR) with no severity suffix.
+    """
+    code = (event_code or "").strip().upper()
+    entry = EVENT_CODE_REGISTRY.get(code)
+    product = str(entry.get("default_product", "")).upper() if entry else ""
+    return _PRODUCT_ACCENTS.get(product, _DEFAULT_ACCENT)
+
+
+def _maybe_compress_audio(
+    audio_data: bytes, filename: str
+) -> Tuple[bytes, str, str, str]:
+    """Best-effort transcode of WAV bytes to MP3 to shrink the attachment.
+
+    Returns ``(data, maintype, subtype, filename)``. Falls back to the
+    original WAV if pydub/ffmpeg are unavailable or the encode fails.
+    """
+    try:
+        from pydub import AudioSegment
+
+        seg = AudioSegment.from_file(io.BytesIO(audio_data), format="wav")
+        buf = io.BytesIO()
+        seg.export(buf, format="mp3", bitrate="64k")
+        mp3 = buf.getvalue()
+        if mp3:
+            mp3_name = os.path.splitext(filename)[0] + ".mp3"
+            logger.debug(
+                "Compressed alert audio %d -> %d bytes (mp3)", len(audio_data), len(mp3)
+            )
+            return mp3, "audio", "mpeg", mp3_name
+    except Exception as exc:
+        logger.warning("Audio compression unavailable, attaching WAV: %s", exc)
+    return audio_data, "audio", "wav", filename
 
 
 def build_smtp_connection(host: str, port: int, security: str):
@@ -61,6 +139,10 @@ def send_eas_alert_email(
     smtp_security: str = "starttls",
     audio_data: Optional[bytes] = None,
     audio_filename: Optional[str] = None,
+    html: bool = False,
+    map_image: Optional[bytes] = None,
+    audio_url: Optional[str] = None,
+    compress_audio: bool = False,
 ) -> bool:
     """Send an EAS alert notification email.
 
@@ -75,6 +157,14 @@ def send_eas_alert_email(
         smtp_security: "none", "starttls", or "ssl".
         audio_data:    Optional WAV bytes to attach to the email.
         audio_filename: Filename for the audio attachment.
+        html:          When True, add a styled HTML body (multipart/alternative)
+                       alongside the plain-text fallback.
+        map_image:     Optional PNG bytes embedded inline in the HTML body
+                       (ignored unless ``html`` is True).
+        audio_url:     Optional URL for a "listen / download" link in the HTML
+                       body (ignored unless ``html`` is True).
+        compress_audio: When True, transcode the WAV attachment to MP3 to
+                       shrink it (falls back to WAV if encoding is unavailable).
 
     Returns:
         True on success, False on failure.
@@ -129,18 +219,60 @@ def send_eas_alert_email(
 
     msg.set_content("\n".join(body_lines))
 
+    # ------------------------------------------------------------------
+    # HTML alternative (with optional inline coverage-map image)
+    # ------------------------------------------------------------------
+    if html:
+        accent_color, severity_label = _event_accent(event_code)
+        map_cid = None
+        map_cid_header = None
+        if map_image:
+            map_cid_header = make_msgid()
+            map_cid = map_cid_header[1:-1]  # bare id for the HTML cid: ref
+        try:
+            html_body = _get_template("eas_alert.html").render(
+                accent_color=accent_color,
+                severity_label=severity_label,
+                event_label=event_label,
+                headline=headline,
+                same_header=same_header,
+                locations=location_labels,
+                timestamp=timestamp,
+                source=source,
+                map_cid=map_cid,
+                audio_url=audio_url,
+            )
+            msg.add_alternative(html_body, subtype="html")
+            if map_image and map_cid_header:
+                # Attach the PNG related to the HTML part so the cid: ref
+                # resolves to an inline image.
+                msg.get_payload()[1].add_related(
+                    map_image,
+                    maintype="image",
+                    subtype="png",
+                    cid=map_cid_header,
+                )
+        except Exception as exc:
+            logger.warning("Failed to render HTML email body, sending text-only: %s", exc)
+
     if audio_data:
         filename = audio_filename or f"eas_alert_{event_code}.wav"
+        data, maintype, subtype, filename = (
+            _maybe_compress_audio(audio_data, filename)
+            if compress_audio
+            else (audio_data, "audio", "wav", filename)
+        )
         msg.add_attachment(
-            audio_data,
-            maintype="audio",
-            subtype="wav",
+            data,
+            maintype=maintype,
+            subtype=subtype,
             filename=filename,
         )
         # Python only sets filename in Content-Disposition; also set name in
         # Content-Type so iOS Mail and similar clients display it correctly.
+        target_type = f"{maintype}/{subtype}"
         for part in msg.iter_attachments():
-            if part.get_content_type() == "audio/wav":
+            if part.get_content_type() == target_type:
                 part.set_param("name", filename, header="Content-Type")
 
     try:

--- a/templates/admin/notifications.html
+++ b/templates/admin/notifications.html
@@ -137,6 +137,76 @@
                         </div>
 
                         <div class="mb-3">
+                            <label for="email_compress_audio" class="form-label">
+                                <i class="fas fa-file-audio"></i> Compress Audio Attachment
+                            </label>
+                            <select class="form-select" id="email_compress_audio" name="email_compress_audio">
+                                <option value="true" {% if settings.email_compress_audio %}selected{% endif %}>Yes &ndash; transcode to MP3 (smaller)</option>
+                                <option value="false" {% if not settings.email_compress_audio %}selected{% endif %}>No &ndash; attach original WAV</option>
+                            </select>
+                            <div class="form-text">
+                                Transcodes the attached audio from WAV to a ~64&nbsp;kbps MP3 (roughly
+                                8&ndash;10&times; smaller). Requires ffmpeg; falls back to WAV automatically
+                                if encoding is unavailable.
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="email_html" class="form-label">
+                                <i class="fas fa-palette"></i> Rich HTML Emails
+                            </label>
+                            <select class="form-select" id="email_html" name="email_html">
+                                <option value="true" {% if settings.email_html %}selected{% endif %}>Yes &ndash; styled HTML body (recommended)</option>
+                                <option value="false" {% if not settings.email_html %}selected{% endif %}>No &ndash; plain text only</option>
+                            </select>
+                            <div class="form-text">
+                                Sends a branded, color-coded HTML body alongside a plain-text fallback.
+                                Required for the inline coverage map and audio link below.
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="email_include_map" class="form-label">
+                                <i class="fas fa-map-marked-alt"></i> Embed Coverage Map
+                            </label>
+                            <select class="form-select" id="email_include_map" name="email_include_map">
+                                <option value="true" {% if settings.email_include_map %}selected{% endif %}>Yes &ndash; embed an alert coverage image</option>
+                                <option value="false" {% if not settings.email_include_map %}selected{% endif %}>No</option>
+                            </select>
+                            <div class="form-text">
+                                Embeds the same coverage-map share card shown on the alert detail page
+                                inline in the HTML email. Ignored when HTML emails are disabled.
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="email_audio_link" class="form-label">
+                                <i class="fas fa-headphones"></i> Audio Listen Link
+                            </label>
+                            <select class="form-select" id="email_audio_link" name="email_audio_link">
+                                <option value="true" {% if settings.email_audio_link %}selected{% endif %}>Yes &ndash; include a "listen / download" button</option>
+                                <option value="false" {% if not settings.email_audio_link %}selected{% endif %}>No</option>
+                            </select>
+                            <div class="form-text">
+                                Adds a button linking to the broadcast audio on this station. Requires the
+                                Public Base URL below to be set.
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="public_base_url" class="form-label">
+                                <i class="fas fa-link"></i> Public Base URL
+                            </label>
+                            <input type="url" class="form-control" id="public_base_url" name="public_base_url"
+                                   value="{{ settings.public_base_url or '' }}"
+                                   placeholder="https://eas.example.com">
+                            <div class="form-text">
+                                Externally reachable URL of this EAS Station, used to build the audio
+                                listen/download link in alert emails. Leave blank to omit links.
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
                             <label for="compliance_alert_emails" class="form-label">
                                 <i class="fas fa-shield-alt"></i> Compliance / Health Alert Recipients
                             </label>

--- a/templates/email/eas_alert.html
+++ b/templates/email/eas_alert.html
@@ -1,0 +1,138 @@
+<!--
+  EAS Station - EAS alert notification email (HTML body).
+
+  Email-client-safe: table layout, inline styles only, no external CSS,
+  no flexbox/grid. Rendered standalone (outside Flask request context)
+  by app_core.notifications.email. The plain-text part remains the
+  fallback for clients that don't render HTML.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ event_label }}</title>
+</head>
+<body style="margin:0; padding:0; background-color:#eceff1; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; color:#1c2833;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#eceff1;">
+    <tr>
+      <td align="center" style="padding:24px 12px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0"
+               style="width:600px; max-width:100%; background-color:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 1px 4px rgba(0,0,0,0.12);">
+
+          <!-- Header band -->
+          <tr>
+            <td style="background-color:{{ accent_color }}; padding:18px 24px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="color:#ffffff; font-size:12px; letter-spacing:1px; text-transform:uppercase; opacity:0.9;">
+                    EAS Station Alert Notification
+                  </td>
+                </tr>
+                <tr>
+                  <td style="color:#ffffff; font-size:22px; font-weight:bold; padding-top:4px;">
+                    {{ event_label }}
+                  </td>
+                </tr>
+                {% if severity_label %}
+                <tr>
+                  <td style="padding-top:8px;">
+                    <span style="display:inline-block; background-color:rgba(255,255,255,0.22); color:#ffffff; font-size:12px; font-weight:bold; padding:3px 10px; border-radius:12px;">
+                      {{ severity_label }}
+                    </span>
+                  </td>
+                </tr>
+                {% endif %}
+              </table>
+            </td>
+          </tr>
+
+          <!-- Headline -->
+          {% if headline %}
+          <tr>
+            <td style="padding:20px 24px 4px 24px;">
+              <div style="font-size:17px; font-weight:600; line-height:1.4; color:#1c2833;">
+                {{ headline }}
+              </div>
+            </td>
+          </tr>
+          {% endif %}
+
+          <!-- Coverage map image (inline, optional) -->
+          {% if map_cid %}
+          <tr>
+            <td style="padding:16px 24px 4px 24px;">
+              <img src="cid:{{ map_cid }}" width="552" alt="Alert coverage map"
+                   style="display:block; width:100%; max-width:552px; height:auto; border:1px solid #d5dbdb; border-radius:6px;">
+            </td>
+          </tr>
+          {% endif %}
+
+          <!-- Details table -->
+          <tr>
+            <td style="padding:16px 24px 4px 24px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-size:14px; line-height:1.5;">
+                {% if locations %}
+                <tr>
+                  <td style="padding:6px 0; color:#5d6d7e; width:120px; vertical-align:top;">Locations</td>
+                  <td style="padding:6px 0; color:#1c2833;">{{ locations | join(', ') }}</td>
+                </tr>
+                {% endif %}
+                {% if timestamp %}
+                <tr>
+                  <td style="padding:6px 0; color:#5d6d7e; vertical-align:top;">Time</td>
+                  <td style="padding:6px 0; color:#1c2833;">{{ timestamp }}</td>
+                </tr>
+                {% endif %}
+                <tr>
+                  <td style="padding:6px 0; color:#5d6d7e; vertical-align:top;">Source</td>
+                  <td style="padding:6px 0; color:#1c2833;">{{ source }}</td>
+                </tr>
+                {% if same_header %}
+                <tr>
+                  <td style="padding:6px 0; color:#5d6d7e; vertical-align:top;">SAME&nbsp;header</td>
+                  <td style="padding:6px 0; color:#1c2833; font-family:'Courier New',monospace; font-size:12px; word-break:break-all;">{{ same_header }}</td>
+                </tr>
+                {% endif %}
+              </table>
+            </td>
+          </tr>
+
+          <!-- Audio listen/download button (optional) -->
+          {% if audio_url %}
+          <tr>
+            <td style="padding:18px 24px 4px 24px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background-color:{{ accent_color }}; border-radius:6px;">
+                    <a href="{{ audio_url }}"
+                       style="display:inline-block; padding:11px 22px; color:#ffffff; font-size:14px; font-weight:bold; text-decoration:none;">
+                      &#9654;&nbsp; Listen to broadcast audio
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <div style="font-size:12px; color:#85929e; padding-top:6px;">
+                Opens the alert's audio on your EAS Station.
+              </div>
+            </td>
+          </tr>
+          {% endif %}
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:22px 24px; border-top:1px solid #eceff1;">
+              <div style="font-size:12px; color:#85929e; line-height:1.5;">
+                This is an automated notification from
+                <strong style="color:#5d6d7e;">EAS Station&trade;</strong> &mdash;
+                Emergency Alert System.
+              </div>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/webapp/admin/notifications.py
+++ b/webapp/admin/notifications.py
@@ -51,6 +51,11 @@ def _get_or_create_settings() -> NotificationSettings:
             compliance_alert_emails=[],
             alert_emails=[],
             email_attach_audio=False,
+            email_html=True,
+            email_include_map=True,
+            email_audio_link=True,
+            email_compress_audio=False,
+            public_base_url='',
             sms_enabled=False,
             sms_provider='twilio',
             sms_account_sid='',
@@ -79,6 +84,11 @@ def _fallback_notification_settings():
         compliance_alert_emails=[],
         alert_emails=[],
         email_attach_audio=False,
+        email_html=True,
+        email_include_map=True,
+        email_audio_link=True,
+        email_compress_audio=False,
+        public_base_url='',
         sms_enabled=False,
         sms_provider='twilio',
         sms_account_sid='',
@@ -133,6 +143,19 @@ def update_notification_settings():
         settings.email_attach_audio = (
             request.form.get('email_attach_audio', 'false').lower() == 'true'
         )
+        settings.email_html = (
+            request.form.get('email_html', 'true').lower() == 'true'
+        )
+        settings.email_include_map = (
+            request.form.get('email_include_map', 'true').lower() == 'true'
+        )
+        settings.email_audio_link = (
+            request.form.get('email_audio_link', 'true').lower() == 'true'
+        )
+        settings.email_compress_audio = (
+            request.form.get('email_compress_audio', 'false').lower() == 'true'
+        )
+        settings.public_base_url = request.form.get('public_base_url', '').strip()
 
         # Only update smtp_password if a non-empty value was submitted
         new_smtp_password = request.form.get('smtp_password', '').strip()


### PR DESCRIPTION
Upgrade EAS alert notification emails on three fronts, all operator-
toggleable from the Notifications settings page:

- Rendering: send a styled, severity-color-coded multipart/alternative
  HTML body (Jinja2 template at templates/email/eas_alert.html) alongside
  the existing plain-text part, which is retained as a fallback. Severity
  accent is derived from the event's default_product class (WRN/WCH/ADV/
  TEST) in the SAME event registry.
- Image: embed an inline coverage-map image of the affected area, reusing
  the existing share-card renderer (app_utils.image_export) so emails
  carry the same tested visual as the alert detail "Export image" feature.
  Degrades gracefully to no image when geometry/Pillow are unavailable.
- Audio: add a "listen / download" link to the broadcast audio (built
  from a new public_base_url setting) and an optional WAV->MP3 compression
  toggle for the attachment that falls back to WAV if ffmpeg is missing.

New notification_settings columns (migration 20260608): email_html,
email_include_map, email_audio_link, email_compress_audio, public_base_url.

The send_eas_alert_email() signature is extended with optional params, so
existing callers and plain-text behavior are unaffected.

https://claude.ai/code/session_01KBtkovf2t12BqEGVUvRMpp