### PR TITLE
Improve RBDS decode robustness: clock-slip recovery and faster sync confirmation

### DIFF
--- a/app_core/audio/redis_sdr_adapter.py
+++ b/app_core/audio/redis_sdr_adapter.py
@@ -470,6 +470,7 @@ class RedisSDRSourceAdapter(AudioSourceAdapter):
                     self.metrics.metadata['rbds_blocks_fec_single'] = decoder_stats.blocks_fec_single
                     self.metrics.metadata['rbds_blocks_fec_burst'] = decoder_stats.blocks_fec_burst
                     self.metrics.metadata['rbds_blocks_uncorrected'] = decoder_stats.blocks_uncorrected
+                    self.metrics.metadata['rbds_blocks_bit_slips'] = decoder_stats.blocks_bit_slips
                     self.metrics.metadata['rbds_groups_decoded'] = decoder_stats.groups_decoded
                     self.metrics.metadata['rbds_sync_acquired_unix'] = decoder_stats.sync_acquired_unix
                     self.metrics.metadata['rbds_sync_lost_count'] = decoder_stats.sync_lost_count

--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -510,6 +510,7 @@ class SDRSourceAdapter(AudioSourceAdapter):
                             metadata['rbds_blocks_fec_single'] = decoder_stats.blocks_fec_single
                             metadata['rbds_blocks_fec_burst'] = decoder_stats.blocks_fec_burst
                             metadata['rbds_blocks_uncorrected'] = decoder_stats.blocks_uncorrected
+                            metadata['rbds_blocks_bit_slips'] = decoder_stats.blocks_bit_slips
                             metadata['rbds_groups_decoded'] = decoder_stats.groups_decoded
                             metadata['rbds_sync_acquired_unix'] = decoder_stats.sync_acquired_unix
                             metadata['rbds_sync_lost_count'] = decoder_stats.sync_lost_count

--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -869,6 +869,12 @@ class RBDSDecoderStats:
     blocks_fec_single: int = 0  # repaired by single-bit corrector
     blocks_fec_burst: int = 0   # repaired by burst-trapping decoder
     blocks_uncorrected: int = 0
+    # Blocks recovered by ±1-bit clock-slip realignment: the block grid was
+    # shifted one bit by an M&M symbol-timing slip and the decoder realigned
+    # in place instead of dropping sync.  These blocks also count in
+    # blocks_ok (they passed CRC cleanly once realigned); a high rate here
+    # with low BLER points at symbol-timing trouble, not RF noise.
+    blocks_bit_slips: int = 0
     groups_decoded: int = 0
     sync_acquired_unix: Optional[float] = None
     sync_lost_count: int = 0
@@ -1489,6 +1495,7 @@ class RBDSWorker:
                 blocks_fec_single=self._stats.blocks_fec_single,
                 blocks_fec_burst=self._stats.blocks_fec_burst,
                 blocks_uncorrected=self._stats.blocks_uncorrected,
+                blocks_bit_slips=self._stats.blocks_bit_slips,
                 groups_decoded=self._stats.groups_decoded,
                 sync_acquired_unix=self._stats.sync_acquired_unix,
                 sync_lost_count=self._stats.sync_lost_count,
@@ -1564,6 +1571,9 @@ class RBDSWorker:
             '_rbds_bytes_array',
             '_rbds_global_bit_counter',
             '_rbds_inverted_polarity',
+            '_rbds_reg_wide',
+            '_rbds_slip_retry_pending',
+            '_rbds_slip_saved_word',
             '_rbds_sync_tentative',
             '_rbds_tentative_good_groups',
             '_rbds_sample_buffer',
@@ -2273,6 +2283,19 @@ class RBDSWorker:
             self._rbds_bytes_array = bytearray(8)
             self._rbds_global_bit_counter = 0  # CRITICAL: maintain across buffer clears
             self._rbds_inverted_polarity = False
+            # Clock-slip recovery state (synced mode only).  _rbds_reg_wide is
+            # a 27-bit shadow of _rbds_reg so the "-1 bit" hypothesis (block
+            # boundary was one bit earlier) can be tested after the newest bit
+            # has already shifted in; _rbds_slip_retry_pending defers the
+            # verdict on a failed block by one bit to test the "+1 bit"
+            # hypothesis (boundary is one bit later).  See the slip-recovery
+            # comments in the synced-mode block handler.
+            self._rbds_reg_wide = 0
+            self._rbds_slip_retry_pending = False
+            # Polarity-adjusted word from the expected block boundary, kept
+            # across the one-bit deferral so the FEC fallback can repair the
+            # original (unshifted) word if the +1 hypothesis fails.
+            self._rbds_slip_saved_word = 0
             # Tentative-sync state: when the presync state machine declares a
             # lock we do NOT immediately trust it.  The presync gate accepts a
             # candidate after only 2 spacing-confirmed syndrome hits (~52 bits
