### PR TITLE
Fix missing coverage map in alert notification emails

### DIFF
--- a/app_core/notifications/alert_image.py
+++ b/app_core/notifications/alert_image.py
@@ -26,9 +26,11 @@ event-themed header, the coverage map with the affected polygon drawn on
 top, and the headline / affected areas / description pulled from the CAP
 alert.
 
-The renderer self-fetches the PostGIS geometry and reads every text field
-straight off the ``CAPAlert`` row, so no request context or web-only
-enrichment helpers are needed here. Any failure (Pillow unavailable, no
+The caller's ``db_session`` is threaded through to the renderer for the
+PostGIS geometry / county-outline queries, because notification emails are
+sent from the CAP poller and audio monitoring services — standalone
+processes with no Flask application context where the renderer's default
+Flask-SQLAlchemy session would fail. Any failure (Pillow unavailable, no
 geometry, offline tile fetch, …) degrades to ``None`` and the email is
 simply sent without the image.
 """
@@ -86,6 +88,7 @@ def build_alert_image(
             location_settings,
             aspect_ratio="landscape",
             image_format="png",
+            db_session=db_session,
         )
 
     except Exception as exc:  # pragma: no cover - defensive

--- a/app_utils/image_export.py
+++ b/app_utils/image_export.py
@@ -49,6 +49,7 @@ Usage::
 
 import io
 import json
+import logging
 import math
 import os
 import random
@@ -57,6 +58,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests as _http
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, PngImagePlugin
+
+logger = logging.getLogger(__name__)
 
 # ─── Canonical brand logo ──────────────────────────────────────────────────
 # Single source of truth for the EAS Station brand logo raster used inside
@@ -1779,6 +1782,7 @@ def _draw_storm_track(canvas: Image.Image, storm: Dict,
 
 def _fetch_county_outlines(
     min_lon: float, min_lat: float, max_lon: float, max_lat: float,
+    db_session: Any = None,
 ) -> List[Dict[str, Any]]:
     """Return simplified GeoJSON geometries for the US counties that
     intersect the given lon/lat bounding box.
@@ -1788,13 +1792,20 @@ def _fetch_county_outlines(
     it falls in) — mirroring the county boundaries on official NWS warning
     graphics.
 
+    *db_session* lets callers running outside a Flask application context
+    (the CAP poller / monitoring services) supply their own SQLAlchemy
+    session; when omitted, the Flask-SQLAlchemy request session is used.
+
     Returns an empty list when the boundary table is unavailable, empty, or
     there is no application / database context (e.g. unit tests, an offline
     render), so the map renderer degrades gracefully to a polygon-only view.
     """
     try:
-        from app_core.extensions import db
         from sqlalchemy import text as _text
+
+        if db_session is None:
+            from app_core.extensions import db
+            db_session = db.session
     except Exception:
         return []
 
@@ -1806,7 +1817,7 @@ def _fetch_county_outlines(
     tol = max(max_lon - min_lon, max_lat - min_lat, 0.01) * 0.0015
 
     try:
-        rows = db.session.execute(
+        rows = db_session.execute(
             _text(
                 """
                 SELECT name,
@@ -1923,11 +1934,14 @@ def _draw_scale_bar(img: Image.Image, fonts: Dict, *,
 def _render_map(geom: Dict, severity: str,
                 storm_motion: Optional[Dict] = None,
                 theme: Optional[_Theme] = None,
-                *, map_w: int = MAP_W, map_h: int = MAP_H) -> Image.Image:
+                *, map_w: int = MAP_W, map_h: int = MAP_H,
+                db_session: Any = None) -> Image.Image:
     """Return a *map_w*×*map_h* RGB map image with the alert polygon overlaid.
 
     *theme* drives the polygon stroke / storm-motion accent colours; if
     omitted we fall back to the severity palette (legacy behaviour).
+    *db_session* is forwarded to the county-outline lookup so callers
+    without a Flask application context still get county borders.
 
     On top of the OSM tiles the map renders muted county reference
     outlines, the alert polygon (plus optional storm-motion overlay), and
@@ -2013,7 +2027,8 @@ def _render_map(geom: Dict, severity: str,
     # labels, which historically collided and cluttered the share image when
     # several boundaries overlapped.  Fetched from the local PostGIS table;
     # if it's unavailable the map simply falls back to a polygon-only view.
-    counties = _fetch_county_outlines(min_lon, min_lat, max_lon, max_lat)
+    counties = _fetch_county_outlines(min_lon, min_lat, max_lon, max_lat,
+                                      db_session=db_session)
     if counties:
         county_w = max(1, int(round(1.4 * stroke_scale)))
         county_layer = Image.new('RGBA', canvas.size, (0, 0, 0, 0))
@@ -2170,6 +2185,7 @@ def generate_alert_image(
     location_settings: Optional[Dict[str, Any]],
     aspect_ratio: str = 'landscape',
     image_format: str = 'png',
+    db_session: Any = None,
 ) -> bytes:
     """Generate a share-card image for *alert* in the requested aspect ratio.
 
@@ -2186,6 +2202,11 @@ def generate_alert_image(
         image_format:      ``png`` (default, universal) or ``webp`` (lossy,
             ~30% smaller at equivalent quality, supported by every major
             social platform).  Unknown values fall back to ``png``.
+        db_session:        Optional SQLAlchemy session used to fetch the
+            alert polygon and county outlines.  Required when rendering
+            outside a Flask application context (the CAP poller and audio
+            monitoring services that send notification emails); inside a
+            request the Flask-SQLAlchemy session is used by default.
 
     Returns:
         Raw image bytes in the requested container.
@@ -2362,13 +2383,18 @@ def generate_alert_image(
         storm_motion = None
     map_img: Optional[Image.Image] = None
     try:
-        from app_core.extensions import db
         from app_core.models import CAPAlert as _CA
         from sqlalchemy import func as _func
         alert_id = getattr(alert, 'id', None)
         if alert_id is not None:
+            session = db_session
+            if session is None:
+                # Web-request path — fall back to the Flask-SQLAlchemy
+                # session (requires an active application context).
+                from app_core.extensions import db
+                session = db.session
             geom_json = (
-                db.session.query(_func.ST_AsGeoJSON(_CA.geom))
+                session.query(_func.ST_AsGeoJSON(_CA.geom))
                 .filter(_CA.id == alert_id)
                 .scalar()
             )
@@ -2376,9 +2402,16 @@ def generate_alert_image(
                 map_img = _render_map(json.loads(geom_json), severity,
                                       storm_motion=storm_motion,
                                       theme=theme,
-                                      map_w=map_w, map_h=map_h)
-    except Exception:
-        pass
+                                      map_w=map_w, map_h=map_h,
+                                      db_session=session)
+    except Exception as exc:
+        # The card is still rendered with a "Map not available" slot, but
+        # leave a trace — a context/session error here is why an email or
+        # share card silently loses its coverage map.
+        logger.warning(
+            "Alert %s: could not fetch geometry for coverage map: %s",
+            getattr(alert, 'id', None), exc,
+        )
 
     if map_img is None:
         map_img = Image.new('RGB', (map_w, map_h), (34, 42, 60))

--- a/tests/test_image_export_themes.py
+++ b/tests/test_image_export_themes.py
@@ -795,7 +795,7 @@ def test_render_map_draws_counties_and_scale_bar(monkeypatch):
     monkeypatch.setattr(image_export, "_fetch_tile", lambda tx, ty, z: None)
 
     # Stub a 3×3 grid of square "counties" around the alert polygon.
-    def _fake_counties(min_lon, min_lat, max_lon, max_lat):
+    def _fake_counties(min_lon, min_lat, max_lon, max_lat, db_session=None):
         xs = [-84.4, -84.0, -83.6, -83.2]
         ys = [39.8, 40.2, 40.6, 41.0]
         out = []
@@ -822,3 +822,91 @@ def test_render_map_draws_counties_and_scale_bar(monkeypatch):
     img = image_export._render_map(geom, "severe", map_w=582, map_h=490)
     assert img.size == (582, 490)
     assert img.mode == "RGB"
+
+
+# ── Coverage map via a caller-supplied DB session ───────────────────────────
+# Notification emails are sent from the CAP poller / audio monitoring
+# services — standalone processes with no Flask application context, where
+# the renderer's default Flask-SQLAlchemy session is unusable.  The caller's
+# own session must be honoured for both the geometry fetch and the
+# county-outline lookup, otherwise the email card silently degrades to the
+# "Map not available" placeholder.
+
+class _StubQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def scalar(self):
+        return self._result
+
+
+class _StubSession:
+    """Minimal SQLAlchemy-session stand-in for the geometry fetch."""
+
+    def __init__(self, geom_json):
+        self._geom_json = geom_json
+        self.query_calls = 0
+
+    def query(self, *args, **kwargs):
+        self.query_calls += 1
+        return _StubQuery(self._geom_json)
+
+    def execute(self, *args, **kwargs):
+        # County-outline lookup — no table in this stub; the renderer must
+        # degrade to a polygon-only map, not crash.
+        raise RuntimeError("no county boundary table in stub session")
+
+
+def test_generate_alert_image_uses_provided_db_session(monkeypatch):
+    """A caller-supplied ``db_session`` must drive the geometry fetch and be
+    forwarded to the map renderer (the no-Flask-context email path)."""
+    import json as _json
+    import types
+
+    # ``generate_alert_image`` imports CAPAlert only to build the query
+    # expression; stub the module so the test stays free of the full app.
+    fake_models = types.ModuleType("app_core.models")
+
+    class _FakeCAPAlert:
+        id = 0
+        geom = None
+
+    fake_models.CAPAlert = _FakeCAPAlert
+    monkeypatch.setitem(sys.modules, "app_core.models", fake_models)
+
+    # Force the offline tile path so the test never hits the network.
+    monkeypatch.setattr(image_export, "_fetch_tile", lambda tx, ty, z: None)
+
+    geom = {
+        "type": "Polygon",
+        "coordinates": [[[-82.6, 40.4], [-82.3, 40.4], [-82.3, 40.7],
+                         [-82.6, 40.7], [-82.6, 40.4]]],
+    }
+    session = _StubSession(_json.dumps(geom))
+
+    rendered = {}
+    real_render_map = image_export._render_map
+
+    def _spy_render_map(g, severity, *args, **kwargs):
+        rendered["geom"] = g
+        rendered["db_session"] = kwargs.get("db_session")
+        return real_render_map(g, severity, *args, **kwargs)
+
+    monkeypatch.setattr(image_export, "_render_map", _spy_render_map)
+
+    alert = _FakeAlert()
+    alert.id = 42
+    png = image_export.generate_alert_image(
+        alert, {}, None, {"county_name": "Test County, OH"},
+        db_session=session,
+    )
+
+    assert png.startswith(b"\x89PNG")
+    assert session.query_calls == 1, \
+        "geometry was not fetched through the provided session"
+    assert rendered.get("geom") == geom, "map was not rendered from the fetched geometry"
+    assert rendered.get("db_session") is session, \
+        "session was not forwarded to the county-outline lookup"


### PR DESCRIPTION
Alert emails are sent from the CAP poller and audio monitoring
services, which run without a Flask application context. The share-card
renderer fetched the alert polygon (and county outlines) through
Flask-SQLAlchemy's context-bound db.session, so in those processes the
query raised, the bare except swallowed it, and every emailed card
showed the 'Map not available' placeholder instead of the coverage map.

Thread the caller's SQLAlchemy session through generate_alert_image ->
_render_map -> _fetch_county_outlines, and pass the notification path's
session from build_alert_image. The web UI export keeps its default
Flask-SQLAlchemy session. Also log a warning when the geometry fetch
fails so this failure mode is no longer invisible, and add a regression
test covering the caller-supplied-session path.

https://claude.ai/code/session_01Ffe39e16p83avU9u73JCC1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of alert image generation and map rendering
  * Improved error visibility with explicit logging for geometry lookup failures
  * Ensured alert emails continue to be sent even when image rendering encounters issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->