### PR TITLE
Improve screen editor UX and redesign default OLED/VFD screens

### DIFF
--- a/app_core/migrations/versions/20260610_refresh_default_screen_designs.py
+++ b/app_core/migrations/versions/20260610_refresh_default_screen_designs.py
@@ -1,0 +1,303 @@
+"""Refresh default OLED/VFD screen designs with graphical layouts.
+
+Replaces the remaining text-only OLED example screens with element-based
+layouts (icon header banners, bars, dividers) and restyles the plain VFD
+screens (aligned meter rows, scale ticks, corner brackets). Mirrors the
+templates in scripts/create_example_screens.py.
+
+Revision ID: 20260610_refresh_default_screen_designs
+Revises: 20260608_add_email_rendering_media
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import column, table
+
+
+revision = "20260610_refresh_default_screen_designs"
+down_revision = "20260608_add_email_rendering_media"
+branch_labels = None
+depends_on = None
+
+
+display_screens = table(
+    "display_screens",
+    column("id", sa.Integer),
+    column("name", sa.String),
+    column("display_type", sa.String),
+    column("template_data", JSONB),
+    column("updated_at", sa.DateTime),
+)
+
+
+# Keep in sync with scripts/create_example_screens.py
+UPDATED_SCREENS = {
+    "oled_alert_summary": {
+        "display_type": "oled",
+        "template_data": {
+            "clear": True,
+            "elements": [
+                {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+                {"type": "icon", "name": "warning", "x": 2, "y": 2, "size": 9},
+                {"type": "text", "text": "ALERTS", "x": 14, "y": 1, "font": "small", "invert": True},
+                {
+                    "type": "text", "text": "{alerts.metadata.total_features} active",
+                    "x": 125, "y": 1, "font": "small", "invert": True,
+                    "align": "right", "max_width": 60, "overflow": "trim",
+                },
+                {
+                    "type": "text", "text": "{alerts.features[0].properties.event}",
+                    "x": 2, "y": 15, "font": "medium",
+                    "max_width": 124, "overflow": "ellipsis", "allow_empty": True,
+                },
+                {
+                    "type": "text", "text": "Sev {alerts.features[0].properties.severity}",
+                    "x": 2, "y": 31, "font": "small",
+                    "max_width": 64, "overflow": "trim", "allow_empty": True,
+                },
+                {
+                    "type": "text", "text": "Exp {alerts.features[0].properties.expires_iso}",
+                    "x": 125, "y": 31, "font": "small", "align": "right",
+                    "max_width": 60, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "dotted_hline", "x": 0, "y": 44, "width": 128},
+                {"type": "icon", "name": "shield", "x": 2, "y": 49, "size": 11},
+                {
+                    "type": "text", "text": "{alerts.features[0].properties.area_desc}",
+                    "x": 17, "y": 50, "font": "small",
+                    "max_width": 109, "overflow": "ellipsis", "allow_empty": True,
+                },
+            ],
+        },
+    },
+    "oled_network_beacon": {
+        "display_type": "oled",
+        "template_data": {
+            "clear": True,
+            "elements": [
+                {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+                {"type": "icon", "name": "network", "x": 2, "y": 2, "size": 9},
+                {"type": "text", "text": "NETWORK", "x": 14, "y": 1, "font": "small", "invert": True},
+                {
+                    "type": "text", "text": "{health.network.primary_interface_name}",
+                    "x": 125, "y": 1, "font": "small", "invert": True,
+                    "align": "right", "max_width": 50, "overflow": "trim",
+                },
+                {
+                    "type": "text", "text": "{health.system.hostname}",
+                    "x": 2, "y": 15, "font": "medium",
+                    "max_width": 124, "overflow": "ellipsis",
+                },
+                {
+                    "type": "text", "text": "{health.network.primary_ipv4}",
+                    "x": 2, "y": 31, "font": "medium",
+                    "max_width": 124, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "hline", "x": 0, "y": 47, "width": 128},
+                {"type": "icon", "name": "clock", "x": 2, "y": 51, "size": 8},
+                {
+                    "type": "text", "text": "Up {health.system.uptime_human}",
+                    "x": 13, "y": 52, "font": "small",
+                    "max_width": 70, "overflow": "trim", "allow_empty": True,
+                },
+                {
+                    "type": "text", "text": "{health.network.primary_interface.speed_mbps}Mb",
+                    "x": 125, "y": 52, "font": "small", "align": "right",
+                    "max_width": 40, "overflow": "trim", "allow_empty": True,
+                },
+            ],
+        },
+    },
+    "oled_ipaws_poll_watch": {
+        "display_type": "oled",
+        "template_data": {
+            "clear": True,
+            "elements": [
+                {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+                {"type": "icon", "name": "shield", "x": 2, "y": 2, "size": 9},
+                {"type": "text", "text": "IPAWS POLLER", "x": 14, "y": 1, "font": "small", "invert": True},
+                {
+                    "type": "text", "text": "{now.time_24}",
+                    "x": 125, "y": 1, "font": "small", "invert": True, "align": "right",
+                },
+                {"type": "icon", "name": "check", "x": 2, "y": 16, "size": 10},
+                {
+                    "type": "text", "text": "{status.last_poll.status}",
+                    "x": 16, "y": 15, "font": "medium",
+                    "max_width": 108, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "dotted_hline", "x": 0, "y": 31, "width": 128},
+                {
+                    "type": "text", "text": "+{status.last_poll.alerts_new} new",
+                    "x": 2, "y": 35, "font": "small",
+                    "max_width": 60, "overflow": "trim", "allow_empty": True,
+                },
+                {
+                    "type": "text", "text": "{status.last_poll.alerts_fetched} fetched",
+                    "x": 125, "y": 35, "font": "small", "align": "right",
+                    "max_width": 64, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "hline", "x": 0, "y": 47, "width": 128},
+                {"type": "icon", "name": "clock", "x": 2, "y": 51, "size": 8},
+                {
+                    "type": "text", "text": "Last {status.last_poll.local_timestamp}",
+                    "x": 13, "y": 52, "font": "small",
+                    "max_width": 113, "overflow": "trim", "allow_empty": True,
+                },
+            ],
+        },
+    },
+    "oled_audio_health_matrix": {
+        "display_type": "oled",
+        "template_data": {
+            "clear": True,
+            "elements": [
+                {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+                {"type": "icon", "name": "heartbeat", "x": 2, "y": 2, "size": 9},
+                {"type": "text", "text": "AUDIO HEALTH", "x": 14, "y": 1, "font": "small", "invert": True},
+                {
+                    "type": "text", "text": "{audio_health.overall_status}",
+                    "x": 125, "y": 1, "font": "small", "invert": True,
+                    "align": "right", "max_width": 48, "overflow": "trim",
+                },
+                {"type": "text", "text": "Score", "x": 2, "y": 16, "font": "small"},
+                {
+                    "type": "bar", "value": "{audio_health.overall_health_score}",
+                    "x": 36, "y": 15, "width": 62, "height": 10,
+                },
+                {
+                    "type": "text", "text": "{audio_health.overall_health_score}%",
+                    "x": 125, "y": 16, "font": "small", "align": "right",
+                    "max_width": 26, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "dotted_hline", "x": 0, "y": 30, "width": 128},
+                {
+                    "type": "text", "text": "Sources {audio_health.active_sources}/{audio_health.total_sources} active",
+                    "x": 2, "y": 34, "font": "small",
+                    "max_width": 124, "overflow": "trim", "allow_empty": True,
+                },
+                {"type": "hline", "x": 0, "y": 46, "width": 128},
+                {"type": "icon", "name": "wave", "x": 2, "y": 50, "size": 9},
+                {
+                    "type": "text", "text": "{audio_health.health_records[0].source_name}",
+                    "x": 14, "y": 51, "font": "small",
+                    "max_width": 74, "overflow": "ellipsis", "allow_empty": True,
+                },
+                {
+                    "type": "text", "text": "OK {audio_health.health_records[0].is_healthy}",
+                    "x": 125, "y": 51, "font": "small", "align": "right",
+                    "max_width": 36, "overflow": "trim", "allow_empty": True,
+                },
+            ],
+        },
+    },
+    "vfd_system_meters": {
+        "display_type": "vfd",
+        "template_data": {
+            "type": "graphics",
+            "elements": [
+                {"type": "text", "x": 0, "y": 0, "text": "SYSTEM"},
+                {"type": "line", "x1": 44, "y1": 3, "x2": 139, "y2": 3},
+                {"type": "text", "x": 0, "y": 8, "text": "CPU"},
+                {
+                    "type": "bar", "x": 22, "y": 8, "width": 88, "height": 7,
+                    "value": "{status.system_resources.cpu_usage_percent}", "border": True,
+                },
+                {"type": "text", "x": 114, "y": 8, "text": "{status.system_resources.cpu_usage_percent}%"},
+                {"type": "text", "x": 0, "y": 16, "text": "MEM"},
+                {
+                    "type": "bar", "x": 22, "y": 16, "width": 88, "height": 7,
+                    "value": "{status.system_resources.memory_usage_percent}", "border": True,
+                },
+                {"type": "text", "x": 114, "y": 16, "text": "{status.system_resources.memory_usage_percent}%"},
+                {"type": "text", "x": 0, "y": 24, "text": "DSK"},
+                {
+                    "type": "bar", "x": 22, "y": 24, "width": 88, "height": 7,
+                    "value": "{status.system_resources.disk_usage_percent}", "border": True,
+                },
+                {"type": "text", "x": 114, "y": 24, "text": "{status.system_resources.disk_usage_percent}%"},
+            ],
+        },
+    },
+    "vfd_audio_vu_meter": {
+        "display_type": "vfd",
+        "template_data": {
+            "type": "graphics",
+            "elements": [
+                {"type": "text", "x": 0, "y": 0, "text": "AUDIO"},
+                {"type": "line", "x1": 38, "y1": 3, "x2": 139, "y2": 3},
+                {"type": "text", "x": 0, "y": 9, "text": "PK"},
+                {
+                    "type": "bar", "x": 16, "y": 9, "width": 100, "height": 8,
+                    "value": "{audio.peak_level_percent}", "border": True,
+                },
+                {"type": "text", "x": 120, "y": 9, "text": "{audio.peak_level_percent}"},
+                {"type": "vline", "x": 41, "y": 18, "height": 2},
+                {"type": "vline", "x": 66, "y": 18, "height": 2},
+                {"type": "vline", "x": 91, "y": 18, "height": 2},
+                {"type": "text", "x": 0, "y": 22, "text": "RMS"},
+                {
+                    "type": "bar", "x": 16, "y": 22, "width": 100, "height": 8,
+                    "value": "{audio.rms_level_percent}", "border": True,
+                },
+                {"type": "text", "x": 120, "y": 22, "text": "{audio.rms_level_percent}"},
+            ],
+        },
+    },
+    "vfd_network_status": {
+        "display_type": "vfd",
+        "template_data": {
+            "type": "graphics",
+            "elements": [
+                {"type": "line", "x1": 0, "y1": 0, "x2": 12, "y2": 0},
+                {"type": "line", "x1": 0, "y1": 0, "x2": 0, "y2": 8},
+                {"type": "line", "x1": 127, "y1": 0, "x2": 139, "y2": 0},
+                {"type": "line", "x1": 139, "y1": 0, "x2": 139, "y2": 8},
+                {"type": "line", "x1": 0, "y1": 31, "x2": 12, "y2": 31},
+                {"type": "line", "x1": 0, "y1": 23, "x2": 0, "y2": 31},
+                {"type": "line", "x1": 127, "y1": 31, "x2": 139, "y2": 31},
+                {"type": "line", "x1": 139, "y1": 23, "x2": 139, "y2": 31},
+                {"type": "text", "x": 49, "y": 2, "text": "NETWORK"},
+                {"type": "line", "x1": 20, "y1": 11, "x2": 119, "y2": 11},
+                {"type": "text", "x": 8, "y": 14, "text": "IP {network.ip_address}"},
+                {"type": "text", "x": 8, "y": 23, "text": "Up {network.uptime_human}"},
+            ],
+        },
+    },
+}
+
+
+def upgrade() -> None:
+    """Apply the refreshed graphical templates to existing default screens."""
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+
+    update_stmt = (
+        display_screens.update()
+        .where(display_screens.c.name == sa.bindparam("target_screen_name"))
+        .where(display_screens.c.display_type == sa.bindparam("target_display_type"))
+    )
+
+    for screen_name, payload in UPDATED_SCREENS.items():
+        serialized_template = json.loads(json.dumps(payload["template_data"]))
+        conn.execute(
+            update_stmt,
+            {
+                "template_data": serialized_template,
+                "updated_at": now,
+                "target_screen_name": screen_name,
+                "target_display_type": payload["display_type"],
+            },
+        )
+
+
+def downgrade() -> None:
+    """No-op: previous layouts can be restored via the screen editor."""
+    pass

--- a/scripts/create_example_screens.py
+++ b/scripts/create_example_screens.py
@@ -283,39 +283,28 @@ VFD_SYSTEM_METERS = {
     "template_data": {
         "type": "graphics",
         "elements": [
+            # Title row with decorative rule filling the remaining width
+            {"type": "text", "x": 0, "y": 0, "text": "SYSTEM"},
+            {"type": "line", "x1": 44, "y1": 3, "x2": 139, "y2": 3},
+            # Three aligned meter rows: label, bordered bar, value column
+            {"type": "text", "x": 0, "y": 8, "text": "CPU"},
             {
-                "type": "text",
-                "x": 2,
-                "y": 1,
-                "text": "SYSTEM RESOURCES"
+                "type": "bar", "x": 22, "y": 8, "width": 88, "height": 7,
+                "value": "{status.system_resources.cpu_usage_percent}", "border": True,
             },
+            {"type": "text", "x": 114, "y": 8, "text": "{status.system_resources.cpu_usage_percent}%"},
+            {"type": "text", "x": 0, "y": 16, "text": "MEM"},
             {
-                "type": "progress_bar",
-                "x": 10,
-                "y": 8,
-                "width": 120,
-                "height": 6,
-                "value": "{status.system_resources.cpu_usage_percent}",
-                "label": "CPU"
+                "type": "bar", "x": 22, "y": 16, "width": 88, "height": 7,
+                "value": "{status.system_resources.memory_usage_percent}", "border": True,
             },
+            {"type": "text", "x": 114, "y": 16, "text": "{status.system_resources.memory_usage_percent}%"},
+            {"type": "text", "x": 0, "y": 24, "text": "DSK"},
             {
-                "type": "progress_bar",
-                "x": 10,
-                "y": 17,
-                "width": 120,
-                "height": 6,
-                "value": "{status.system_resources.memory_usage_percent}",
-                "label": "MEM"
+                "type": "bar", "x": 22, "y": 24, "width": 88, "height": 7,
+                "value": "{status.system_resources.disk_usage_percent}", "border": True,
             },
-            {
-                "type": "progress_bar",
-                "x": 10,
-                "y": 26,
-                "width": 120,
-                "height": 6,
-                "value": "{status.system_resources.disk_usage_percent}",
-                "label": "DSK"
-            }
+            {"type": "text", "x": 114, "y": 24, "text": "{status.system_resources.disk_usage_percent}%"},
         ]
     },
     "data_sources": [
@@ -337,30 +326,27 @@ VFD_AUDIO_VU_METER = {
     "template_data": {
         "type": "graphics",
         "elements": [
+            # Title row with decorative rule
+            {"type": "text", "x": 0, "y": 0, "text": "AUDIO"},
+            {"type": "line", "x1": 38, "y1": 3, "x2": 139, "y2": 3},
+            # PEAK meter row
+            {"type": "text", "x": 0, "y": 9, "text": "PK"},
             {
-                "type": "text",
-                "x": 2,
-                "y": 1,
-                "text": "AUDIO LEVELS"
+                "type": "bar", "x": 16, "y": 9, "width": 100, "height": 8,
+                "value": "{audio.peak_level_percent}", "border": True,
             },
+            {"type": "text", "x": 120, "y": 9, "text": "{audio.peak_level_percent}"},
+            # Scale ticks at 25/50/75% shared between the meters
+            {"type": "vline", "x": 41, "y": 18, "height": 2},
+            {"type": "vline", "x": 66, "y": 18, "height": 2},
+            {"type": "vline", "x": 91, "y": 18, "height": 2},
+            # RMS meter row
+            {"type": "text", "x": 0, "y": 22, "text": "RMS"},
             {
-                "type": "progress_bar",
-                "x": 10,
-                "y": 12,
-                "width": 120,
-                "height": 8,
-                "value": "{audio.peak_level_percent}",
-                "label": "PEAK"
+                "type": "bar", "x": 16, "y": 22, "width": 100, "height": 8,
+                "value": "{audio.rms_level_percent}", "border": True,
             },
-            {
-                "type": "progress_bar",
-                "x": 10,
-                "y": 23,
-                "width": 120,
-                "height": 8,
-                "value": "{audio.rms_level_percent}",
-                "label": "RMS"
-            }
+            {"type": "text", "x": 120, "y": 22, "text": "{audio.rms_level_percent}"},
         ]
     },
     "data_sources": [
@@ -449,39 +435,21 @@ VFD_NETWORK_STATUS = {
     "template_data": {
         "type": "graphics",
         "elements": [
-            {
-                "type": "rectangle",
-                "x1": 2,
-                "y1": 2,
-                "x2": 137,
-                "y2": 29,
-                "filled": False
-            },
-            {
-                "type": "text",
-                "x": 6,
-                "y": 5,
-                "text": "NETWORK STATUS"
-            },
-            {
-                "type": "line",
-                "x1": 6,
-                "y1": 13,
-                "x2": 133,
-                "y2": 13
-            },
-            {
-                "type": "text",
-                "x": 6,
-                "y": 16,
-                "text": "IP: {network.ip_address}"
-            },
-            {
-                "type": "text",
-                "x": 6,
-                "y": 24,
-                "text": "Uptime: {network.uptime_human}"
-            }
+            # Corner brackets instead of a full frame for a cleaner look
+            {"type": "line", "x1": 0, "y1": 0, "x2": 12, "y2": 0},
+            {"type": "line", "x1": 0, "y1": 0, "x2": 0, "y2": 8},
+            {"type": "line", "x1": 127, "y1": 0, "x2": 139, "y2": 0},
+            {"type": "line", "x1": 139, "y1": 0, "x2": 139, "y2": 8},
+            {"type": "line", "x1": 0, "y1": 31, "x2": 12, "y2": 31},
+            {"type": "line", "x1": 0, "y1": 23, "x2": 0, "y2": 31},
+            {"type": "line", "x1": 127, "y1": 31, "x2": 139, "y2": 31},
+            {"type": "line", "x1": 139, "y1": 23, "x2": 139, "y2": 31},
+            # Centered title ("NETWORK" = 7 chars x 6px = 42px wide)
+            {"type": "text", "x": 49, "y": 2, "text": "NETWORK"},
+            {"type": "line", "x1": 20, "y1": 11, "x2": 119, "y2": 11},
+            # IP and uptime rows
+            {"type": "text", "x": 8, "y": 14, "text": "IP {network.ip_address}"},
+            {"type": "text", "x": 8, "y": 23, "text": "Up {network.uptime_human}"}
         ]
     },
     "data_sources": [
@@ -666,7 +634,7 @@ OLED_SYSTEM_OVERVIEW = {
 
 OLED_ALERT_SUMMARY = {
     "name": "oled_alert_summary",
-    "description": "Active alert highlight with event, severity, and affected area.",
+    "description": "Active alert spotlight with warning banner, event, severity, and area.",
     "display_type": "oled",
     "enabled": True,
     "priority": 2,
@@ -674,38 +642,40 @@ OLED_ALERT_SUMMARY = {
     "duration": 12,
     "template_data": {
         "clear": True,
-        "lines": [
+        "elements": [
+            # Inverted header banner with warning icon and active count
+            {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+            {"type": "icon", "name": "warning", "x": 2, "y": 2, "size": 9},
+            {"type": "text", "text": "ALERTS", "x": 14, "y": 1, "font": "small", "invert": True},
             {
-                "text": "◢ ALERT STACK ◣",
-                "font": "medium",
-                "wrap": False,
-                "invert": True,
-                "spacing": 1,
+                "type": "text", "text": "{alerts.metadata.total_features} active",
+                "x": 125, "y": 1, "font": "small", "invert": True,
+                "align": "right", "max_width": 60, "overflow": "trim",
+            },
+            # Event name, prominent
+            {
+                "type": "text", "text": "{alerts.features[0].properties.event}",
+                "x": 2, "y": 15, "font": "medium",
+                "max_width": 124, "overflow": "ellipsis", "allow_empty": True,
+            },
+            # Severity / expiry row
+            {
+                "type": "text", "text": "Sev {alerts.features[0].properties.severity}",
+                "x": 2, "y": 31, "font": "small",
+                "max_width": 64, "overflow": "trim", "allow_empty": True,
             },
             {
-                "text": "Active {alerts.metadata.total_features}",
-                "font": "small",
-                "wrap": False,
-                "y": 15,
+                "type": "text", "text": "Exp {alerts.features[0].properties.expires_iso}",
+                "x": 125, "y": 31, "font": "small", "align": "right",
+                "max_width": 60, "overflow": "trim", "allow_empty": True,
             },
+            {"type": "dotted_hline", "x": 0, "y": 44, "width": 128},
+            # Affected area footer with shield icon
+            {"type": "icon", "name": "shield", "x": 2, "y": 49, "size": 11},
             {
-                "text": "{alerts.features[0].properties.event}",
-                "font": "medium",
-                "y": 26,
-                "max_width": 124,
-                "allow_empty": True,
-            },
-            {
-                "text": "Severity {alerts.features[0].properties.severity}  ·  Exp {alerts.features[0].properties.expires_iso}",
-                "y": 40,
-                "allow_empty": True,
-                "max_width": 124,
-            },
-            {
-                "text": "Area {alerts.features[0].properties.area_desc}",
-                "y": 52,
-                "max_width": 124,
-                "allow_empty": True,
+                "type": "text", "text": "{alerts.features[0].properties.area_desc}",
+                "x": 17, "y": 50, "font": "small",
+                "max_width": 109, "overflow": "ellipsis", "allow_empty": True,
             },
         ],
     },
@@ -724,41 +694,40 @@ OLED_NETWORK_BEACON = {
     "duration": 12,
     "template_data": {
         "clear": True,
-        "lines": [
+        "elements": [
+            # Inverted header banner with network icon and interface name
+            {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+            {"type": "icon", "name": "network", "x": 2, "y": 2, "size": 9},
+            {"type": "text", "text": "NETWORK", "x": 14, "y": 1, "font": "small", "invert": True},
             {
-                "text": "◢ NETWORK BEACON ◣",
-                "font": "medium",
-                "wrap": False,
-                "invert": True,
-                "spacing": 1,
+                "type": "text", "text": "{health.network.primary_interface_name}",
+                "x": 125, "y": 1, "font": "small", "invert": True,
+                "align": "right", "max_width": 50, "overflow": "trim",
+            },
+            # Hostname, prominent
+            {
+                "type": "text", "text": "{health.system.hostname}",
+                "x": 2, "y": 15, "font": "medium",
+                "max_width": 124, "overflow": "ellipsis",
+            },
+            # IPv4 address, prominent
+            {
+                "type": "text", "text": "{health.network.primary_ipv4}",
+                "x": 2, "y": 31, "font": "medium",
+                "max_width": 124, "overflow": "trim", "allow_empty": True,
+            },
+            {"type": "hline", "x": 0, "y": 47, "width": 128},
+            # Footer: uptime left, link speed right
+            {"type": "icon", "name": "clock", "x": 2, "y": 51, "size": 8},
+            {
+                "type": "text", "text": "Up {health.system.uptime_human}",
+                "x": 13, "y": 52, "font": "small",
+                "max_width": 70, "overflow": "trim", "allow_empty": True,
             },
             {
-                "text": "{health.system.hostname}",
-                "font": "small",
-                "wrap": False,
-                "y": 15,
-                "max_width": 124,
-            },
-            {
-                "text": "Uptime {health.system.uptime_human}",
-                "y": 27,
-                "allow_empty": True,
-            },
-            {
-                "text": "LAN {health.network.primary_interface_name}",
-                "y": 39,
-                "allow_empty": True,
-            },
-            {
-                "text": "{health.network.primary_ipv4}",
-                "y": 49,
-                "allow_empty": True,
-            },
-            {
-                "text": "Speed {health.network.primary_interface.speed_mbps} Mbps  MTU {health.network.primary_interface.mtu}",
-                "y": 59,
-                "allow_empty": True,
-                "max_width": 124,
+                "type": "text", "text": "{health.network.primary_interface.speed_mbps}Mb",
+                "x": 125, "y": 52, "font": "small", "align": "right",
+                "max_width": 40, "overflow": "trim", "allow_empty": True,
             },
         ],
     },
@@ -777,36 +746,41 @@ OLED_IPAWS_POLL_WATCH = {
     "duration": 12,
     "template_data": {
         "clear": True,
-        "lines": [
+        "elements": [
+            # Inverted header banner with shield icon and current time
+            {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+            {"type": "icon", "name": "shield", "x": 2, "y": 2, "size": 9},
+            {"type": "text", "text": "IPAWS POLLER", "x": 14, "y": 1, "font": "small", "invert": True},
             {
-                "text": "◢ IPAWS POLLER ◣",
-                "font": "medium",
-                "wrap": False,
-                "invert": True,
-                "spacing": 1,
+                "type": "text", "text": "{now.time_24}",
+                "x": 125, "y": 1, "font": "small", "invert": True, "align": "right",
+            },
+            # Poll status, prominent, with check icon
+            {"type": "icon", "name": "check", "x": 2, "y": 16, "size": 10},
+            {
+                "type": "text", "text": "{status.last_poll.status}",
+                "x": 16, "y": 15, "font": "medium",
+                "max_width": 108, "overflow": "trim", "allow_empty": True,
+            },
+            {"type": "dotted_hline", "x": 0, "y": 31, "width": 128},
+            # New vs fetched alert counts
+            {
+                "type": "text", "text": "+{status.last_poll.alerts_new} new",
+                "x": 2, "y": 35, "font": "small",
+                "max_width": 60, "overflow": "trim", "allow_empty": True,
             },
             {
-                "text": "Last {status.last_poll.local_timestamp}",
-                "y": 17,
-                "allow_empty": True,
-                "max_width": 124,
+                "type": "text", "text": "{status.last_poll.alerts_fetched} fetched",
+                "x": 125, "y": 35, "font": "small", "align": "right",
+                "max_width": 64, "overflow": "trim", "allow_empty": True,
             },
+            {"type": "hline", "x": 0, "y": 47, "width": 128},
+            # Last poll timestamp footer
+            {"type": "icon", "name": "clock", "x": 2, "y": 51, "size": 8},
             {
-                "text": "Status {status.last_poll.status}",
-                "y": 29,
-                "allow_empty": True,
-            },
-            {
-                "text": "+{status.last_poll.alerts_new} new / {status.last_poll.alerts_fetched} fetched",
-                "y": 41,
-                "allow_empty": True,
-                "max_width": 124,
-            },
-            {
-                "text": "Source {status.last_poll.data_source}",
-                "y": 53,
-                "allow_empty": True,
-                "max_width": 124,
+                "type": "text", "text": "Last {status.last_poll.local_timestamp}",
+                "x": 13, "y": 52, "font": "small",
+                "max_width": 113, "overflow": "trim", "allow_empty": True,
             },
         ],
     },
@@ -825,36 +799,46 @@ OLED_AUDIO_HEALTH_MATRIX = {
     "duration": 12,
     "template_data": {
         "clear": True,
-        "lines": [
+        "elements": [
+            # Inverted header banner with heartbeat icon and overall status
+            {"type": "rectangle", "x": 0, "y": 0, "width": 128, "height": 12, "filled": True},
+            {"type": "icon", "name": "heartbeat", "x": 2, "y": 2, "size": 9},
+            {"type": "text", "text": "AUDIO HEALTH", "x": 14, "y": 1, "font": "small", "invert": True},
             {
-                "text": "◢ AUDIO HEALTH ◣",
-                "font": "medium",
-                "wrap": False,
-                "invert": True,
-                "spacing": 1,
+                "type": "text", "text": "{audio_health.overall_status}",
+                "x": 125, "y": 1, "font": "small", "invert": True,
+                "align": "right", "max_width": 48, "overflow": "trim",
+            },
+            # Health score bar row
+            {"type": "text", "text": "Score", "x": 2, "y": 16, "font": "small"},
+            {
+                "type": "bar", "value": "{audio_health.overall_health_score}",
+                "x": 36, "y": 15, "width": 62, "height": 10,
             },
             {
-                "text": "Score {audio_health.overall_health_score}% ({audio_health.overall_status})",
-                "y": 15,
-                "allow_empty": True,
-                "max_width": 124,
+                "type": "text", "text": "{audio_health.overall_health_score}%",
+                "x": 125, "y": 16, "font": "small", "align": "right",
+                "max_width": 26, "overflow": "trim", "allow_empty": True,
+            },
+            {"type": "dotted_hline", "x": 0, "y": 30, "width": 128},
+            # Active source count
+            {
+                "type": "text", "text": "Sources {audio_health.active_sources}/{audio_health.total_sources} active",
+                "x": 2, "y": 34, "font": "small",
+                "max_width": 124, "overflow": "trim", "allow_empty": True,
+            },
+            {"type": "hline", "x": 0, "y": 46, "width": 128},
+            # First-source diagnosis footer
+            {"type": "icon", "name": "wave", "x": 2, "y": 50, "size": 9},
+            {
+                "type": "text", "text": "{audio_health.health_records[0].source_name}",
+                "x": 14, "y": 51, "font": "small",
+                "max_width": 74, "overflow": "ellipsis", "allow_empty": True,
             },
             {
-                "text": "Active {audio_health.active_sources}/{audio_health.total_sources}",
-                "y": 27,
-                "allow_empty": True,
-            },
-            {
-                "text": "{audio_health.health_records[0].source_name}",
-                "y": 39,
-                "allow_empty": True,
-                "max_width": 124,
-            },
-            {
-                "text": "Healthy {audio_health.health_records[0].is_healthy}  Silence {audio_health.health_records[0].silence_detected}",
-                "y": 51,
-                "allow_empty": True,
-                "max_width": 124,
+                "type": "text", "text": "OK {audio_health.health_records[0].is_healthy}",
+                "x": 125, "y": 51, "font": "small", "align": "right",
+                "max_width": 36, "overflow": "trim", "allow_empty": True,
             },
         ],
     },

--- a/static/css/screen-editor.css
+++ b/static/css/screen-editor.css
@@ -99,11 +99,12 @@
 }
 
 .canvas-toolbar {
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 1rem;
     background: var(--card-bg, #fff);
     border-bottom: 1px solid var(--border-color, #dee2e6);
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.5rem;
 }
 
@@ -140,11 +141,23 @@
 
 .canvas-container {
     position: relative;
-    background: var(--bg-primary);
-    border: 3px solid var(--color-border-dark);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    transform-origin: center center;
+    background: #000;
+    border: 6px solid #1b1f24;
+    border-radius: 10px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45), inset 0 0 18px rgba(0, 0, 0, 0.8);
+}
+
+/* Per-display "bezel" glow so the preview feels like the real hardware */
+.canvas-container.display-oled {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45), 0 0 22px rgba(120, 180, 255, 0.18);
+}
+
+.canvas-container.display-vfd {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45), 0 0 22px rgba(60, 255, 190, 0.18);
+}
+
+.canvas-container.display-led {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45), 0 0 22px rgba(255, 170, 0, 0.2);
 }
 
 #display-canvas {
@@ -152,6 +165,16 @@
     image-rendering: pixelated;
     image-rendering: crisp-edges;
     cursor: crosshair;
+}
+
+#canvas-grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    display: none;
 }
 
 #element-overlays {
@@ -165,22 +188,34 @@
 
 .element-overlay {
     position: absolute;
-    border: 2px dashed var(--color-info);
-    background: var(--color-info-light);
+    border: 1px dashed rgba(59, 130, 246, 0.55);
+    background: transparent;
     cursor: move;
     pointer-events: all;
-    transition: border-color 0.2s;
+    transition: border-color 0.15s, background 0.15s;
 }
 
 .element-overlay:hover {
-    border-color: var(--color-info-dark);
-    background: rgba(59, 130, 246, 0.2);
+    border-color: var(--color-info-dark, #2563eb);
+    background: rgba(59, 130, 246, 0.12);
 }
 
 .element-overlay.selected {
-    border-color: var(--color-warning);
-    background: var(--color-warning-light);
-    border-style: solid;
+    border: 1px solid var(--color-warning, #f59e0b);
+    background: rgba(245, 158, 11, 0.08);
+}
+
+.resize-handle {
+    position: absolute;
+    right: -6px;
+    bottom: -6px;
+    width: 11px;
+    height: 11px;
+    border-radius: 2px;
+    background: var(--color-warning, #f59e0b);
+    border: 1px solid #fff;
+    cursor: nwse-resize;
+    pointer-events: all;
 }
 
 .element-overlay-label {
@@ -452,11 +487,83 @@
     color: var(--color-info);
 }
 
-/* Add-element selector in the toolbar */
-.add-element-select {
-    width: auto;
-    min-width: 170px;
-    font-weight: 600;
+/* Element palette in the toolbar */
+.element-palette {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.palette-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 0.35rem 0.5rem;
+    min-width: 52px;
+    border: 1px solid var(--border-color, #dee2e6);
+    border-radius: 6px;
+    background: var(--bg-primary, #f8f9fa);
+    color: var(--text-primary, #212529);
+    cursor: pointer;
+    font-size: 0.7rem;
+    line-height: 1;
+    transition: all 0.15s;
+}
+
+.palette-btn i {
+    font-size: 0.9rem;
+}
+
+.palette-btn:hover {
+    border-color: var(--color-info, #3b82f6);
+    background: var(--color-info-light, rgba(59, 130, 246, 0.12));
+    color: var(--color-info, #3b82f6);
+}
+
+/* Toolbar toggle buttons (grid / snap) */
+.canvas-toolbar .btn.active {
+    background: var(--color-info, #3b82f6);
+    border-color: var(--color-info, #3b82f6);
+    color: #fff;
+}
+
+.canvas-hints {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary, #6c757d);
+    text-align: center;
+}
+
+/* Toast notifications */
+.editor-toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translate(-50%, 16px);
+    padding: 0.6rem 1.2rem;
+    border-radius: 8px;
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 500;
+    z-index: 2000;
+    opacity: 0;
+    transition: opacity 0.25s, transform 0.25s;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.editor-toast.show {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.editor-toast-success {
+    background: #16a34a;
+}
+
+.editor-toast-error {
+    background: #dc2626;
 }
 
 .button-group {

--- a/static/js/screen-editor.js
+++ b/static/js/screen-editor.js
@@ -3,8 +3,8 @@
  *
  * Schema-driven WYSIWYG editor. Every element type is described once in the
  * TYPES registry (defaults, property fields, canvas drawing, overlay bounds,
- * and server (de)serialisation), so the toolbar, property panel, layer list,
- * canvas preview and save payload all stay in sync automatically.
+ * resize behaviour, and server (de)serialisation), so the palette, property
+ * panel, layer list, canvas preview and save payload all stay in sync.
  *
  * Supported graphics:
  *   text, bar, rectangle, line, hline, vline, circle, arc, icon, gauge, clock
@@ -13,6 +13,10 @@
  *   - oled: full graphics set (monochrome 128x64 SSD1306)
  *   - vfd:  text + shapes the GU-7000 hardware can draw (140x32)
  *   - led:  text only (character-based sign)
+ *
+ * Editing niceties: undo/redo history, drag to move, corner handle to
+ * resize, arrow-key nudging, snap-to-grid, per-display phosphor colours,
+ * and live {now.*} variables in the preview.
  */
 
 const ScreenEditor = (function() {
@@ -23,16 +27,22 @@ const ScreenEditor = (function() {
         displayType: 'oled',
         canvasWidth: 128,
         canvasHeight: 64,
-        zoom: 1,
+        zoom: 4,
         elements: [],
         selectedElement: null,
         dataSources: [],
         isDragging: false,
+        isResizing: false,
         dragElement: null,
         dragStartX: 0,
         dragStartY: 0,
+        dragStartProps: null,
+        dragMoved: false,
         screenId: null,
-        activeDynamicInput: null
+        activeDynamicInput: null,
+        showGrid: false,
+        snapOn: false,
+        dirty: false
     };
 
     // Display dimensions by type
@@ -41,6 +51,15 @@ const ScreenEditor = (function() {
         vfd: { width: 140, height: 32 },
         led: { width: 80, height: 32 }  // Virtual dimensions for LED (4 lines x 20 chars)
     };
+
+    // Phosphor colours so the preview looks like the real hardware
+    const DISPLAY_THEMES = {
+        oled: { pix: '#d4ecff', bg: '#01040a' },   // cool blue-white OLED
+        vfd:  { pix: '#5dffc3', bg: '#001a12' },   // cyan-green VFD phosphor
+        led:  { pix: '#ffb300', bg: '#140d00' }    // amber LED matrix
+    };
+
+    function theme() { return DISPLAY_THEMES[state.displayType] || DISPLAY_THEMES.oled; }
 
     // Font sizes (actual pixel heights)
     const FONT_SIZES = {
@@ -61,14 +80,43 @@ const ScreenEditor = (function() {
 
     const ALIGN_OPTIONS = [['left', 'Left'], ['center', 'Center'], ['right', 'Right']];
 
+    // LED sign options (mirror scripts/led_sign_controller.py enums)
+    const LED_COLORS = ['AMBER', 'RED', 'GREEN', 'ORANGE', 'YELLOW', 'DIM_RED', 'DIM_GREEN',
+        'BROWN', 'RAINBOW_1', 'RAINBOW_2', 'COLOR_MIX', 'AUTO_COLOR'];
+    const LED_MODES = ['HOLD', 'ROTATE', 'FLASH', 'SCROLL', 'ROLL_LEFT', 'ROLL_RIGHT',
+        'ROLL_UP', 'ROLL_DOWN', 'WIPE_LEFT', 'WIPE_RIGHT', 'AUTO_MODE'];
+    const LED_SPEEDS = ['SPEED_1', 'SPEED_2', 'SPEED_3', 'SPEED_4', 'SPEED_5'];
+    const LED_FONTS = ['FONT_5x7', 'FONT_6x7', 'FONT_7x9', 'FONT_8x7', 'FONT_7x11',
+        'FONT_15x7', 'FONT_19x7', 'FONT_7x13', 'FONT_16x9', 'FONT_32x16'];
+
     // Built-in vector icons available on the OLED (mirrors app_core/oled.py)
     const ICON_NAMES = [
         'antenna', 'speaker', 'warning', 'check', 'cross',
         'network', 'shield', 'wave', 'clock', 'heartbeat'
     ];
 
+    // Suggested {variable} names per endpoint for the data-source modal
+    const ENDPOINT_VAR_SUGGESTIONS = {
+        '/api/system_status': 'status',
+        '/api/system_health': 'health',
+        '/api/alerts': 'alerts',
+        '/api/audio/metrics': 'audio',
+        '/api/audio/metrics/latest': 'audio',
+        '/api/audio/health': 'audio_health',
+        '/api/eas-monitor/status': 'eas',
+        '/api/hardware/gps/status': 'gps',
+        '/api/monitoring/radio': 'radio',
+        '/api/stream/status': 'stream',
+        '/api/receivers': 'receivers'
+    };
+
     // Canvas and context
     let canvas, ctx;
+
+    // Undo/redo history (JSON snapshots of elements + data sources)
+    let history = [];
+    let historyIndex = -1;
+    let nudgeCommitTimer = null;
 
     // ------------------------------------------------------------------
     // Small icon renderers for the canvas preview. These are intentionally
@@ -144,6 +192,24 @@ const ScreenEditor = (function() {
         }
     };
 
+    // Substitute built-in {now.*} variables so clocks/dates look real in the
+    // editor preview. Data-source variables are left verbatim so the user can
+    // see which fields are dynamic.
+    function previewText(text) {
+        if (!text || text.indexOf('{now.') === -1) return text;
+        const now = new Date();
+        const pad = n => String(n).padStart(2, '0');
+        const h12 = now.getHours() % 12 || 12;
+        const ampm = now.getHours() >= 12 ? 'PM' : 'AM';
+        const vars = {
+            'now.time': `${pad(h12)}:${pad(now.getMinutes())} ${ampm}`,
+            'now.time_24': `${pad(now.getHours())}:${pad(now.getMinutes())}`,
+            'now.date': `${pad(now.getMonth() + 1)}/${pad(now.getDate())}/${now.getFullYear()}`
+        };
+        vars['now.datetime'] = `${vars['now.date']} ${vars['now.time']}`;
+        return text.replace(/\{(now\.[a-z_0-9]+)\}/g, (m, key) => vars[key] !== undefined ? vars[key] : m);
+    }
+
     // ------------------------------------------------------------------
     // Property-field helpers
     // ------------------------------------------------------------------
@@ -162,9 +228,9 @@ const ScreenEditor = (function() {
     // Element type registry
     //   create()        -> default props (id added by caller)
     //   fields          -> property panel schema
-    //   draw(el)        -> render onto the canvas (white-on-black preview)
+    //   draw(el)        -> render onto the canvas (phosphor-on-black preview)
     //   bounds(el)      -> {x, y, w, h} top-left overlay box
-    //   move(el,dx,dy)  -> reposition (defaults to x/y translate)
+    //   resize(el, start, dx, dy, snap) -> apply corner-handle resize (optional)
     //   toTemplate(el)  -> server JSON
     //   fromTemplate(t) -> editor props (id added by caller)
     //   layerLabel(el)  -> short label for the layers list
@@ -190,23 +256,24 @@ const ScreenEditor = (function() {
                 const fontSize = FONT_SIZES[el.font] || 11;
                 ctx.font = `${fontSize}px monospace`;
                 ctx.textBaseline = 'top';
-                const w = Math.max(2, ctx.measureText(el.text || '').width);
+                const txt = previewText(el.text || '');
+                const w = Math.max(2, ctx.measureText(txt).width);
                 let x = el.x;
                 if (el.align === 'right') x = el.x - w;
                 else if (el.align === 'center') x = el.x - w / 2;
                 if (el.invert) {
-                    ctx.fillStyle = '#fff';
+                    ctx.fillStyle = theme().pix;
                     ctx.fillRect(x - 1, el.y - 1, w + 2, fontSize + 2);
-                    ctx.fillStyle = '#000';
+                    ctx.fillStyle = theme().bg;
                 } else {
-                    ctx.fillStyle = '#fff';
+                    ctx.fillStyle = theme().pix;
                 }
-                ctx.fillText(el.text || '', x, el.y);
+                ctx.fillText(txt, x, el.y);
             },
             bounds(el) {
                 const fontSize = FONT_SIZES[el.font] || 11;
                 ctx.font = `${fontSize}px monospace`;
-                const w = Math.max(10, ctx.measureText(el.text || '').width);
+                const w = Math.max(10, ctx.measureText(previewText(el.text || '')).width);
                 let x = el.x;
                 if (el.align === 'right') x = el.x - w;
                 else if (el.align === 'center') x = el.x - w / 2;
@@ -222,7 +289,7 @@ const ScreenEditor = (function() {
         },
 
         bar: {
-            label: 'Bar Graph', icon: 'fa-chart-bar', displays: ['oled', 'vfd'],
+            label: 'Bar', icon: 'fa-chart-bar', displays: ['oled', 'vfd'],
             create: () => ({ type: 'bar', x: 4, y: 10, width: 80, height: 9,
                 value: '50', border: true, preview: 60 }),
             fields: [
@@ -239,7 +306,7 @@ const ScreenEditor = (function() {
             draw(el) {
                 const w = Math.max(4, el.width), h = Math.max(3, el.height);
                 const pct = clamp(el.preview != null ? el.preview : 60, 0, 100);
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 if (el.border !== false) {
                     ctx.strokeRect(el.x + 0.5, el.y + 0.5, w - 1, h - 1);
                     const inner = Math.floor((pct / 100) * (w - 2));
@@ -250,6 +317,10 @@ const ScreenEditor = (function() {
                 }
             },
             bounds: el => ({ x: el.x, y: el.y, w: Math.max(4, el.width), h: Math.max(3, el.height) }),
+            resize(el, start, dx, dy, snap) {
+                el.width = Math.max(4, snap(start.width + dx));
+                el.height = Math.max(3, snap(start.height + dy));
+            },
             toTemplate: el => ({ type: 'bar', x: el.x, y: el.y, width: el.width,
                 height: el.height, value: el.value || '0', border: el.border !== false }),
             fromTemplate: t => ({ type: 'bar', x: t.x || 0, y: t.y || 0, width: t.width || 80,
@@ -259,7 +330,7 @@ const ScreenEditor = (function() {
         },
 
         rectangle: {
-            label: 'Rectangle', icon: 'fa-square', displays: ['oled', 'vfd'],
+            label: 'Rect', icon: 'fa-square', displays: ['oled', 'vfd'],
             create: () => ({ type: 'rectangle', x: 4, y: 4, width: 30, height: 20, filled: false }),
             fields: [
                 ...posFields(),
@@ -269,11 +340,15 @@ const ScreenEditor = (function() {
             ],
             draw(el) {
                 const w = Math.max(1, el.width), h = Math.max(1, el.height);
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 if (el.filled) ctx.fillRect(el.x, el.y, w, h);
                 else ctx.strokeRect(el.x + 0.5, el.y + 0.5, w - 1, h - 1);
             },
             bounds: el => ({ x: el.x, y: el.y, w: Math.max(1, el.width), h: Math.max(1, el.height) }),
+            resize(el, start, dx, dy, snap) {
+                el.width = Math.max(1, snap(start.width + dx));
+                el.height = Math.max(1, snap(start.height + dy));
+            },
             toTemplate: el => ({ type: 'rectangle', x: el.x, y: el.y, width: el.width,
                 height: el.height, filled: !!el.filled }),
             fromTemplate: t => ({ type: 'rectangle', x: t.x || 0, y: t.y || 0, width: t.width || 30,
@@ -292,7 +367,7 @@ const ScreenEditor = (function() {
                 { key: 'lineWidth', label: 'Thickness (px)', kind: 'number', min: 1 }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff';
+                ctx.strokeStyle = theme().pix;
                 ctx.lineWidth = Math.max(1, el.lineWidth || 1);
                 ctx.beginPath();
                 ctx.moveTo(el.x1 + 0.5, el.y1 + 0.5);
@@ -301,7 +376,10 @@ const ScreenEditor = (function() {
             },
             bounds: el => ({ x: Math.min(el.x1, el.x2), y: Math.min(el.y1, el.y2),
                 w: Math.max(2, Math.abs(el.x2 - el.x1)), h: Math.max(2, Math.abs(el.y2 - el.y1)) }),
-            move(el, dx, dy) { el.x1 += dx; el.y1 += dy; el.x2 += dx; el.y2 += dy; },
+            resize(el, start, dx, dy, snap) {
+                el.x2 = snap(start.x2 + dx);
+                el.y2 = snap(start.y2 + dy);
+            },
             toTemplate: el => ({ type: 'line', x1: el.x1, y1: el.y1, x2: el.x2, y2: el.y2,
                 width: el.lineWidth || 1 }),
             fromTemplate: t => ({ type: 'line', x1: t.x1 || 0, y1: t.y1 || 0, x2: t.x2 || 0,
@@ -310,7 +388,7 @@ const ScreenEditor = (function() {
         },
 
         hline: {
-            label: 'Horizontal Divider', icon: 'fa-grip-lines', displays: ['oled', 'vfd'],
+            label: 'H-Divider', icon: 'fa-grip-lines', displays: ['oled', 'vfd'],
             create: () => ({ type: 'hline', x: 0, y: 16, width: 64, dotted: false }),
             fields: [
                 ...posFields(),
@@ -318,7 +396,7 @@ const ScreenEditor = (function() {
                 { key: 'dotted', label: 'Dotted', kind: 'checkbox' }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 const w = Math.max(1, el.width);
                 if (el.dotted) {
                     for (let px = 0; px < w; px += 2) ctx.fillRect(el.x + px, el.y, 1, 1);
@@ -328,6 +406,9 @@ const ScreenEditor = (function() {
                 }
             },
             bounds: el => ({ x: el.x, y: el.y - 2, w: Math.max(1, el.width), h: 5 }),
+            resize(el, start, dx, dy, snap) {
+                el.width = Math.max(1, snap(start.width + dx));
+            },
             toTemplate: el => ({ type: el.dotted ? 'dotted_hline' : 'hline', x: el.x, y: el.y, width: el.width }),
             fromTemplate: t => ({ type: 'hline', x: t.x || 0, y: t.y || 0, width: t.width || 64,
                 dotted: t.type === 'dotted_hline' }),
@@ -335,19 +416,22 @@ const ScreenEditor = (function() {
         },
 
         vline: {
-            label: 'Vertical Divider', icon: 'fa-grip-lines-vertical', displays: ['oled', 'vfd'],
+            label: 'V-Divider', icon: 'fa-grip-lines-vertical', displays: ['oled', 'vfd'],
             create: () => ({ type: 'vline', x: 16, y: 0, height: 32 }),
             fields: [
                 ...posFields(),
                 { key: 'height', label: 'Height (px)', kind: 'number', min: 1 }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.lineWidth = 1;
                 const h = Math.max(1, el.height);
                 ctx.beginPath();
                 ctx.moveTo(el.x + 0.5, el.y); ctx.lineTo(el.x + 0.5, el.y + h); ctx.stroke();
             },
             bounds: el => ({ x: el.x - 2, y: el.y, w: 5, h: Math.max(1, el.height) }),
+            resize(el, start, dx, dy, snap) {
+                el.height = Math.max(1, snap(start.height + dy));
+            },
             toTemplate: el => ({ type: 'vline', x: el.x, y: el.y, height: el.height }),
             fromTemplate: t => ({ type: 'vline', x: t.x || 0, y: t.y || 0, height: t.height || 32 }),
             layerLabel: el => `V-Line ${el.height}px`
@@ -363,12 +447,15 @@ const ScreenEditor = (function() {
                 { key: 'filled', label: 'Filled', kind: 'checkbox' }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.arc(el.x, el.y, Math.max(1, el.radius), 0, 2 * Math.PI);
                 if (el.filled) ctx.fill(); else ctx.stroke();
             },
             bounds: el => ({ x: el.x - el.radius, y: el.y - el.radius, w: el.radius * 2, h: el.radius * 2 }),
+            resize(el, start, dx, dy, snap) {
+                el.radius = Math.max(1, snap(start.radius + Math.round((dx + dy) / 2)));
+            },
             toTemplate: el => ({ type: 'circle', x: el.x, y: el.y, radius: el.radius, filled: !!el.filled }),
             fromTemplate: t => ({ type: 'circle', x: t.x || 32, y: t.y || 32, radius: t.radius || 12,
                 filled: !!t.filled }),
@@ -386,13 +473,16 @@ const ScreenEditor = (function() {
                 { key: 'end', label: 'End °', kind: 'number', col: 6 }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.lineWidth = 1;
                 ctx.beginPath();
                 ctx.arc(el.x, el.y, Math.max(1, el.radius),
                     (el.start || 0) * Math.PI / 180, (el.end || 0) * Math.PI / 180);
                 ctx.stroke();
             },
             bounds: el => ({ x: el.x - el.radius, y: el.y - el.radius, w: el.radius * 2, h: el.radius * 2 }),
+            resize(el, start, dx, dy, snap) {
+                el.radius = Math.max(1, snap(start.radius + Math.round((dx + dy) / 2)));
+            },
             toTemplate: el => ({ type: 'arc', x: el.x, y: el.y, radius: el.radius, start: el.start, end: el.end }),
             fromTemplate: t => ({ type: 'arc', x: t.x || 32, y: t.y || 32, radius: t.radius || 14,
                 start: t.start || 0, end: t.end != null ? t.end : 180 }),
@@ -408,12 +498,15 @@ const ScreenEditor = (function() {
                 { key: 'size', label: 'Size (px)', kind: 'number', min: 6 }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 const fn = ICON_DRAW[el.name];
                 if (fn) fn(ctx, el.x, el.y, Math.max(6, el.size));
                 else ctx.strokeRect(el.x + 0.5, el.y + 0.5, el.size - 1, el.size - 1);
             },
             bounds: el => ({ x: el.x, y: el.y, w: Math.max(6, el.size), h: Math.max(6, el.size) }),
+            resize(el, start, dx, dy, snap) {
+                el.size = Math.max(6, snap(start.size + Math.max(dx, dy)));
+            },
             toTemplate: el => ({ type: 'icon', name: el.name, x: el.x, y: el.y, size: el.size }),
             fromTemplate: t => ({ type: 'icon', name: t.name || 'antenna', x: t.x || 0, y: t.y || 0,
                 size: t.size || 16 }),
@@ -433,7 +526,7 @@ const ScreenEditor = (function() {
                     help: 'Canvas preview only — live data used on device' }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 const r = Math.max(8, el.radius);
                 ctx.beginPath(); ctx.arc(el.x, el.y, r, Math.PI, 2 * Math.PI); ctx.stroke();
                 const pct = clamp(el.preview != null ? el.preview : 60, 0, 100);
@@ -445,6 +538,9 @@ const ScreenEditor = (function() {
                 ctx.beginPath(); ctx.arc(el.x, el.y, 1.5, 0, 2 * Math.PI); ctx.fill();
             },
             bounds: el => ({ x: el.x - el.radius, y: el.y - el.radius, w: el.radius * 2, h: el.radius + 4 }),
+            resize(el, start, dx, dy, snap) {
+                el.radius = Math.max(8, snap(start.radius + Math.round((dx + dy) / 2)));
+            },
             toTemplate: el => ({ type: 'gauge', x: el.x, y: el.y, radius: el.radius, value: el.value || '0' }),
             fromTemplate: t => ({ type: 'gauge', x: t.x || 64, y: t.y || 48, radius: t.radius || 24,
                 value: t.value != null ? String(t.value) : '50', preview: 60 }),
@@ -452,7 +548,7 @@ const ScreenEditor = (function() {
         },
 
         clock: {
-            label: 'Analog Clock', icon: 'fa-clock', displays: ['oled'],
+            label: 'Clock', icon: 'fa-clock', displays: ['oled'],
             create: () => ({ type: 'clock', x: 32, y: 32, radius: 28, showSeconds: false, showTicks: true }),
             fields: [
                 { key: 'x', label: 'Center X', kind: 'number', col: 6 },
@@ -462,7 +558,7 @@ const ScreenEditor = (function() {
                 { key: 'showSeconds', label: 'Second Hand', kind: 'checkbox' }
             ],
             draw(el) {
-                ctx.strokeStyle = '#fff'; ctx.fillStyle = '#fff'; ctx.lineWidth = 1;
+                ctx.strokeStyle = theme().pix; ctx.fillStyle = theme().pix; ctx.lineWidth = 1;
                 const r = Math.max(8, el.radius), cx = el.x, cy = el.y;
                 ctx.beginPath(); ctx.arc(cx, cy, r, 0, 2 * Math.PI); ctx.stroke();
                 if (el.showTicks) {
@@ -484,6 +580,9 @@ const ScreenEditor = (function() {
                 ctx.beginPath(); ctx.arc(cx, cy, 1.5, 0, 2 * Math.PI); ctx.fill();
             },
             bounds: el => ({ x: el.x - el.radius, y: el.y - el.radius, w: el.radius * 2, h: el.radius * 2 }),
+            resize(el, start, dx, dy, snap) {
+                el.radius = Math.max(8, snap(start.radius + Math.round((dx + dy) / 2)));
+            },
             toTemplate: el => ({ type: 'clock', x: el.x, y: el.y, radius: el.radius,
                 show_seconds: !!el.showSeconds, show_ticks: el.showTicks !== false }),
             fromTemplate: t => ({ type: 'clock', x: t.x || 32, y: t.y || 32, radius: t.radius || 28,
@@ -503,7 +602,93 @@ const ScreenEditor = (function() {
 
     function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
 
+    function snapValue(v) {
+        if (!state.snapOn) return v;
+        return Math.round(v / 4) * 4;
+    }
+
     function typeDef(el) { return TYPES[el.type] || TYPES.text; }
+
+    // ------------------------------------------------------------------
+    // Undo / redo history
+    // ------------------------------------------------------------------
+    function snapshot() {
+        return JSON.stringify({ elements: state.elements, dataSources: state.dataSources });
+    }
+
+    function resetHistory() {
+        history = [snapshot()];
+        historyIndex = 0;
+        updateUndoRedoButtons();
+    }
+
+    // Record the current state as an undo step and mark the screen dirty.
+    function commit() {
+        const snap = snapshot();
+        if (history[historyIndex] === snap) return;
+        history = history.slice(0, historyIndex + 1);
+        history.push(snap);
+        if (history.length > 60) history.shift();
+        historyIndex = history.length - 1;
+        updateUndoRedoButtons();
+        markDirty();
+    }
+
+    function restoreSnapshot(snap) {
+        const data = JSON.parse(snap);
+        state.elements = data.elements || [];
+        state.dataSources = data.dataSources || [];
+        if (state.selectedElement && !getElementById(state.selectedElement)) {
+            state.selectedElement = null;
+            hideElementProps();
+        } else if (state.selectedElement) {
+            showElementProps(getElementById(state.selectedElement));
+        }
+        updateLayers();
+        updateDataSourcesList();
+        render();
+        markDirty();
+    }
+
+    function undo() {
+        if (historyIndex <= 0) return;
+        historyIndex--;
+        restoreSnapshot(history[historyIndex]);
+        updateUndoRedoButtons();
+    }
+
+    function redo() {
+        if (historyIndex >= history.length - 1) return;
+        historyIndex++;
+        restoreSnapshot(history[historyIndex]);
+        updateUndoRedoButtons();
+    }
+
+    function updateUndoRedoButtons() {
+        const undoBtn = document.getElementById('btn-undo');
+        const redoBtn = document.getElementById('btn-redo');
+        if (undoBtn) undoBtn.disabled = historyIndex <= 0;
+        if (redoBtn) redoBtn.disabled = historyIndex >= history.length - 1;
+    }
+
+    function markDirty() {
+        state.dirty = true;
+    }
+
+    // ------------------------------------------------------------------
+    // Toast notifications (non-blocking replacement for alert())
+    // ------------------------------------------------------------------
+    function toast(message, kind) {
+        const el = document.createElement('div');
+        el.className = `editor-toast editor-toast-${kind || 'success'}`;
+        el.textContent = message;
+        document.body.appendChild(el);
+        requestAnimationFrame(() => el.classList.add('show'));
+        setTimeout(() => {
+            el.classList.remove('show');
+            setTimeout(() => el.remove(), 300);
+        }, 2800);
+    }
 
     // ------------------------------------------------------------------
     // Initialisation
@@ -517,29 +702,44 @@ const ScreenEditor = (function() {
             state.screenId = parseInt(screenIdInput.value);
         }
 
+        populateLedSelects();
         setupEventListeners();
         updateCanvasDimensions();
-        rebuildAddMenu();
+        updateDisplayPanels();
+        rebuildPalette();
+        resetHistory();
         render();
+    }
+
+    function populateLedSelects() {
+        const fill = (id, options, def) => {
+            const sel = document.getElementById(id);
+            if (!sel || sel.options.length) return;
+            sel.innerHTML = options.map(o =>
+                `<option value="${o}" ${o === def ? 'selected' : ''}>${o.replace(/_/g, ' ')}</option>`).join('');
+        };
+        fill('led-color', LED_COLORS, 'AMBER');
+        fill('led-mode', LED_MODES, 'HOLD');
+        fill('led-speed', LED_SPEEDS, 'SPEED_3');
+        fill('led-font', LED_FONTS, 'FONT_7x9');
     }
 
     function setupEventListeners() {
         document.getElementById('display-type').addEventListener('change', function() {
             state.displayType = this.value;
             updateCanvasDimensions();
-            updateEffectsPanel();
-            rebuildAddMenu();
+            updateDisplayPanels();
+            rebuildPalette();
             render();
+            markDirty();
         });
 
-        // Add-element selector
-        const addSelect = document.getElementById('add-element-select');
-        if (addSelect) {
-            addSelect.addEventListener('change', function() {
-                if (this.value) {
-                    addElement(this.value);
-                    this.value = '';
-                }
+        // Element palette buttons (delegated)
+        const palette = document.getElementById('element-palette');
+        if (palette) {
+            palette.addEventListener('click', function(e) {
+                const btn = e.target.closest('.palette-btn');
+                if (btn) addElement(btn.dataset.type);
             });
         }
 
@@ -550,31 +750,64 @@ const ScreenEditor = (function() {
                 render();
                 updateLayers();
                 hideElementProps();
+                commit();
             }
         });
 
-        document.getElementById('btn-zoom-in').addEventListener('click', () => changeZoom(0.25));
-        document.getElementById('btn-zoom-out').addEventListener('click', () => changeZoom(-0.25));
+        document.getElementById('btn-zoom-in').addEventListener('click', () => changeZoom(1));
+        document.getElementById('btn-zoom-out').addEventListener('click', () => changeZoom(-1));
+
+        const gridBtn = document.getElementById('btn-toggle-grid');
+        if (gridBtn) {
+            gridBtn.addEventListener('click', () => {
+                state.showGrid = !state.showGrid;
+                gridBtn.classList.toggle('active', state.showGrid);
+                updateGridOverlay();
+            });
+        }
+
+        const snapBtn = document.getElementById('btn-toggle-snap');
+        if (snapBtn) {
+            snapBtn.addEventListener('click', () => {
+                state.snapOn = !state.snapOn;
+                snapBtn.classList.toggle('active', state.snapOn);
+            });
+        }
+
+        document.getElementById('btn-undo')?.addEventListener('click', undo);
+        document.getElementById('btn-redo')?.addEventListener('click', redo);
 
         // Element actions (single shared panel)
         document.getElementById('btn-delete-element').addEventListener('click', deleteSelectedElement);
         document.getElementById('btn-duplicate-element').addEventListener('click', duplicateSelectedElement);
 
-        // Delegated property field changes
+        // Delegated property field changes: 'input' updates live, 'change'
+        // (blur / commit) records an undo step.
         document.getElementById('element-props-fields').addEventListener('input', onFieldChange);
-        document.getElementById('element-props-fields').addEventListener('change', onFieldChange);
+        document.getElementById('element-props-fields').addEventListener('change', e => {
+            onFieldChange(e);
+            commit();
+        });
 
         // Scroll effect controls
         document.getElementById('scroll-effect').addEventListener('change', function() {
             const needsSpeed = !['static', 'fade_in'].includes(this.value);
             document.getElementById('scroll-speed-group').style.display = needsSpeed ? 'block' : 'none';
             document.getElementById('scroll-fps-group').style.display = needsSpeed ? 'block' : 'none';
+            markDirty();
         });
         document.getElementById('scroll-speed').addEventListener('input', function() {
             document.getElementById('scroll-speed-value').textContent = this.value;
+            markDirty();
         });
         document.getElementById('scroll-fps').addEventListener('input', function() {
             document.getElementById('scroll-fps-value').textContent = this.value;
+            markDirty();
+        });
+
+        // LED sign option selects just mark the screen dirty; values are read on save
+        ['led-color', 'led-mode', 'led-speed', 'led-font'].forEach(id => {
+            document.getElementById(id)?.addEventListener('change', markDirty);
         });
 
         // Canvas mouse events
@@ -582,6 +815,7 @@ const ScreenEditor = (function() {
         canvasContainer.addEventListener('mousedown', handleCanvasMouseDown);
         canvasContainer.addEventListener('mousemove', handleCanvasMouseMove);
         canvasContainer.addEventListener('mouseup', handleCanvasMouseUp);
+        canvasContainer.addEventListener('mouseleave', handleCanvasMouseUp);
         canvas.addEventListener('mousemove', updateMousePosition);
 
         // Data source modal
@@ -590,6 +824,14 @@ const ScreenEditor = (function() {
         if (dataSourceModal && addDataSourceBtn) {
             addDataSourceBtn.addEventListener('click', () => new bootstrap.Modal(dataSourceModal).show());
         }
+        const endpointSelect = document.getElementById('data-source-endpoint');
+        if (endpointSelect) {
+            endpointSelect.addEventListener('change', function() {
+                const varInput = document.getElementById('data-source-var-name');
+                const suggestion = ENDPOINT_VAR_SUGGESTIONS[this.value];
+                if (varInput && suggestion && !varInput.value) varInput.value = suggestion;
+            });
+        }
         const testDataSourceBtn = document.getElementById('btn-test-data-source');
         if (testDataSourceBtn) testDataSourceBtn.addEventListener('click', testDataSource);
         const addDataSourceConfirmBtn = document.getElementById('btn-add-data-source-confirm');
@@ -597,10 +839,23 @@ const ScreenEditor = (function() {
 
         document.getElementById('btn-preview').addEventListener('click', showPreview);
         document.getElementById('btn-save').addEventListener('click', saveScreen);
+        document.getElementById('btn-send-to-display')?.addEventListener('click', sendToDisplay);
         document.addEventListener('keydown', handleKeyDown);
 
-        // Built-in variable helper clicks
-        document.querySelectorAll('#dynamic-variables, .variable-help').forEach(() => {});
+        // Settings fields mark the screen dirty
+        ['screen-name', 'screen-description', 'screen-duration'].forEach(id => {
+            document.getElementById(id)?.addEventListener('input', markDirty);
+        });
+        document.getElementById('screen-enabled')?.addEventListener('change', markDirty);
+
+        // Warn before navigating away with unsaved changes
+        window.addEventListener('beforeunload', e => {
+            if (state.dirty) {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        });
+
         bindVariableItems(document);
     }
 
@@ -621,14 +876,16 @@ const ScreenEditor = (function() {
     }
 
     // ------------------------------------------------------------------
-    // Add-element menu (filtered by display type)
+    // Element palette (filtered by display type)
     // ------------------------------------------------------------------
-    function rebuildAddMenu() {
-        const select = document.getElementById('add-element-select');
-        if (!select) return;
+    function rebuildPalette() {
+        const palette = document.getElementById('element-palette');
+        if (!palette) return;
         const available = Object.keys(TYPES).filter(k => TYPES[k].displays.includes(state.displayType));
-        select.innerHTML = '<option value="">+ Add Element…</option>' +
-            available.map(k => `<option value="${k}">${TYPES[k].label}</option>`).join('');
+        palette.innerHTML = available.map(k => `
+            <button type="button" class="palette-btn" data-type="${k}" title="Add ${TYPES[k].label}">
+                <i class="fas ${TYPES[k].icon}"></i><span>${TYPES[k].label}</span>
+            </button>`).join('');
     }
 
     function updateCanvasDimensions() {
@@ -638,11 +895,55 @@ const ScreenEditor = (function() {
         canvas.width = dims.width;
         canvas.height = dims.height;
         document.getElementById('canvas-dimensions').textContent = `${dims.width} x ${dims.height} pixels`;
+
+        const container = document.getElementById('canvas-container');
+        container.classList.remove('display-oled', 'display-vfd', 'display-led');
+        container.classList.add(`display-${state.displayType}`);
+
+        applyZoom();
     }
 
-    function updateEffectsPanel() {
-        document.getElementById('effects-panel').style.display =
-            state.displayType === 'led' ? 'none' : 'block';
+    // Show the right option panels for the current display type
+    function updateDisplayPanels() {
+        const isLed = state.displayType === 'led';
+        document.getElementById('effects-panel').style.display = isLed ? 'none' : 'block';
+        const ledPanel = document.getElementById('led-options-panel');
+        if (ledPanel) ledPanel.style.display = isLed ? 'block' : 'none';
+    }
+
+    // ------------------------------------------------------------------
+    // Zoom & grid. The canvas keeps its logical (device) resolution and is
+    // scaled up with CSS so pixels stay crisp; overlays are positioned in
+    // screen coordinates (device px * zoom).
+    // ------------------------------------------------------------------
+    function applyZoom() {
+        canvas.style.width = `${state.canvasWidth * state.zoom}px`;
+        canvas.style.height = `${state.canvasHeight * state.zoom}px`;
+        document.getElementById('zoom-level').textContent = `${state.zoom}×`;
+        updateGridOverlay();
+        updateOverlays();
+    }
+
+    function changeZoom(delta) {
+        state.zoom = clamp(state.zoom + delta, 1, 10);
+        applyZoom();
+    }
+
+    function updateGridOverlay() {
+        const grid = document.getElementById('canvas-grid');
+        if (!grid) return;
+        grid.style.display = state.showGrid ? 'block' : 'none';
+        if (!state.showGrid) return;
+        const minor = 4 * state.zoom;
+        const major = 8 * state.zoom;
+        grid.style.backgroundImage = [
+            'linear-gradient(to right, rgba(120,170,255,0.14) 1px, transparent 1px)',
+            'linear-gradient(to bottom, rgba(120,170,255,0.14) 1px, transparent 1px)',
+            'linear-gradient(to right, rgba(120,170,255,0.28) 1px, transparent 1px)',
+            'linear-gradient(to bottom, rgba(120,170,255,0.28) 1px, transparent 1px)'
+        ].join(',');
+        grid.style.backgroundSize =
+            `${minor}px ${minor}px, ${minor}px ${minor}px, ${major}px ${major}px, ${major}px ${major}px`;
     }
 
     // ------------------------------------------------------------------
@@ -656,6 +957,7 @@ const ScreenEditor = (function() {
         selectElement(element.id);
         updateLayers();
         render();
+        commit();
     }
 
     function selectElement(elementId) {
@@ -666,6 +968,14 @@ const ScreenEditor = (function() {
             updateLayers();
             render();
         }
+    }
+
+    function deselectElement() {
+        if (!state.selectedElement) return;
+        state.selectedElement = null;
+        hideElementProps();
+        updateLayers();
+        render();
     }
 
     function showElementProps(element) {
@@ -746,7 +1056,7 @@ const ScreenEditor = (function() {
         render();
     }
 
-    // Re-populate field inputs from the element (used after drag).
+    // Re-populate field inputs from the element (used after drag/resize/nudge).
     function syncFormFromElement(element) {
         if (!element || state.selectedElement !== element.id) return;
         const container = document.getElementById('element-props-fields');
@@ -769,6 +1079,7 @@ const ScreenEditor = (function() {
         hideElementProps();
         updateLayers();
         render();
+        commit();
     }
 
     function duplicateSelectedElement() {
@@ -784,6 +1095,7 @@ const ScreenEditor = (function() {
         selectElement(copy.id);
         updateLayers();
         render();
+        commit();
     }
 
     function getElementById(id) {
@@ -802,7 +1114,7 @@ const ScreenEditor = (function() {
                 <div class="empty-state">
                     <i class="fas fa-inbox"></i>
                     <p>No elements yet</p>
-                    <small>Use "+ Add Element…" to start</small>
+                    <small>Pick an element from the toolbar above the canvas</small>
                 </div>`;
             return;
         }
@@ -852,13 +1164,14 @@ const ScreenEditor = (function() {
         [state.elements[index], state.elements[newIndex]] = [state.elements[newIndex], state.elements[index]];
         updateLayers();
         render();
+        commit();
     }
 
     // ------------------------------------------------------------------
     // Canvas rendering
     // ------------------------------------------------------------------
     function render() {
-        ctx.fillStyle = '#000';
+        ctx.fillStyle = theme().bg;
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         state.elements.forEach(element => {
             try { typeDef(element).draw(element); } catch (err) { /* ignore bad element */ }
@@ -868,103 +1181,205 @@ const ScreenEditor = (function() {
 
     function updateOverlays() {
         const overlaysContainer = document.getElementById('element-overlays');
+        if (!overlaysContainer) return;
         overlaysContainer.innerHTML = '';
+        const z = state.zoom;
         state.elements.forEach(element => {
             const def = typeDef(element);
             const b = def.bounds(element);
             const overlay = document.createElement('div');
             overlay.className = 'element-overlay';
-            if (state.selectedElement === element.id) overlay.classList.add('selected');
-            overlay.style.left = `${b.x}px`;
-            overlay.style.top = `${b.y}px`;
-            overlay.style.width = `${Math.max(6, b.w)}px`;
-            overlay.style.height = `${Math.max(6, b.h)}px`;
+            const selected = state.selectedElement === element.id;
+            if (selected) overlay.classList.add('selected');
+            overlay.style.left = `${b.x * z}px`;
+            overlay.style.top = `${b.y * z}px`;
+            overlay.style.width = `${Math.max(6, b.w * z)}px`;
+            overlay.style.height = `${Math.max(6, b.h * z)}px`;
             overlay.dataset.elementId = element.id;
 
             const label = document.createElement('div');
             label.className = 'element-overlay-label';
             label.textContent = def.layerLabel(element).substring(0, 22);
             overlay.appendChild(label);
+
+            // Corner resize handle for resizable elements
+            if (selected && def.resize) {
+                const handle = document.createElement('div');
+                handle.className = 'resize-handle';
+                handle.title = 'Drag to resize';
+                overlay.appendChild(handle);
+            }
+
             overlaysContainer.appendChild(overlay);
         });
     }
 
     // ------------------------------------------------------------------
-    // Canvas drag
+    // Canvas drag & resize
     // ------------------------------------------------------------------
-    function handleCanvasMouseDown(e) {
+    function canvasCoords(e) {
         const rect = canvas.getBoundingClientRect();
-        const x = Math.floor((e.clientX - rect.left) / state.zoom);
-        const y = Math.floor((e.clientY - rect.top) / state.zoom);
+        return {
+            x: Math.floor((e.clientX - rect.left) / state.zoom),
+            y: Math.floor((e.clientY - rect.top) / state.zoom)
+        };
+    }
+
+    // Keys that participate in generic move (snapshotted on drag start)
+    const MOVE_KEYS = ['x', 'y', 'x1', 'y1', 'x2', 'y2', 'width', 'height', 'radius', 'size'];
+
+    function captureStartProps(element) {
+        const props = {};
+        MOVE_KEYS.forEach(k => { if (k in element) props[k] = element[k]; });
+        return props;
+    }
+
+    function handleCanvasMouseDown(e) {
+        const pos = canvasCoords(e);
+        const handle = e.target.closest('.resize-handle');
         const overlay = e.target.closest('.element-overlay');
+
+        if (handle && overlay) {
+            const elementId = parseInt(overlay.dataset.elementId);
+            const element = getElementById(elementId);
+            if (!element) return;
+            selectElement(elementId);
+            state.isResizing = true;
+            state.dragElement = elementId;
+            state.dragStartX = pos.x;
+            state.dragStartY = pos.y;
+            state.dragStartProps = captureStartProps(element);
+            state.dragMoved = false;
+            e.preventDefault();
+            return;
+        }
+
         if (overlay) {
             const elementId = parseInt(overlay.dataset.elementId);
+            const element = getElementById(elementId);
+            if (!element) return;
             selectElement(elementId);
             state.isDragging = true;
             state.dragElement = elementId;
-            state.dragStartX = x;
-            state.dragStartY = y;
+            state.dragStartX = pos.x;
+            state.dragStartY = pos.y;
+            state.dragStartProps = captureStartProps(element);
+            state.dragMoved = false;
             e.preventDefault();
+            return;
         }
+
+        // Click on empty canvas: deselect
+        if (e.target === canvas) deselectElement();
     }
 
     function handleCanvasMouseMove(e) {
-        if (!state.isDragging || !state.dragElement) return;
-        const rect = canvas.getBoundingClientRect();
-        const x = Math.floor((e.clientX - rect.left) / state.zoom);
-        const y = Math.floor((e.clientY - rect.top) / state.zoom);
+        if ((!state.isDragging && !state.isResizing) || !state.dragElement) return;
+        const pos = canvasCoords(e);
         const element = getElementById(state.dragElement);
-        if (!element) return;
+        if (!element || !state.dragStartProps) return;
 
-        let dx = x - state.dragStartX;
-        let dy = y - state.dragStartY;
+        const tdx = pos.x - state.dragStartX;
+        const tdy = pos.y - state.dragStartY;
+        if (tdx === 0 && tdy === 0) return;
+        state.dragMoved = true;
+
         const def = typeDef(element);
-        if (def.move) def.move(element, dx, dy);
-        else {
-            element.x = clamp(element.x + dx, 0, state.canvasWidth);
-            element.y = clamp(element.y + dy, 0, state.canvasHeight);
+        const start = state.dragStartProps;
+
+        if (state.isResizing && def.resize) {
+            def.resize(element, start, tdx, tdy, snapValue);
+        } else {
+            // Generic move: translate every positional key from its start value
+            if ('x' in start) element.x = clamp(snapValue(start.x + tdx), 0, state.canvasWidth);
+            if ('y' in start) element.y = clamp(snapValue(start.y + tdy), 0, state.canvasHeight);
+            if ('x1' in start) {
+                element.x1 = snapValue(start.x1 + tdx);
+                element.y1 = snapValue(start.y1 + tdy);
+                element.x2 = snapValue(start.x2 + tdx);
+                element.y2 = snapValue(start.y2 + tdy);
+            }
         }
 
-        state.dragStartX = x;
-        state.dragStartY = y;
         syncFormFromElement(element);
         updateLayers();
         render();
     }
 
     function handleCanvasMouseUp() {
+        const moved = state.dragMoved;
         state.isDragging = false;
+        state.isResizing = false;
         state.dragElement = null;
+        state.dragStartProps = null;
+        state.dragMoved = false;
+        if (moved) commit();
     }
 
     function updateMousePosition(e) {
-        const rect = canvas.getBoundingClientRect();
-        const x = Math.floor((e.clientX - rect.left) / state.zoom);
-        const y = Math.floor((e.clientY - rect.top) / state.zoom);
-        document.getElementById('mouse-position').textContent = `X: ${x}, Y: ${y}`;
+        const pos = canvasCoords(e);
+        document.getElementById('mouse-position').textContent = `X: ${pos.x}, Y: ${pos.y}`;
     }
 
-    function changeZoom(delta) {
-        state.zoom = clamp(state.zoom + delta, 0.5, 4);
-        document.getElementById('canvas-container').style.transform = `scale(${state.zoom})`;
-        document.getElementById('zoom-level').textContent = `${Math.round(state.zoom * 100)}%`;
+    function nudgeSelected(dx, dy) {
+        const element = getElementById(state.selectedElement);
+        if (!element) return;
+        if ('x1' in element) {
+            element.x1 += dx; element.y1 += dy;
+            element.x2 += dx; element.y2 += dy;
+        } else if ('x' in element) {
+            element.x = clamp(element.x + dx, 0, state.canvasWidth);
+            element.y = clamp(element.y + dy, 0, state.canvasHeight);
+        } else {
+            return;
+        }
+        syncFormFromElement(element);
+        updateLayers();
+        render();
+        // Coalesce rapid keypresses into one undo step
+        clearTimeout(nudgeCommitTimer);
+        nudgeCommitTimer = setTimeout(commit, 400);
     }
 
     function handleKeyDown(e) {
         const inField = ['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName);
+
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+            saveScreen();
+            e.preventDefault();
+            return;
+        }
+        if ((e.ctrlKey || e.metaKey) && !inField && e.key.toLowerCase() === 'z') {
+            e.shiftKey ? redo() : undo();
+            e.preventDefault();
+            return;
+        }
+        if ((e.ctrlKey || e.metaKey) && !inField && e.key.toLowerCase() === 'y') {
+            redo();
+            e.preventDefault();
+            return;
+        }
         if ((e.key === 'Delete' || e.key === 'Backspace') && state.selectedElement && !inField) {
             deleteSelectedElement();
             e.preventDefault();
+            return;
         }
         if ((e.ctrlKey || e.metaKey) && e.key === 'd' && state.selectedElement) {
             duplicateSelectedElement();
             e.preventDefault();
+            return;
         }
         if (e.key === 'Escape' && state.selectedElement) {
-            state.selectedElement = null;
-            hideElementProps();
-            updateLayers();
-            render();
+            deselectElement();
+            return;
+        }
+        if (!inField && state.selectedElement &&
+            ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+            const step = e.shiftKey ? 8 : 1;
+            const dx = e.key === 'ArrowLeft' ? -step : e.key === 'ArrowRight' ? step : 0;
+            const dy = e.key === 'ArrowUp' ? -step : e.key === 'ArrowDown' ? step : 0;
+            nudgeSelected(dx, dy);
+            e.preventDefault();
         }
     }
 
@@ -973,7 +1388,7 @@ const ScreenEditor = (function() {
     // ------------------------------------------------------------------
     function testDataSource() {
         const endpoint = document.getElementById('data-source-endpoint').value;
-        if (!endpoint) { alert('Please select an endpoint'); return; }
+        if (!endpoint) { toast('Please select an endpoint', 'error'); return; }
         const preview = document.getElementById('data-source-preview');
         preview.innerHTML = '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>';
         preview.style.display = 'block';
@@ -986,9 +1401,10 @@ const ScreenEditor = (function() {
     function confirmAddDataSource() {
         const endpoint = document.getElementById('data-source-endpoint').value;
         const varName = document.getElementById('data-source-var-name').value;
-        if (!endpoint || !varName) { alert('Please fill in all fields'); return; }
+        if (!endpoint || !varName) { toast('Please fill in all fields', 'error'); return; }
         state.dataSources.push({ endpoint, var_name: varName });
         updateDataSourcesList();
+        commit();
         bootstrap.Modal.getInstance(document.getElementById('dataSourceModal')).hide();
         document.getElementById('data-source-endpoint').value = '';
         document.getElementById('data-source-var-name').value = '';
@@ -1012,6 +1428,7 @@ const ScreenEditor = (function() {
     function removeDataSource(index) {
         state.dataSources.splice(index, 1);
         updateDataSourcesList();
+        commit();
     }
 
     function updateDynamicVariables() {
@@ -1038,8 +1455,31 @@ const ScreenEditor = (function() {
         previewCanvas.width = canvas.width;
         previewCanvas.height = canvas.height;
         previewCtx.drawImage(canvas, 0, 0);
+        previewCanvas.style.width = `${canvas.width * 4}px`;
+        previewCanvas.style.height = `${canvas.height * 4}px`;
         const previewModal = document.getElementById('previewModal');
         if (previewModal) new bootstrap.Modal(previewModal).show();
+    }
+
+    function sendToDisplay() {
+        if (!state.screenId) {
+            toast('Save the screen first, then send it to the display', 'error');
+            return;
+        }
+        if (state.dirty) {
+            toast('You have unsaved changes — save before sending', 'error');
+            return;
+        }
+        fetch(`/api/screens/${state.screenId}/display`, {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': window.CSRF_TOKEN }
+        })
+        .then(r => r.json().then(data => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => {
+            if (ok) toast('Screen sent to display');
+            else toast(data.error || 'Failed to send to display', 'error');
+        })
+        .catch(err => toast('Failed to send: ' + err.message, 'error'));
     }
 
     // ------------------------------------------------------------------
@@ -1055,7 +1495,7 @@ const ScreenEditor = (function() {
             template_data: buildTemplateData(),
             data_sources: state.dataSources
         };
-        if (!screenData.name) { alert('Please enter a screen name'); return; }
+        if (!screenData.name) { toast('Please enter a screen name', 'error'); return; }
 
         const url = state.screenId ? `/api/screens/${state.screenId}` : '/api/screens';
         const method = state.screenId ? 'PUT' : 'POST';
@@ -1064,21 +1504,40 @@ const ScreenEditor = (function() {
             headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
             body: JSON.stringify(screenData)
         })
-        .then(r => r.json())
-        .then(data => {
-            if (data.error) alert('Error saving screen: ' + data.error);
-            else { alert('Screen saved successfully!'); window.location.href = '/screens'; }
+        .then(r => r.json().then(data => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => {
+            if (!ok || data.error) {
+                toast('Error saving screen: ' + (data.error || 'unknown error'), 'error');
+                return;
+            }
+            state.dirty = false;
+            const created = !state.screenId;
+            if (created && data.id) {
+                // Stay in the editor and switch to edit mode for the new screen
+                state.screenId = data.id;
+                window.history.replaceState({}, '', `/screens/editor/${data.id}`);
+            }
+            document.getElementById('screen-name-display').textContent = screenData.name;
+            toast(created ? 'Screen created' : 'Screen saved');
         })
-        .catch(err => alert('Error saving screen: ' + err.message));
+        .catch(err => toast('Error saving screen: ' + err.message, 'error'));
     }
 
     function buildTemplateData() {
-        // LED is character-based: emit a `lines` array consumed by render_led_screen.
+        // LED is character-based: emit a `lines` array consumed by render_led_screen,
+        // plus screen-level sign options (colour, display mode, speed, font).
         if (state.displayType === 'led') {
             const lines = state.elements
                 .filter(e => e.type === 'text')
-                .map(e => ({ text: e.text, font: e.font }));
-            return { lines, clear: true };
+                .map(e => ({ text: e.text }));
+            return {
+                lines,
+                clear: true,
+                color: document.getElementById('led-color')?.value || 'AMBER',
+                mode: document.getElementById('led-mode')?.value || 'HOLD',
+                speed: document.getElementById('led-speed')?.value || 'SPEED_3',
+                font: document.getElementById('led-font')?.value || 'FONT_7x9'
+            };
         }
 
         const elements = state.elements.map(e => typeDef(e).toTemplate(e));
@@ -1112,19 +1571,21 @@ const ScreenEditor = (function() {
 
         state.displayType = screenData.display_type || 'oled';
         updateCanvasDimensions();
-        updateEffectsPanel();
-        rebuildAddMenu();
+        updateDisplayPanels();
+        rebuildPalette();
 
         const td = screenData.template_data || {};
         if (Array.isArray(td.elements) && td.elements.length) {
             state.elements = td.elements.map(elementFromTemplate);
         } else if (Array.isArray(td.lines) && td.lines.length) {
-            // Legacy lines format -> text elements
+            // Legacy lines format -> text elements, staggered vertically when
+            // a line has no explicit y so they don't pile up at (0,0).
+            const lineHeight = state.displayType === 'led' ? 8 : 13;
             state.elements = td.lines.map((line, index) => {
-                if (typeof line === 'string') {
-                    return { id: Date.now() + index, ...TYPES.text.fromTemplate({ text: line }) };
-                }
-                return { id: Date.now() + index, ...TYPES.text.fromTemplate(line) };
+                const t = typeof line === 'string' ? { text: line } : line;
+                const el = { id: Date.now() + index, ...TYPES.text.fromTemplate(t) };
+                if (t.y == null) el.y = index * lineHeight;
+                return el;
             });
         } else {
             state.elements = [];
@@ -1142,6 +1603,18 @@ const ScreenEditor = (function() {
             document.getElementById('scroll-fps-group').style.display = 'block';
         }
 
+        // LED sign options
+        if (state.displayType === 'led') {
+            const setSel = (id, value) => {
+                const sel = document.getElementById(id);
+                if (sel && value) sel.value = value;
+            };
+            setSel('led-color', td.color);
+            setSel('led-mode', td.mode);
+            setSel('led-speed', td.speed);
+            setSel('led-font', td.font);
+        }
+
         if (screenData.data_sources) {
             state.dataSources = screenData.data_sources;
             updateDataSourcesList();
@@ -1150,6 +1623,8 @@ const ScreenEditor = (function() {
         document.getElementById('screen-name-display').textContent = screenData.name || 'New Screen';
         updateLayers();
         render();
+        resetHistory();
+        state.dirty = false;
     }
 
     function escapeHtml(text) {

--- a/templates/led_control.html
+++ b/templates/led_control.html
@@ -240,6 +240,81 @@
 .color-preset-orange { background: color-mix(in srgb, orange 100%, transparent) !important; color: white !important; }
 .color-preset-purple { background: color-mix(in srgb, purple 100%, transparent) !important; color: white !important; }
 
+/* Status chips in the hero card */
+.led-status-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.led-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.65rem;
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    background: var(--surface-color);
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+.led-chip i { opacity: 0.6; }
+.led-chip-ok {
+    border-color: color-mix(in srgb, var(--success-color) 50%, transparent);
+    background: color-mix(in srgb, var(--success-color) 10%, transparent);
+}
+
+.led-quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+/* Keep the 8 tabs on one scrollable row instead of wrapping into a mess */
+#ledTabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+}
+#ledTabs .nav-link { white-space: nowrap; }
+
+/* Collapsible per-line options */
+.line-options-toggle {
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    padding: 0 0.4rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.line-options-toggle:hover { color: var(--primary-color); }
+.line-options-toggle[aria-expanded="true"] { color: var(--primary-color); }
+
+/* Collapsible debug terminal */
+details.debug-details > summary {
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.9rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--surface-color);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+details.debug-details > summary::-webkit-details-marker { display: none; }
+details.debug-details > summary .summary-chevron { transition: transform 0.2s; margin-left: auto; }
+details.debug-details[open] > summary .summary-chevron { transform: rotate(180deg); }
+details.debug-details[open] > summary { border-radius: 8px 8px 0 0; }
+details.debug-details > .debug-details-body {
+    border: 1px solid var(--border-color);
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    padding: 0.9rem;
+}
+
 @media (max-width: 768px) {
     .tab-content { padding: 1rem; }
     .feature-group { padding: 10px; }
@@ -497,80 +572,67 @@
 
 {% block content %}
 <div class="container-fluid py-4">
-<!-- LED Status Overview -->
+<!-- LED Status + Quick Actions hero -->
 <div class="card mb-4">
-    <div class="card-header bg-primary text-white">
-        <h5 class="mb-0">
-            <i class="fas fa-tv"></i> LED Sign Status
-            <small class="ms-2 opacity-75">Alpha 9120C M-Protocol</small>
-        </h5>
-    </div>
     <div class="card-body">
-        <div class="row">
-            <div class="col-md-6">
+        <div class="row g-4 align-items-center">
+            <div class="col-lg-6">
                 <div id="led-status-display">
-                    <div class="d-flex align-items-center mb-3">
-                        <span class="status-indicator status-connected"></span>
-                        <strong>LED Sign: Ready</strong>
+                    <h5 class="mb-1">
+                        <i class="fas fa-tv text-primary"></i> LED Sign
+                        <small class="text-muted fw-normal">Alpha 9120C &middot; M-Protocol</small>
+                    </h5>
+                    <div class="led-status-chips my-3">
+                        <span class="led-chip led-chip-ok">
+                            <span class="status-indicator status-connected"></span> Connected
+                        </span>
+                        <span class="led-chip">
+                            <i class="fas fa-network-wired"></i>
+                            {{ led_status.host if led_status else '192.168.1.100' }}:{{ led_status.port if led_status else '10001' }}
+                        </span>
+                        <span class="led-chip">
+                            <i class="fas fa-grip"></i> 4 lines &times; 20 chars
+                        </span>
+                        <span class="led-chip">
+                            <i class="fas fa-clock"></i> Updated <span id="last-update-time">just now</span>
+                        </span>
                     </div>
-                    <div class="alert alert-success mb-3">
-                        <div><strong>Status:</strong> Connected and ready</div>
-                        <div><strong>Location:</strong> {{ led_status.host if led_status else '192.168.1.100' }}:{{ led_status.port if led_status else '10001' }}</div>
-                        <div><strong>Last Update:</strong> <span id="last-update-time">Just now</span></div>
-                        <div><strong>Features:</strong> RGB Support, Graphics, 4 Lines × 20 Chars</div>
-                    </div>
-                    <div class="alert alert-info mb-0">
-                        <div><strong><i class="fas fa-network-wired"></i> Connection:</strong> {{ led_status.host if led_status else '192.168.1.100' }}:{{ led_status.port if led_status else '10001' }}</div>
-                        <small class="text-muted d-block mt-2">
-                            To configure connection settings (IP address, port, serial mode, baud rate), visit 
-                            <a href="/admin/hardware" class="alert-link"><strong>Hardware Settings</strong></a> → LED Sign tab.
-                        </small>
+                    <small class="text-muted d-block mb-3">
+                        Connection settings (IP, port, serial mode, baud rate) live in
+                        <a href="/admin/hardware"><strong>Hardware Settings</strong></a> &rarr; LED Sign.
+                    </small>
+                    <div class="led-quick-actions">
+                        <button class="btn btn-sm btn-success" onclick="sendDefaultMessage()">
+                            <i class="fas fa-home"></i> Default Message
+                        </button>
+                        <button class="btn btn-sm btn-warning" onclick="clearDisplay()">
+                            <i class="fas fa-eraser"></i> Clear Display
+                        </button>
+                        <button class="btn btn-sm btn-outline-info" onclick="testAllFeatures()">
+                            <i class="fas fa-vial"></i> Test
+                        </button>
+                        <button class="btn btn-sm btn-outline-secondary" onclick="loadMessageHistory()">
+                            <i class="fas fa-history"></i> History
+                        </button>
+                        <button class="btn btn-sm btn-outline-primary" onclick="reconnectLED()" id="reconnectBtn">
+                            <i class="fas fa-plug"></i> Reconnect
+                        </button>
+                        <button class="btn btn-sm btn-outline-secondary" onclick="loadLEDStatus()">
+                            <i class="fas fa-sync"></i> Refresh
+                        </button>
                     </div>
                 </div>
             </div>
-            <div class="col-md-6">
+            <div class="col-lg-6">
                 <div class="message-preview" id="message-preview">
                     {% set preview_lines = location_settings.led_default_lines or ['LINE 1', 'LINE 2', 'LINE 3', 'LINE 4'] %}
                     {% for line in preview_lines %}
                     <div class="preview-line">{{ line }}</div>
                     {% endfor %}
                 </div>
+                <small class="text-muted d-block text-center mt-1">Default sign message</small>
             </div>
         </div>
-    </div>
-</div>
-
-<!-- Quick Action Buttons -->
-<div class="row mb-4 g-2">
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-success w-100" onclick="sendDefaultMessage()">
-            <i class="fas fa-home"></i> Default Message
-        </button>
-    </div>
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-warning w-100" onclick="clearDisplay()">
-            <i class="fas fa-eraser"></i> Clear Display
-        </button>
-    </div>
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-info w-100" onclick="testAllFeatures()">
-            <i class="fas fa-cog"></i> Test Features
-        </button>
-    </div>
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-secondary w-100" onclick="loadMessageHistory()">
-            <i class="fas fa-history"></i> Message History
-        </button>
-    </div>
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-primary w-100" onclick="reconnectLED()" id="reconnectBtn">
-            <i class="fas fa-plug"></i> Reconnect
-        </button>
-    </div>
-    <div class="col-md-2 col-sm-6">
-        <button class="btn btn-outline-secondary w-100" onclick="loadLEDStatus()">
-            <i class="fas fa-sync"></i> Refresh
-        </button>
     </div>
 </div>
 
@@ -651,51 +713,6 @@
                 </small>
             </div>
 
-            <!-- ══ Protocol Debug Terminal — what is actually going to the sign ══ -->
-            <div class="mb-4" id="debug-terminal-block">
-                <div class="d-flex align-items-center justify-content-between mb-2">
-                    <label class="form-label fw-semibold mb-0">
-                        <i class="fas fa-terminal text-success"></i> Protocol Debug Terminal
-                        <small class="text-muted ms-1" style="font-weight:normal">M-Protocol bytes sent to the sign</small>
-                    </label>
-                    <div class="d-flex align-items-center gap-2">
-                        <span class="badge bg-secondary" id="debug-frame-count" style="font-size:.7em">0 frames</span>
-                        <div class="form-check form-switch m-0" title="Show hexadecimal byte dump">
-                            <input class="form-check-input" type="checkbox" id="debug-show-hex" checked>
-                            <label class="form-check-label small" for="debug-show-hex">Hex</label>
-                        </div>
-                        <div class="form-check form-switch m-0" title="Show ASCII / control-byte view">
-                            <input class="form-check-input" type="checkbox" id="debug-show-ascii" checked>
-                            <label class="form-check-label small" for="debug-show-ascii">ASCII</label>
-                        </div>
-                        <div class="form-check form-switch m-0" title="Auto-scroll to newest frame">
-                            <input class="form-check-input" type="checkbox" id="debug-auto-scroll" checked>
-                            <label class="form-check-label small" for="debug-auto-scroll">Auto-scroll</label>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary"
-                                style="font-size:.75em;padding:2px 8px"
-                                id="debug-pause-btn" onclick="toggleDebugPause()"
-                                title="Pause/Resume frame polling">⏸ Pause</button>
-                        <button type="button" class="btn btn-sm btn-outline-danger"
-                                style="font-size:.75em;padding:2px 8px"
-                                onclick="clearDebugTerminal()"
-                                title="Clear the debug ring buffer">
-                            <i class="fas fa-trash"></i> Clear
-                        </button>
-                    </div>
-                </div>
-                <div id="debug-terminal" class="debug-terminal" aria-live="polite">
-                    <div class="debug-terminal-empty text-center py-3">
-                        <i class="fas fa-satellite-dish opacity-50"></i><br>
-                        <small>No frames captured yet — send a message to see the M-Protocol bytes.</small>
-                    </div>
-                </div>
-                <small class="text-muted d-block mt-1">
-                    Frames: <code class="small">&lt;NUL&gt;×5 &lt;SOH&gt; TT AA &lt;STX&gt; payload &lt;ETX&gt; CC &lt;EOT&gt;</code>
-                    — the most recent <span id="debug-buffer-size">50</span> frames are kept.
-                </small>
-            </div>
-
             <form id="custom-message-form">
                 <div class="row">
                     <div class="col-lg-8">
@@ -703,7 +720,7 @@
                         {% set positions = [' ', '!', '"', '#'] %}
                         <div class="feature-group">
                             <h6><i class="fas fa-keyboard"></i> Message Designer</h6>
-                            <p class="text-muted small mb-3">Click the line cards to edit text, choose colours and effects, and preview exactly how the sign will render each line.</p>
+                            <p class="text-muted small mb-3">Type directly into each line. Use the <i class="fas fa-sliders-h"></i> button on a card for per-line colour, effect and speed overrides.</p>
                             <div class="row g-3">
                                 {% for idx in range(4) %}
                                 <div class="col-xl-6">
@@ -712,10 +729,16 @@
                                             <span class="fw-semibold">Line {{ idx + 1 }}</span>
                                             <span class="effect-pill ep-hold" id="line{{ idx + 1 }}-effect">HOLD</span>
                                             <span class="char-count" id="line{{ idx + 1 }}-count">0 / 20</span>
+                                            <button type="button" class="line-options-toggle" data-bs-toggle="collapse"
+                                                    data-bs-target="#line{{ idx + 1 }}-options" aria-expanded="false"
+                                                    aria-controls="line{{ idx + 1 }}-options" title="Colour, effect & speed options">
+                                                <i class="fas fa-sliders-h"></i>
+                                            </button>
                                         </div>
                                         <div class="card-body">
                                             <div class="line-preview" id="line{{ idx + 1 }}-editor" contenteditable="true" data-line-index="{{ idx }}" data-placeholder="Line {{ idx + 1 }} text"></div>
-                                            <div class="row g-2 mt-3 line-controls">
+                                            <div class="collapse" id="line{{ idx + 1 }}-options">
+                                            <div class="row g-2 mt-2 line-controls">
                                                 <div class="col-md-4">
                                                     <label class="form-label">Colour</label>
                                                     <select class="form-select line-color" data-line-index="{{ idx }}">
@@ -804,6 +827,7 @@
                                                     <i class="fas fa-backspace"></i> Clear line
                                                 </button>
                                             </div>
+                                            </div><!-- /.collapse line options -->
                                         </div>
                                     </div>
                                 </div>
@@ -811,12 +835,12 @@
                             </div>
                         </div>
 
-                        <!-- Color & Font Selection -->
+                        <!-- Message defaults: colour, font, effects, priority, typography -->
                         <div class="feature-group">
-                            <h6><i class="fas fa-paint-brush"></i> Default Colour &amp; Font</h6>
-                            <p class="text-muted small">Applied whenever a line card is set to "Use default" for colour or font.</p>
-                            <div class="row">
-                                <div class="col-md-6">
+                            <h6><i class="fas fa-sliders-h"></i> Message Defaults</h6>
+                            <p class="text-muted small">Used wherever a line card is set to "Use default" — line-specific settings always win.</p>
+                            <div class="row g-3">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-color" class="form-label">Color</label>
                                     <select class="form-select" id="custom-color" onchange="updatePreview()">
                                         <option value="RED">🔴 Red</option>
@@ -833,7 +857,7 @@
                                         <option value="AUTO_COLOR">🔄 Auto Color</option>
                                     </select>
                                 </div>
-                                <div class="col-md-6">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-font" class="form-label">Font Size</label>
                                     <select class="form-select" id="custom-font" onchange="updatePreview()">
                                         <option value="FONT_5x7">5×7 (Tiny)</option>
@@ -848,15 +872,7 @@
                                         <option value="FONT_32x16">32×16 (Huge)</option>
                                     </select>
                                 </div>
-                            </div>
-                        </div>
-
-                        <!-- Display Effects -->
-                        <div class="feature-group">
-                            <h6><i class="fas fa-magic"></i> Default Display Effects</h6>
-                            <p class="text-muted small">Line-specific settings override these defaults; otherwise they control the animation applied on the sign.</p>
-                            <div class="row">
-                                <div class="col-md-6">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-mode" class="form-label">Display Mode</label>
                                     <select class="form-select" id="custom-mode" onchange="updatePreview()">
                                         <option value="HOLD" selected>📌 Hold (Static)</option>
@@ -896,7 +912,7 @@
                                         </optgroup>
                                     </select>
                                 </div>
-                                <div class="col-md-6">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-speed" class="form-label">Animation Speed</label>
                                     <select class="form-select" id="custom-speed">
                                         <option value="SPEED_1">🐌 Slowest</option>
@@ -906,14 +922,7 @@
                                         <option value="SPEED_5">🏎️ Fastest</option>
                                     </select>
                                 </div>
-                            </div>
-                        </div>
-
-                        <!-- Priority & Settings -->
-                        <div class="feature-group">
-                            <h6><i class="fas fa-exclamation"></i> Priority & Settings</h6>
-                            <div class="row">
-                                <div class="col-md-6">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-priority" class="form-label">Message Priority</label>
                                     <select class="form-select" id="custom-priority">
                                         <option value="0">🚨 Emergency</option>
@@ -922,29 +931,19 @@
                                         <option value="3">📝 Low</option>
                                     </select>
                                 </div>
-                                <div class="col-md-6">
+                                <div class="col-md-4 col-sm-6">
                                     <label for="custom-hold" class="form-label">Hold Time (seconds)</label>
                                     <input type="number" class="form-control" id="custom-hold" min="1" max="60" value="5">
                                 </div>
-                            </div>
-                        </div>
-
-                        <!-- Special Functions -->
-                        <div class="feature-group">
-                            <h6><i class="fas fa-star"></i> Typography Options</h6>
-                            <p class="text-muted small">Line-specific flash, wide, and descender toggles are available on each editor card. Use these controls to set the default font width for the entire message.</p>
-                            <div class="row">
-                                <div class="col-md-6">
-                                    <div class="special-function-group">
-                                        <h6 class="mb-2">Font Width</h6>
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="font-style" id="fixed-width" value="FIXED_WIDTH">
-                                            <label class="form-check-label" for="fixed-width">Fixed Width Font</label>
-                                        </div>
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="font-style" id="prop-width" value="PROP_WIDTH" checked>
-                                            <label class="form-check-label" for="prop-width">Proportional Width Font</label>
-                                        </div>
+                                <div class="col-md-4 col-sm-6">
+                                    <label class="form-label d-block">Font Width</label>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="font-style" id="prop-width" value="PROP_WIDTH" checked>
+                                        <label class="form-check-label" for="prop-width">Proportional</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="font-style" id="fixed-width" value="FIXED_WIDTH">
+                                        <label class="form-check-label" for="fixed-width">Fixed</label>
                                     </div>
                                 </div>
                             </div>
@@ -998,6 +997,52 @@
                     </div>
                 </div>
             </form>
+
+            <!-- ══ Protocol Debug Terminal — what is actually going to the sign ══ -->
+            <details class="debug-details mt-4" id="debug-terminal-block">
+                <summary>
+                    <i class="fas fa-terminal text-success"></i> Protocol Debug Terminal
+                    <small class="text-muted fw-normal">M-Protocol bytes sent to the sign</small>
+                    <span class="badge bg-secondary" id="debug-frame-count" style="font-size:.7em">0 frames</span>
+                    <i class="fas fa-chevron-down summary-chevron"></i>
+                </summary>
+                <div class="debug-details-body">
+                    <div class="d-flex align-items-center justify-content-end flex-wrap gap-2 mb-2">
+                        <div class="form-check form-switch m-0" title="Show hexadecimal byte dump">
+                            <input class="form-check-input" type="checkbox" id="debug-show-hex" checked>
+                            <label class="form-check-label small" for="debug-show-hex">Hex</label>
+                        </div>
+                        <div class="form-check form-switch m-0" title="Show ASCII / control-byte view">
+                            <input class="form-check-input" type="checkbox" id="debug-show-ascii" checked>
+                            <label class="form-check-label small" for="debug-show-ascii">ASCII</label>
+                        </div>
+                        <div class="form-check form-switch m-0" title="Auto-scroll to newest frame">
+                            <input class="form-check-input" type="checkbox" id="debug-auto-scroll" checked>
+                            <label class="form-check-label small" for="debug-auto-scroll">Auto-scroll</label>
+                        </div>
+                        <button type="button" class="btn btn-sm btn-outline-secondary"
+                                style="font-size:.75em;padding:2px 8px"
+                                id="debug-pause-btn" onclick="toggleDebugPause()"
+                                title="Pause/Resume frame polling">⏸ Pause</button>
+                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                style="font-size:.75em;padding:2px 8px"
+                                onclick="clearDebugTerminal()"
+                                title="Clear the debug ring buffer">
+                            <i class="fas fa-trash"></i> Clear
+                        </button>
+                    </div>
+                    <div id="debug-terminal" class="debug-terminal" aria-live="polite">
+                        <div class="debug-terminal-empty text-center py-3">
+                            <i class="fas fa-satellite-dish opacity-50"></i><br>
+                            <small>No frames captured yet — send a message to see the M-Protocol bytes.</small>
+                        </div>
+                    </div>
+                    <small class="text-muted d-block mt-1">
+                        Frames: <code class="small">&lt;NUL&gt;×5 &lt;SOH&gt; TT AA &lt;STX&gt; payload &lt;ETX&gt; CC &lt;EOT&gt;</code>
+                        — the most recent <span id="debug-buffer-size">50</span> frames are kept.
+                    </small>
+                </div>
+            </details>
         </div>
 
         <!-- RGB Message Tab -->

--- a/templates/screen_editor.html
+++ b/templates/screen_editor.html
@@ -91,6 +91,34 @@
                 </div>
             </div>
 
+            <!-- LED Sign Options Panel (LED only) -->
+            <div class="panel" id="led-options-panel" style="display: none;">
+                <div class="panel-header">
+                    <i class="fas fa-sign"></i> LED Sign Options
+                </div>
+                <div class="panel-body">
+                    <div class="form-group">
+                        <label>Color</label>
+                        <select id="led-color" class="form-control"></select>
+                    </div>
+                    <div class="form-group">
+                        <label>Display Mode</label>
+                        <select id="led-mode" class="form-control"></select>
+                    </div>
+                    <div class="form-group">
+                        <label>Speed</label>
+                        <select id="led-speed" class="form-control"></select>
+                    </div>
+                    <div class="form-group">
+                        <label>Font</label>
+                        <select id="led-font" class="form-control"></select>
+                    </div>
+                    <small class="form-text text-muted">
+                        Applied to the whole message. The sign shows up to 4 lines of 20 characters.
+                    </small>
+                </div>
+            </div>
+
             <!-- Scroll Effects Panel (OLED/VFD only) -->
             <div class="panel" id="effects-panel">
                 <div class="panel-header">
@@ -131,33 +159,49 @@
         <!-- Center - Canvas Area -->
         <div class="canvas-area">
             <div class="canvas-toolbar">
-                <select id="add-element-select" class="form-control add-element-select">
-                    <option value="">+ Add Element…</option>
-                </select>
-                <button id="btn-clear-canvas" class="btn btn-outline-secondary">
-                    <i class="fas fa-eraser"></i> Clear All
+                <div id="element-palette" class="element-palette"></div>
+                <div class="toolbar-divider"></div>
+                <button id="btn-undo" class="btn btn-sm btn-outline-secondary" title="Undo (Ctrl+Z)" disabled>
+                    <i class="fas fa-undo"></i>
+                </button>
+                <button id="btn-redo" class="btn btn-sm btn-outline-secondary" title="Redo (Ctrl+Shift+Z)" disabled>
+                    <i class="fas fa-redo"></i>
                 </button>
                 <div class="toolbar-divider"></div>
+                <button id="btn-toggle-grid" class="btn btn-sm btn-outline-secondary" title="Show grid">
+                    <i class="fas fa-border-all"></i>
+                </button>
+                <button id="btn-toggle-snap" class="btn btn-sm btn-outline-secondary" title="Snap to 4px grid">
+                    <i class="fas fa-magnet"></i>
+                </button>
+                <button id="btn-clear-canvas" class="btn btn-sm btn-outline-secondary" title="Remove all elements">
+                    <i class="fas fa-eraser"></i>
+                </button>
                 <div class="zoom-controls">
-                    <button id="btn-zoom-out" class="btn btn-sm btn-outline-secondary">
+                    <button id="btn-zoom-out" class="btn btn-sm btn-outline-secondary" title="Zoom out">
                         <i class="fas fa-search-minus"></i>
                     </button>
-                    <span id="zoom-level">100%</span>
-                    <button id="btn-zoom-in" class="btn btn-sm btn-outline-secondary">
+                    <span id="zoom-level">4×</span>
+                    <button id="btn-zoom-in" class="btn btn-sm btn-outline-secondary" title="Zoom in">
                         <i class="fas fa-search-plus"></i>
                     </button>
                 </div>
             </div>
 
             <div class="canvas-wrapper">
-                <div class="canvas-container" id="canvas-container">
+                <div class="canvas-container display-oled" id="canvas-container">
                     <canvas id="display-canvas" width="128" height="64"></canvas>
+                    <div id="canvas-grid"></div>
                     <div id="element-overlays"></div>
                 </div>
                 <div class="canvas-info">
                     <span id="canvas-dimensions">128 x 64 pixels</span>
                     <span class="separator">|</span>
                     <span id="mouse-position">X: 0, Y: 0</span>
+                </div>
+                <div class="canvas-hints">
+                    Drag to move &middot; corner handle to resize &middot; arrow keys to nudge (Shift = 8px)
+                    &middot; Del to delete &middot; Ctrl+Z undo &middot; Ctrl+D duplicate &middot; Ctrl+S save
                 </div>
             </div>
         </div>
@@ -175,7 +219,7 @@
                         <div class="empty-state">
                             <i class="fas fa-inbox"></i>
                             <p>No elements yet</p>
-                            <small>Click "Add Text Element" to start</small>
+                            <small>Pick an element from the toolbar above the canvas</small>
                         </div>
                     </div>
                 </div>
@@ -244,8 +288,14 @@
                     <select id="data-source-endpoint" class="form-control">
                         <option value="">Select an endpoint...</option>
                         <option value="/api/system_status">System Status</option>
-                        <option value="/api/audio/metrics">Audio Metrics</option>
+                        <option value="/api/system_health">System Health</option>
                         <option value="/api/alerts">Active Alerts</option>
+                        <option value="/api/audio/metrics">Audio Metrics</option>
+                        <option value="/api/audio/metrics/latest">Audio Metrics (Latest)</option>
+                        <option value="/api/audio/health">Audio Health</option>
+                        <option value="/api/eas-monitor/status">EAS Decoder Status</option>
+                        <option value="/api/hardware/gps/status">GPS Status</option>
+                        <option value="/api/monitoring/radio">Radio Monitoring</option>
                         <option value="/api/stream/status">Stream Status</option>
                         <option value="/api/receivers">Radio Receivers</option>
                     </select>
@@ -281,7 +331,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body text-center">
-                <canvas id="preview-canvas" width="128" height="64" style="border: 2px solid #333; max-width: 100%; height: auto;"></canvas>
+                <canvas id="preview-canvas" width="128" height="64" style="border: 2px solid #333; border-radius: 6px; max-width: 100%; image-rendering: pixelated;"></canvas>
                 <div class="mt-3">
                     <button id="btn-send-to-display" class="btn btn-success">
                         <i class="fas fa-paper-plane"></i> Send to Display Now


### PR DESCRIPTION
Screen editor (OLED/VFD/LED WYSIWYG):
- Replace add-element dropdown with a visual icon palette filtered by display type
- Add undo/redo history with Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y and toolbar buttons
- Add drag-resize corner handles for bars, rectangles, lines, circles, icons,
  gauges, clocks and dividers
- Add arrow-key nudging (Shift = 8px), snap-to-grid and a pixel grid overlay
- Default to 4x crisp pixel zoom with per-display phosphor colours (blue-white
  OLED, cyan-green VFD, amber LED) and matching bezel glow
- Render {now.*} variables live in the canvas preview
- Add LED sign options panel (color, display mode, speed, font) persisted in
  the template payload
- Stay in the editor after save (new screens switch to edit mode), replace
  blocking alerts with toasts, wire up Send to Display, and warn before
  navigating away with unsaved changes
- Expand the data-source endpoint list and auto-suggest variable names
- Stagger legacy line-based screens vertically when loaded into the canvas

Default screens:
- Convert the four text-only OLED screens (alerts, network, IPAWS, audio
  health) to graphical layouts with icon header banners, bars and dividers
- Restyle VFD system meters, audio VU meter (scale ticks) and network status
  (corner brackets) within the GU-7000 primitive set
- Add migration to refresh the templates on existing installs

https://claude.ai/code/session_013kcUbnP5E7MGBBm9P4bx9B