@@ -2425,6 +2448,13 @@ class RBDSWorker:
                             # disabling the corrector that's most useful right
                             # when we're trying to ratify a tentative sync.
                             self._rbds_consecutive_crc_failures = 0
+                            # Seed the slip-recovery shadow register from the
+                            # presync register so the very first synced block
+                            # can already test the -1-bit hypothesis, and make
+                            # sure no stale deferred retry survives from a
+                            # previous lock.
+                            self._rbds_reg_wide = self._rbds_reg
+                            self._rbds_slip_retry_pending = False
                             # Update polarity to match the triggering block so synced-mode
                             # CRC checks use the correct inversion flag.
                             self._rbds_inverted_polarity = polarity
@@ -2455,6 +2485,12 @@ class RBDSWorker:
             
             else:
                 # SYNCED MODE (python-radio logic)
+                # Shadow register for slip recovery: one bit wider than
+                # _rbds_reg so the 26-bit window ending one bit *earlier*
+                # is still recoverable after the newest bit shifts in.
+                # Updated only while synced to keep the presync hot path
+                # untouched; seeded from _rbds_reg at sync acquisition.
+                self._rbds_reg_wide = ((self._rbds_reg_wide << 1) | bits[i]) & 0x7FFFFFF
                 if self._rbds_block_bit_counter < 25:
                     self._rbds_block_bit_counter += 1
                 else:
@@ -2573,33 +2609,114 @@ class RBDSWorker:
                             return True, fixed, 'burst'
                         return False, candidate_word, 'fail'
 
+                    # Block decision with clock-slip recovery.  A single M&M
+                    # symbol-timing slip shifts the 26-bit block grid by one
+                    # bit and, without recovery, every subsequent block fails
+                    # CRC until the 50-block window drops sync — a ~1 s outage
+                    # plus full reacquisition for a one-bit problem.  When the
+                    # block fails the clean CRC check we therefore test the
+                    # two ±1-bit grid hypotheses BEFORE attempting FEC:
+                    # a slipped word is a shifted codeword, which lands within
+                    # 1 bit of some *other* valid codeword often enough that
+                    # the single-bit corrector will occasionally "repair" it
+                    # into a wrong-but-valid dataword.  Slip hypotheses are
+                    # accepted only on a *clean* CRC pass (never via FEC):
+                    # a false realignment corrupts every following block,
+                    # which is worse than one lost block.
+                    #
+                    # Decision order per block:
+                    #   1. clean CRC at the expected boundary       → good
+                    #   2. clean CRC one bit earlier (-1, via the
+                    #      shadow register)                         → realign
+                    #   3. defer one bit; clean CRC one bit later
+                    #      (+1)                                     → realign
+                    #   4. FEC + polarity recovery on the word from
+                    #      the original boundary                    → repair
+                    # Steps 3 and 4 happen on the deferred retry pass; stats,
+                    # group assembly and sync-quality bookkeeping run exactly
+                    # once per block, on whichever pass reaches a verdict.
                     good_block = False
+                    slip_recovered = False
+                    # Value _rbds_block_bit_counter is reset to after this
+                    # block; 1 when one bit of the next block (or of the
+                    # restored grid) has already been consumed.
+                    next_block_bit_counter = 0
+                    retry_pass = self._rbds_slip_retry_pending
+                    self._rbds_slip_retry_pending = False
                     block_word = self._rbds_reg ^ 0x3FFFFFF if self._rbds_inverted_polarity else self._rbds_reg
 
-                    corrected, corrected_word, repair_path = _repair_block(
-                        block_word, self._rbds_block_number
-                    )
-                    if corrected:
-                        block_word = corrected_word
-                        good_block = True
-                    else:
-                        # If current polarity suddenly fails CRC but opposite polarity passes,
-                        # recover immediately instead of waiting for a full sync-loss window.
-                        alternate_block_word = block_word ^ 0x3FFFFFF
-                        corrected_alt, corrected_alt_word, alt_path = _repair_block(
-                            alternate_block_word, self._rbds_block_number
-                        )
-                        if corrected_alt:
-                            self._rbds_inverted_polarity = not self._rbds_inverted_polarity
-                            block_word = corrected_alt_word
-                            repair_path = alt_path
+                    if not retry_pass:
+                        if _crc_ok_for_block(block_word, self._rbds_block_number):
                             good_block = True
-                            logger.info(
-                                "RBDS polarity flipped while synced; continuing decode (%s polarity)",
-                                "inverted" if self._rbds_inverted_polarity else "normal",
-                            )
+                            repair_path = 'clean'
                         else:
-                            self._rbds_wrong_blocks_counter += 1
+                            # Early hypothesis (-1): the true boundary was one
+                            # bit ago; the shadow register still holds that
+                            # 26-bit window.
+                            early_word = (self._rbds_reg_wide >> 1) & 0x3FFFFFF
+                            if self._rbds_inverted_polarity:
+                                early_word ^= 0x3FFFFFF
+                            if _crc_ok_for_block(early_word, self._rbds_block_number):
+                                block_word = early_word
+                                good_block = True
+                                slip_recovered = True
+                                repair_path = 'clean'
+                                # The newest bit already belongs to the next
+                                # block on the realigned grid.
+                                next_block_bit_counter = 1
+                                logger.info(
+                                    "RBDS bit slip (-1) recovered at block %d; grid realigned in place",
+                                    self._rbds_block_number,
+                                )
+                            else:
+                                # Late hypothesis (+1) needs one more bit:
+                                # save the word from the expected boundary for
+                                # the FEC fallback and re-enter block
+                                # processing on the next bit.
+                                self._rbds_slip_saved_word = block_word
+                                self._rbds_slip_retry_pending = True
+                                self._rbds_block_bit_counter = 25
+                                continue
+                    elif _crc_ok_for_block(block_word, self._rbds_block_number):
+                        # Late-slip (+1) confirmed: a clean block sits one bit
+                        # past the expected boundary.  Keep the shifted grid.
+                        good_block = True
+                        slip_recovered = True
+                        repair_path = 'clean'
+                        logger.info(
+                            "RBDS bit slip (+1) recovered at block %d; grid realigned in place",
+                            self._rbds_block_number,
+                        )
+                    else:
+                        # No slip: fall back to FEC on the word captured at
+                        # the original boundary, then restore the original
+                        # grid (the deferral consumed one extra bit).
+                        next_block_bit_counter = 1
+                        original_word = self._rbds_slip_saved_word
+                        corrected, corrected_word, repair_path = _repair_block(
+                            original_word, self._rbds_block_number
+                        )
+                        if corrected:
+                            block_word = corrected_word
+                            good_block = True
+                        else:
+                            # If current polarity suddenly fails CRC but opposite polarity passes,
+                            # recover immediately instead of waiting for a full sync-loss window.
+                            alternate_block_word = original_word ^ 0x3FFFFFF
+                            corrected_alt, corrected_alt_word, alt_path = _repair_block(
+                                alternate_block_word, self._rbds_block_number
+                            )
+                            if corrected_alt:
+                                self._rbds_inverted_polarity = not self._rbds_inverted_polarity
+                                block_word = corrected_alt_word
+                                repair_path = alt_path
+                                good_block = True
+                                logger.info(
+                                    "RBDS polarity flipped while synced; continuing decode (%s polarity)",
+                                    "inverted" if self._rbds_inverted_polarity else "normal",
+                                )
+                            else:
+                                self._rbds_wrong_blocks_counter += 1
 
                     # Attribute this block to the FEC counters.  'clean' means
                     # the syndrome was zero before any FEC; the others are
@@ -2607,6 +2724,8 @@ class RBDSWorker:
                     # NRSC-4-B BLER computation surfaced via get_stats().
                     with self._stats_lock:
                         self._stats.blocks_total += 1
+                        if slip_recovered:
+                            self._stats.blocks_bit_slips += 1
                         if repair_path == 'clean':
                             self._stats.blocks_ok += 1
                         elif repair_path == 'single':
@@ -2648,22 +2767,54 @@ class RBDSWorker:
                                 program_identification = group_0
 
                                 if self._rbds_sync_tentative:
-                                    # Sync not yet confirmed: count this group
-                                    # toward the confirmation threshold but do
-                                    # NOT publish to the RBDSDecoder (which
-                                    # feeds the UI) and do NOT bump the
-                                    # groups_decoded stat.  If the lock turns
-                                    # out to be false the discarded group is
-                                    # exactly the kind of bogus PI/group-type
-                                    # we don't want to surface.
                                     self._rbds_tentative_good_groups += 1
-                                    logger.debug(
-                                        "RBDS tentative group %d/%d: PI=0x%04X type=%d (not published)",
-                                        self._rbds_tentative_good_groups,
-                                        self._RBDS_TENTATIVE_GOOD_GROUPS,
-                                        program_identification,
-                                        group_type,
-                                    )
+                                    if (
+                                        self._rbds_tentative_good_groups
+                                        >= self._RBDS_TENTATIVE_GOOD_GROUPS
+                                    ):
+                                        # Confirm the lock the moment the Nth
+                                        # fully-decoded group completes instead
+                                        # of waiting for the 50-block window
+                                        # boundary.  Each 4-block group is 104
+                                        # bits of CRC-validated evidence — by
+                                        # the Nth the odds of a false lock are
+                                        # negligible, and waiting out the rest
+                                        # of the window only delayed first
+                                        # published data by up to ~0.8 s on a
+                                        # healthy channel.  The confirming
+                                        # group itself is published below: it
+                                        # passed the same CRC gauntlet as
+                                        # everything that will follow it.
+                                        logger.info(
+                                            "RBDS sync CONFIRMED (%d good groups after %d blocks)",
+                                            self._rbds_tentative_good_groups,
+                                            self._rbds_blocks_counter + 1,
+                                        )
+                                        self._rbds_sync_tentative = False
+                                        with self._stats_lock:
+                                            self._stats.sync_acquired_unix = time.time()
+                                        self._rbds_decoder.process_group(
+                                            (group_0, group_1, group_2, group_3)
+                                        )
+                                        changed = True
+                                        with self._stats_lock:
+                                            self._stats.groups_decoded += 1
+                                    else:
+                                        # Below the confirmation threshold:
+                                        # count the group but do NOT publish to
+                                        # the RBDSDecoder (which feeds the UI)
+                                        # and do NOT bump groups_decoded.  If
+                                        # the lock turns out to be false this
+                                        # is exactly the kind of bogus
+                                        # PI/group-type we don't want to
+                                        # surface.
+                                        logger.debug(
+                                            "RBDS tentative group %d/%d: PI=0x%04X type=%d (not published)",
+                                            self._rbds_tentative_good_groups,
+                                            self._RBDS_TENTATIVE_GOOD_GROUPS,
+                                            program_identification,
+                                            group_type,
+                                        )
                                 else:
                                     # Update our RBDSData decoder
                                     self._rbds_decoder.process_group((group_0, group_1, group_2, group_3))
@@ -2673,46 +2824,34 @@ class RBDSWorker:
 
                                     logger.info("RBDS group: PI=0x%04X type=%s", program_identification, group_type)
                     
-                    # Reset for next block
-                    self._rbds_block_bit_counter = 0
+                    # Reset for next block.  next_block_bit_counter is 1 when
+                    # slip recovery already consumed one bit of the next block
+                    # (or of the restored grid after a failed retry), 0 otherwise.
+                    self._rbds_block_bit_counter = next_block_bit_counter
                     self._rbds_block_number = (self._rbds_block_number + 1) % 4
                     self._rbds_blocks_counter += 1
                     
                     # Check sync quality every 50 blocks
                     if self._rbds_blocks_counter == 50:
                         if self._rbds_sync_tentative:
-                            # Tentative-sync confirmation window: confirm only
-                            # if at least _RBDS_TENTATIVE_GOOD_GROUPS fully-
-                            # decoded groups landed in this window.  This
-                            # ratifies the presync state machine's lock
-                            # against actual valid RBDS frames before we
-                            # publish anything to the UI or start the
-                            # sync_acquired_unix clock.
-                            if self._rbds_tentative_good_groups >= self._RBDS_TENTATIVE_GOOD_GROUPS:
-                                logger.info(
-                                    "RBDS sync CONFIRMED (%d good groups, %d bad blocks on %d total)",
-                                    self._rbds_tentative_good_groups,
-                                    self._rbds_wrong_blocks_counter,
-                                    50,
-                                )
-                                self._rbds_sync_tentative = False
-                                with self._stats_lock:
-                                    self._stats.sync_acquired_unix = time.time()
-                            else:
-                                # Quality gate failed: drop back to presync
-                                # silently.  This was a false lock — never
-                                # surfaced to the UI — so we deliberately do
-                                # NOT bump sync_lost_count (that counter is
-                                # for *real* drops the operator should see).
-                                logger.info(
-                                    "RBDS tentative sync REJECTED (only %d good groups, %d bad blocks on %d total)",
-                                    self._rbds_tentative_good_groups,
-                                    self._rbds_wrong_blocks_counter,
-                                    50,
-                                )
-                                self._rbds_synced = False
-                                self._rbds_presync = False
-                                self._rbds_sync_tentative = False
+                            # Confirmation happens inline the moment the Nth
+                            # good group completes (see group assembly above),
+                            # so reaching the window boundary still tentative
+                            # means the lock never produced enough valid
+                            # groups.  Drop back to presync silently: this was
+                            # a false lock — never surfaced to the UI — so we
+                            # deliberately do NOT bump sync_lost_count (that
+                            # counter is for *real* drops the operator should
+                            # see).
+                            logger.info(
+                                "RBDS tentative sync REJECTED (only %d good groups, %d bad blocks on %d total)",
+                                self._rbds_tentative_good_groups,
+                                self._rbds_wrong_blocks_counter,
+                                50,
+                            )
+                            self._rbds_synced = False
+                            self._rbds_presync = False
+                            self._rbds_sync_tentative = False
                             self._rbds_tentative_good_groups = 0
                         elif self._rbds_wrong_blocks_counter > 35:
                             logger.info("RBDS SYNC LOST (%d bad blocks on %d total)", self._rbds_wrong_blocks_counter, self._rbds_blocks_counter)

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -494,8 +494,16 @@ def _force_synced_tentative(worker: RBDSWorker, *, block_number: int = 0) -> Non
     worker._rbds_group_assembly_started = False
     worker._rbds_inverted_polarity = False
     worker._rbds_reg = 0
+    worker._rbds_reg_wide = 0
+    worker._rbds_slip_retry_pending = False
     worker._rbds_group_good_blocks_counter = 0
     worker._rbds_consecutive_crc_failures = 0
+
+
+def _force_synced_confirmed(worker: RBDSWorker, *, block_number: int = 0) -> None:
+    """Drive the worker into synced+confirmed state (publishing enabled)."""
+    _force_synced_tentative(worker, block_number=block_number)
+    worker._rbds_sync_tentative = False
 
 
 def test_rbds_lock_starts_in_tentative_state():
@@ -582,7 +590,14 @@ def test_rbds_lock_resets_per_sync_stats_but_keeps_sync_lost_count():
 
 
 def test_rbds_tentative_sync_confirms_with_enough_good_groups():
-    """≥ _RBDS_TENTATIVE_GOOD_GROUPS fully-decoded groups in 50 blocks → CONFIRMED."""
+    """≥ _RBDS_TENTATIVE_GOOD_GROUPS fully-decoded groups → CONFIRMED.
+
+    Confirmation fires inline the moment the Nth good group completes (not
+    at the 50-block window boundary), and from the confirming group onward
+    everything is published.  Groups decoded *before* the threshold stay
+    suppressed — if the lock had turned out to be false those are exactly
+    the bogus PI/group-type values we don't want surfaced.
+    """
     worker = _make_worker()
     _force_synced_tentative(worker, block_number=0)
 
@@ -605,14 +620,43 @@ def test_rbds_tentative_sync_confirms_with_enough_good_groups():
     assert worker._rbds_synced is True
     assert worker._rbds_sync_tentative is False, "sync should have been confirmed"
     assert worker._stats.sync_acquired_unix is not None
-    # While tentative, process_group must not have been called once: every
-    # one of the 12 complete groups was suppressed.
-    assert published == [], (
-        "process_group must not be called while sync is tentative; got "
+    # Groups 1-2 were suppressed (still tentative); the confirming 3rd group
+    # and the 9 that follow it are published.
+    assert len(published) == 10, (
+        "expected the confirming group plus all later groups to publish; got "
         f"{len(published)} publishes"
     )
-    # And groups_decoded must not have been bumped during tentative either.
-    assert worker._stats.groups_decoded == 0
+    assert published[0] == (0xABCD + 8, 0xABCD + 9, 0xABCD + 10, 0xABCD + 11)
+    assert worker._stats.groups_decoded == 10
+    worker.stop()
+
+
+def test_rbds_tentative_sync_confirms_immediately_at_threshold():
+    """Confirmation must not wait for the 50-block window boundary.
+
+    Three good groups are 104 bits of CRC-validated evidence each; once the
+    threshold is met, waiting out the rest of the 50-block window only
+    delayed first published data by up to ~0.8 s on a healthy channel.
+    """
+    worker = _make_worker()
+    _force_synced_tentative(worker, block_number=0)
+
+    published: list[tuple[int, int, int, int]] = []
+    worker._rbds_decoder.process_group = lambda group: published.append(tuple(group))  # type: ignore[assignment]
+
+    # Exactly 3 full groups (12 blocks) — well short of the 50-block window.
+    bits: list[int] = []
+    for i in range(12):
+        bits.extend(_bits_for_valid_block(worker, 0x1000 + i, i % 4))
+    worker._rbds_bit_buffer = bits
+    worker._decode_rbds_groups()
+
+    assert worker._rbds_synced is True
+    assert worker._rbds_sync_tentative is False, "threshold reached → confirmed"
+    assert worker._stats.sync_acquired_unix is not None
+    # The confirming (3rd) group publishes; the first two stay suppressed.
+    assert published == [(0x1008, 0x1009, 0x100A, 0x100B)]
+    assert worker._stats.groups_decoded == 1
     worker.stop()
 
 
@@ -670,6 +714,119 @@ def test_rbds_tentative_sync_does_not_publish_groups_mid_window():
     assert worker._rbds_tentative_good_groups == 1
     assert published == []
     assert worker._stats.groups_decoded == 0
+    worker.stop()
+
+
+# ---------------------------------------------------------------------------
+# Clock-slip recovery tests
+#
+# M&M symbol timing can insert or drop a symbol during a fade.  Without
+# recovery, a single slipped bit misaligns the 26-bit block grid and every
+# subsequent block fails CRC until the 50-block sync-quality window drops
+# sync — a ~1 s outage plus full reacquisition for a one-bit problem.  The
+# decoder tests both ±1-bit hypotheses when a block fails all repair paths
+# and realigns the grid in place when one passes the CRC cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_rbds_bit_slip_late_recovered_without_sync_loss():
+    """An inserted symbol (+1 bit) mid-group must not kill the group or sync.
+
+    The stray bit pushes block C one bit late; the decoder defers the verdict
+    by one bit, finds a clean C there, and realigns — the group still
+    completes and no uncorrected block is recorded.
+    """
+    worker = _make_worker()
+    _force_synced_confirmed(worker)
+
+    published: list[tuple[int, int, int, int]] = []
+    worker._rbds_decoder.process_group = lambda group: published.append(tuple(group))  # type: ignore[assignment]
+
+    bits: list[int] = []
+    bits.extend(_bits_for_valid_block(worker, 0x1111, 0))
+    bits.extend(_bits_for_valid_block(worker, 0x2222, 1))
+    bits.append(0)  # spurious extra bit: M&M emitted one symbol too many
+    bits.extend(_bits_for_valid_block(worker, 0x3333, 2))
+    bits.extend(_bits_for_valid_block(worker, 0x4444, 3))
+    worker._rbds_bit_buffer = bits
+    worker._decode_rbds_groups()
+
+    assert worker._rbds_synced is True
+    assert published == [(0x1111, 0x2222, 0x3333, 0x4444)]
+    assert worker._stats.blocks_bit_slips == 1
+    assert worker._stats.blocks_uncorrected == 0
+    worker.stop()
+
+
+def test_rbds_bit_slip_early_recovered_without_sync_loss():
+    """A dropped symbol (-1 bit) must not cost more than the damaged block.
+
+    Block C loses its last (checkword) bit.  The damaged C either still
+    passes as-is or is repaired by single-bit FEC (only its checkword was
+    hit), and the decoder realigns on the next block via the shadow
+    register's -1-bit window — so *both* groups decode with the correct
+    datawords.  Before slip recovery this scenario failed every block until
+    sync dropped.
+    """
+    worker = _make_worker()
+    _force_synced_confirmed(worker)
+
+    published: list[tuple[int, int, int, int]] = []
+    worker._rbds_decoder.process_group = lambda group: published.append(tuple(group))  # type: ignore[assignment]
+
+    bits: list[int] = []
+    bits.extend(_bits_for_valid_block(worker, 0x1111, 0))
+    bits.extend(_bits_for_valid_block(worker, 0x2222, 1))
+    bits.extend(_bits_for_valid_block(worker, 0x3333, 2)[:-1])  # dropped symbol
+    bits.extend(_bits_for_valid_block(worker, 0x4444, 3))
+    for block_no, dataword in enumerate((0x5555, 0x6666, 0x7777, 0x8888)):
+        bits.extend(_bits_for_valid_block(worker, dataword, block_no))
+    worker._rbds_bit_buffer = bits
+    worker._decode_rbds_groups()
+
+    assert worker._rbds_synced is True
+    assert published == [
+        (0x1111, 0x2222, 0x3333, 0x4444),
+        (0x5555, 0x6666, 0x7777, 0x8888),
+    ]
+    assert worker._stats.blocks_bit_slips == 1
+    assert worker._stats.blocks_uncorrected == 0
+    worker.stop()
+
+
+def test_rbds_uncorrectable_block_does_not_shift_grid():
+    """A noise-corrupted block must not trigger a false slip realignment.
+
+    Scattered (non-burst) errors beyond FEC reach fail both ±1-bit
+    hypotheses; the decoder must restore the original block grid after the
+    deferred retry so the very next block — and the next group — decode at
+    the unshifted positions.
+    """
+    worker = _make_worker()
+    _force_synced_confirmed(worker)
+
+    published: list[tuple[int, int, int, int]] = []
+    worker._rbds_decoder.process_group = lambda group: published.append(tuple(group))  # type: ignore[assignment]
+
+    bits: list[int] = []
+    bits.extend(_bits_for_valid_block(worker, 0x1111, 0))
+    bits.extend(_bits_for_valid_block(worker, 0x2222, 1))
+    corrupted = _bits_for_valid_block(worker, 0x3333, 2)
+    for pos in (3, 11, 19):  # scattered errors: beyond single-bit and burst FEC
+        corrupted[pos] ^= 1
+    bits.extend(corrupted)
+    bits.extend(_bits_for_valid_block(worker, 0x4444, 3))
+    for block_no, dataword in enumerate((0x5555, 0x6666, 0x7777, 0x8888)):
+        bits.extend(_bits_for_valid_block(worker, dataword, block_no))
+    worker._rbds_bit_buffer = bits
+    worker._decode_rbds_groups()
+
+    assert worker._rbds_synced is True
+    # Group 1 is lost to the corrupt C, but block D and all of group 2 must
+    # decode at the original grid positions.
+    assert published == [(0x5555, 0x6666, 0x7777, 0x8888)]
+    assert worker._stats.blocks_bit_slips == 0
+    assert worker._stats.blocks_uncorrected == 1
     worker.stop()
 
 


### PR DESCRIPTION
Two decoder improvements targeting "stay in sync" and "sync quicker":

1. ±1-bit clock-slip recovery while synced.  An M&M symbol-timing slip
   shifts the 26-bit block grid by one bit; previously every subsequent
   block failed CRC until the 50-block window dropped sync (~1 s outage
   plus full reacquisition for a one-bit problem).  The decoder now keeps
   a 27-bit shadow register and, when a block fails the clean CRC check,
   tests the -1-bit window and (after a one-bit deferral) the +1-bit
   window, realigning the grid in place on a clean CRC pass.

   Slip hypotheses are tested BEFORE FEC and accepted only on clean CRC:
   a slipped word is a shifted codeword that lands within 1 bit of some
   other valid codeword often enough that the single-bit corrector would
   occasionally "repair" it into a wrong-but-valid dataword (silent data
   corruption that the previous pipeline was exposed to).  FEC and
   polarity recovery still run as the fallback, on the word captured at
   the original boundary, and the original grid is restored if neither
   hypothesis holds.

2. Early tentative-sync confirmation.  The post-lock quality gate
   previously waited for the 50-block window boundary even when the
   required good groups arrived in the first 12 blocks.  Sync is now
   confirmed (and the confirming group published) the moment the Nth
   fully-decoded group completes, cutting up to ~0.8 s off
   time-to-first-data; the window boundary still rejects locks that
   never produce enough groups.

New blocks_bit_slips counter is surfaced through RBDSDecoderStats and
the receiver metadata so timing-slip trouble is distinguishable from RF
noise in the field.

https://claude.ai/code/session_01TWqQg36KWSz99LcsEqDJHS