### PR TITLE
RBDS decoder false-read hardening + navigation/UX improvements

### DIFF
--- a/app_core/audio/redis_sdr_adapter.py
+++ b/app_core/audio/redis_sdr_adapter.py
@@ -481,6 +481,12 @@ class RedisSDRSourceAdapter(AudioSourceAdapter):
                         dict(decoder_stats.group_type_counts)
                         if decoder_stats.group_type_counts else None
                     )
+                    # Field-churn / false-read telemetry from the two-sighting
+                    # confirmation gate (see RBDSDecoderStats).
+                    self.metrics.metadata['rbds_pi_change_count'] = decoder_stats.pi_change_count
+                    self.metrics.metadata['rbds_pty_change_count'] = decoder_stats.pty_change_count
+                    self.metrics.metadata['rbds_ta_toggle_count'] = decoder_stats.ta_toggle_count
+                    self.metrics.metadata['rbds_glitches_rejected'] = decoder_stats.glitches_rejected
 
                 # RF RSSI (mean IQ magnitude).  Linear value; the UI converts to
                 # dBFS for the signal meter.  Without this the RSSI indicator is

--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -521,6 +521,15 @@ class SDRSourceAdapter(AudioSourceAdapter):
                                 dict(decoder_stats.group_type_counts)
                                 if decoder_stats.group_type_counts else None
                             )
+                            # Field-churn / false-read telemetry from the
+                            # two-sighting confirmation gate.  Non-zero
+                            # pi/pty churn on a locked, stationary tune is
+                            # a red flag; glitches_rejected shows how many
+                            # single-sighting false reads the gate stopped.
+                            metadata['rbds_pi_change_count'] = decoder_stats.pi_change_count
+                            metadata['rbds_pty_change_count'] = decoder_stats.pty_change_count
+                            metadata['rbds_ta_toggle_count'] = decoder_stats.ta_toggle_count
+                            metadata['rbds_glitches_rejected'] = decoder_stats.glitches_rejected
 
                         # RBDS data (if available)
                         rbds_data = demod_status.rbds_data

--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -960,6 +960,20 @@ class RBDSDecoderStats:
     # Keys are e.g. "0A", "2A", "11A" — bare "A"/"B" suffixes match what
     # the RDS specs use everywhere so the UI doesn't have to translate.
     group_type_counts: Dict[str, int] = field(default_factory=dict)
+    # Field-level churn counters from the two-sighting confirmation gate.
+    # pi/pty/ta count *accepted* value changes after the field first
+    # resolved — on a station that stays tuned these should sit at 0
+    # (a mid-lock PI change means either an actual station change or a
+    # repeated glitch that beat the voting gate).  glitches_rejected
+    # counts single-sighting candidates that were contradicted by the
+    # next observation before they could confirm — i.e. false reads the
+    # gate stopped from reaching the UI.  Unlike the block counters
+    # these are cumulative since tune/reset, not per-lock, because the
+    # decoder's field state also survives a sync drop.
+    pi_change_count: int = 0
+    pty_change_count: int = 0
+    ta_toggle_count: int = 0
+    glitches_rejected: int = 0
 
     @property
     def raw_block_error_rate(self) -> Optional[float]:
@@ -1606,12 +1620,17 @@ class RBDSWorker:
                 chunks_dropped=self._chunks_dropped,
                 group_type_counts={},
             )
-        # Group histogram lives on the RBDSDecoder; pull a copy here so
-        # the snapshot is internally consistent.
+        # Group histogram and field-churn counters live on the
+        # RBDSDecoder; pull copies here so the snapshot is internally
+        # consistent.
         if self._rbds_decoder is not None:
             snap.group_type_counts = dict(
                 getattr(self._rbds_decoder, '_group_type_counts', {}) or {}
             )
+            snap.pi_change_count = getattr(self._rbds_decoder, 'pi_change_count', 0)
+            snap.pty_change_count = getattr(self._rbds_decoder, 'pty_change_count', 0)
+            snap.ta_toggle_count = getattr(self._rbds_decoder, 'ta_toggle_count', 0)
+            snap.glitches_rejected = getattr(self._rbds_decoder, 'glitches_rejected', 0)
         return snap
 
     def reset(self) -> None:
@@ -4119,6 +4138,12 @@ def pi_to_call_sign(pi: int) -> Optional[str]:
     return None
 
 
+# Sentinel for "no pending candidate" in the two-sighting confirmation
+# gate.  Cannot use None because None/False/0 are all legitimate pending
+# field values (e.g. a TA=False candidate).
+_CONFIRM_UNSET = object()
+
+
 class RBDSDecoder:
     """
     RBDS/RDS decoder for FM radio.
@@ -4256,6 +4281,92 @@ class RBDSDecoder:
         # look like a valid cycle).
         self._ps_candidate = None  # type: Optional[str]
         self._ps_candidate_count = 0
+        # Two-sighting confirmation gate for single-shot fields (PI, PTY,
+        # TP, TA, MS, DI bits, fast-switching flags, ODA registrations).
+        # A new value must be observed in two consecutive groups before
+        # it replaces the accepted state, so one corrupted block that
+        # slips past the CRC — or gets "repaired" into the wrong codeword
+        # by burst FEC — can never flip a published field on its own.
+        # These fields repeat continuously on-air (PI/PTY/TP arrive in
+        # every group, TA/MS in every Group 0), so the added latency is
+        # one group spacing (~90 ms to ~1 s).  Keys are attribute names
+        # plus a few synthetic slot keys, so the dict stays bounded.
+        self._confirm_pending: Dict[str, object] = {}
+        # AF frequencies staged on first sighting; promoted to _af_buffer
+        # on the second.  A corrupted Block C that decodes to a plausible
+        # AF code would otherwise pollute the published AF list until the
+        # next retune.  Insertion-ordered dict so noise can be evicted
+        # oldest-first when the staging area fills.
+        self._af_pending: Dict[float, bool] = {}
+        # EON networks staged on first sighting of a new cross-referenced
+        # PI (Group 14 Block C is a prime garbage-injection vector).
+        # Dict rather than a single slot because stations interleave EON
+        # groups across several real networks.
+        self._eon_pending: Dict[int, bool] = {}
+        # Field-churn counters surfaced through RBDSDecoderStats.  See
+        # the dataclass comment for semantics.
+        self.pi_change_count = 0
+        self.pty_change_count = 0
+        self.ta_toggle_count = 0
+        self.glitches_rejected = 0
+
+    def _confirm_value(self, key: str, current: object, new_value: object) -> bool:
+        """Two-consecutive-sighting voting gate.
+
+        Returns True when ``new_value`` differs from ``current`` AND has
+        now been observed twice in a row, i.e. the caller should accept
+        it.  A single observation only stages the value; if the next
+        observation for the same key disagrees with the staged candidate
+        the candidate is discarded (and counted in glitches_rejected),
+        so an isolated false read can never be published.
+        """
+        if new_value == current:
+            # Observation agrees with accepted state; any contrary
+            # staged candidate was a one-off false read.
+            if self._confirm_pending.pop(key, _CONFIRM_UNSET) is not _CONFIRM_UNSET:
+                self.glitches_rejected += 1
+            return False
+        pending = self._confirm_pending.get(key, _CONFIRM_UNSET)
+        if pending is not _CONFIRM_UNSET and pending == new_value:
+            del self._confirm_pending[key]
+            return True
+        if pending is not _CONFIRM_UNSET:
+            # Staged candidate contradicted by a different new value
+            # before it could confirm.
+            self.glitches_rejected += 1
+        self._confirm_pending[key] = new_value
+        return False
+
+    def _confirmed_set(self, attr: str, new_value: object) -> bool:
+        """Apply ``new_value`` to ``self.<attr>`` through the voting gate.
+
+        Returns True only when the attribute actually changed (second
+        consecutive sighting of a differing value).
+        """
+        if self._confirm_value(attr, getattr(self, attr), new_value):
+            setattr(self, attr, new_value)
+            return True
+        return False
+
+    def _stage_eon_pi(self, eon_pi: int) -> bool:
+        """Second-sighting gate for new EON network entries.
+
+        Group 14 Block C carries the cross-referenced PI directly, so a
+        corrupted-but-CRC-passing block injects a phantom network into
+        the EON table that persists until retune.  A new PI must be seen
+        in two Group 14 broadcasts before an entry is created.  Returns
+        True when the caller may create the entry now.
+        """
+        if eon_pi in self._eon_pending:
+            del self._eon_pending[eon_pi]
+            # Hard cap on tracked networks: EON addresses "other networks
+            # of the same broadcaster" — real deployments carry a handful,
+            # the protocol practically tops out well below this.
+            return len(self._eon_map) < 32
+        if len(self._eon_pending) >= 16:
+            self._eon_pending.pop(next(iter(self._eon_pending)))
+        self._eon_pending[eon_pi] = True
+        return False
 
     def process_group(self, group_data: Tuple[int, int, int, int]) -> Optional[bool]:
         """
@@ -4284,25 +4395,28 @@ class RBDSDecoder:
         self._group_type_counts[gt_key] = self._group_type_counts.get(gt_key, 0) + 1
 
         pi_code = f"{a:04X}"
-        if self.pi_code != pi_code:
-            self.pi_code = pi_code
+        prev_pi = self.pi_code
+        if self._confirmed_set('pi_code', pi_code):
             new_call = pi_to_call_sign(a)
             if new_call != self.call_sign:
                 self.call_sign = new_call
+            if prev_pi is not None:
+                self.pi_change_count += 1
             changed = True
 
         pty = (b >> 5) & 0x1F
-        if self.pty != pty:
-            self.pty = pty
+        prev_pty = self.pty
+        if self._confirmed_set('pty', pty):
             # A PTY change invalidates any previously-decoded PTYN for the
             # old program type.
             self.pty_name = None
             self._pty_name_buf = [' '] * 8
+            if prev_pty is not None:
+                self.pty_change_count += 1
             changed = True
 
         tp = bool((b >> 10) & 0x1)
-        if self.tp != tp:
-            self.tp = tp
+        if self._confirmed_set('tp', tp):
             changed = True
 
         # Bits 4-0 of Block B are group-type-dependent. TA (bit 4) and MS
@@ -4312,13 +4426,14 @@ class RBDSDecoder:
         # would corrupt the flags each time a non-Group-0 group arrived.
         if group_type == 0:
             ta = bool((b >> 4) & 0x1)
-            if self.ta != ta:
-                self.ta = ta
+            prev_ta = self.ta
+            if self._confirmed_set('ta', ta):
+                if prev_ta is not None:
+                    self.ta_toggle_count += 1
                 changed = True
 
             ms = bool((b >> 3) & 0x1)
-            if self.ms != ms:
-                self.ms = ms
+            if self._confirmed_set('ms', ms):
                 changed = True
 
             di_bit = bool((b >> 2) & 0x1)
@@ -4369,7 +4484,11 @@ class RBDSDecoder:
                             changed = True
                 if new_freqs:
                     prev_len = len(self._af_buffer)
-                    for f in new_freqs:
+                    # Dedupe within the group (dict preserves order) so a
+                    # Method-B marker pair (af1 == af2) still needs a
+                    # second *group* to confirm, not just a second byte
+                    # from the same possibly-corrupt block.
+                    for f in dict.fromkeys(new_freqs):
                         # RBDS spec caps an AF list at 25 entries (Method A
                         # codes 224..249 encode counts 0..25).  Without a
                         # cap, a bad-CRC-but-presumed-valid block stream on
@@ -4380,7 +4499,24 @@ class RBDSDecoder:
                             break
                         if f in self._af_buffer:
                             continue
-                        self._af_buffer.append(f)
+                        # Second-sighting requirement: an AF only joins the
+                        # published list once it has appeared in two
+                        # separate groups.  AF lists cycle continuously on
+                        # Group 0A, so real entries confirm within a few
+                        # seconds; a corrupted-but-CRC-passing block that
+                        # decodes to a plausible AF code stays staged and
+                        # is eventually evicted instead of polluting the
+                        # list until the next retune.
+                        if f in self._af_pending:
+                            del self._af_pending[f]
+                            self._af_buffer.append(f)
+                        else:
+                            if len(self._af_pending) >= 32:
+                                # Evict the oldest staged candidate —
+                                # anything real will be re-staged by the
+                                # station's ongoing AF cycle.
+                                self._af_pending.pop(next(iter(self._af_pending)))
+                            self._af_pending[f] = True
                     if len(self._af_buffer) != prev_len:
                         changed = True
 
@@ -4446,9 +4582,16 @@ class RBDSDecoder:
             aid = c
             if aid != 0:
                 key = (oda_group_type, oda_version)
-                if key not in self._oda_app_map or self._oda_app_map[key] != aid:
+                # ODA registrations go through the two-sighting gate too:
+                # 3A groups repeat each assignment continuously, and a
+                # corrupted Block C here would otherwise register a
+                # garbage AID that then accumulates payload state forever.
+                confirm_key = f"oda_slot_{oda_group_type}_{oda_version}"
+                if self._confirm_value(confirm_key, self._oda_app_map.get(key), aid):
                     self._oda_app_map[key] = aid
-                    if aid not in self.oda_apps:
+                    # Cap mirrors the 32 possible (group_type, version)
+                    # slots; re-registrations beyond that are noise.
+                    if aid not in self.oda_apps and len(self.oda_apps) < 32:
                         self.oda_apps.append(aid)
                     changed = True
         elif group_type == 4 and not version_b:
@@ -4574,75 +4717,79 @@ class RBDSDecoder:
             variant = b & 0xF
             eon_tp = bool((b >> 4) & 0x1)
             eon_pi = c
-            if eon_pi not in self._eon_map:
+            if eon_pi not in self._eon_map and self._stage_eon_pi(eon_pi):
                 self._eon_map[eon_pi] = {
                     'pi': f"{eon_pi:04X}", 'tp': eon_tp, 'ps': ' ' * 8, 'af': []
                 }
-            eon = self._eon_map[eon_pi]
-            eon['tp'] = eon_tp
-            if variant <= 3:
-                ps_chars = [(d >> 8) & 0xFF, d & 0xFF]
-                ps_list = list(eon['ps'])
-                for i, code in enumerate(ps_chars):
-                    idx = variant * 2 + i
-                    if idx < 8:
-                        ps_list[idx] = chr(code) if 32 <= code < 127 else ' '
-                eon['ps'] = ''.join(ps_list)
-            elif variant == 4:
-                # Block D in EON variant 4 carries TWO 8-bit AF codes:
-                # high byte = mapped frequency for the cross-referenced
-                # programme, low byte = matched frequency for the tuned
-                # programme.  Earlier code dropped the low byte, halving
-                # EON AF coverage; capture both as direct codes 1..204.
-                for shift in (8, 0):
-                    af_code = (d >> shift) & 0xFF
-                    if 1 <= af_code <= 204:
-                        af_mhz = round(87.6 + 0.1 * af_code, 1)
-                        # Cap per-EON AF list at the RBDS spec maximum of
-                        # 25 entries.  Same memory-leak rationale as the
-                        # main station ``_af_buffer`` above: corrupt-but-
-                        # CRC-passing blocks on a noisy signal otherwise
-                        # grow this list unboundedly.
-                        if af_mhz not in eon['af'] and len(eon['af']) < 25:
-                            eon['af'].append(af_mhz)
-            elif variant == 12:
-                eon['linkage'] = d
-            elif variant == 13:
-                eon['pty'] = (d >> 11) & 0x1F
-                eon['ta'] = bool((d >> 0) & 0x1)
-            elif variant == 14:
-                eon['pin_day'] = (d >> 11) & 0x1F
-                eon['pin_hour'] = (d >> 6) & 0x1F
-                eon['pin_minute'] = d & 0x3F
-            changed = True
+            # eon is None while a new PI is still staged (or the table is
+            # at cap) — skip the variant payload for a network we haven't
+            # admitted yet, but still fall through to the ODA dispatch
+            # below in case the station registered an ODA on this slot.
+            eon = self._eon_map.get(eon_pi)
+            if eon is not None:
+                eon['tp'] = eon_tp
+                if variant <= 3:
+                    ps_chars = [(d >> 8) & 0xFF, d & 0xFF]
+                    ps_list = list(eon['ps'])
+                    for i, code in enumerate(ps_chars):
+                        idx = variant * 2 + i
+                        if idx < 8:
+                            ps_list[idx] = chr(code) if 32 <= code < 127 else ' '
+                    eon['ps'] = ''.join(ps_list)
+                elif variant == 4:
+                    # Block D in EON variant 4 carries TWO 8-bit AF codes:
+                    # high byte = mapped frequency for the cross-referenced
+                    # programme, low byte = matched frequency for the tuned
+                    # programme.  Earlier code dropped the low byte, halving
+                    # EON AF coverage; capture both as direct codes 1..204.
+                    for shift in (8, 0):
+                        af_code = (d >> shift) & 0xFF
+                        if 1 <= af_code <= 204:
+                            af_mhz = round(87.6 + 0.1 * af_code, 1)
+                            # Cap per-EON AF list at the RBDS spec maximum of
+                            # 25 entries.  Same memory-leak rationale as the
+                            # main station ``_af_buffer`` above: corrupt-but-
+                            # CRC-passing blocks on a noisy signal otherwise
+                            # grow this list unboundedly.
+                            if af_mhz not in eon['af'] and len(eon['af']) < 25:
+                                eon['af'].append(af_mhz)
+                elif variant == 12:
+                    eon['linkage'] = d
+                elif variant == 13:
+                    eon['pty'] = (d >> 11) & 0x1F
+                    eon['ta'] = bool((d >> 0) & 0x1)
+                elif variant == 14:
+                    eon['pin_day'] = (d >> 11) & 0x1F
+                    eon['pin_hour'] = (d >> 6) & 0x1F
+                    eon['pin_minute'] = d & 0x3F
+                changed = True
         elif group_type == 14 and version_b:
             eon_tp = bool((b >> 4) & 0x1)
             eon_ta = bool((b >> 3) & 0x1)
             eon_pi = c
-            if eon_pi not in self._eon_map:
+            if eon_pi not in self._eon_map and self._stage_eon_pi(eon_pi):
                 self._eon_map[eon_pi] = {
                     'pi': f"{eon_pi:04X}", 'tp': eon_tp, 'ta': eon_ta,
                     'ps': ' ' * 8, 'af': []
                 }
-            self._eon_map[eon_pi]['tp'] = eon_tp
-            self._eon_map[eon_pi]['ta'] = eon_ta
-            changed = True
+            if eon_pi in self._eon_map:
+                self._eon_map[eon_pi]['tp'] = eon_tp
+                self._eon_map[eon_pi]['ta'] = eon_ta
+                changed = True
         elif group_type == 15 and version_b:
             fast_ta = bool((b >> 4) & 0x1)
             fast_ms = bool((b >> 3) & 0x1)
             fast_di = bool((b >> 2) & 0x1)
             address = b & 0x3
-            changed_flags = False
-            if self.fast_tp != tp:
-                self.fast_tp = tp
-                changed_flags = True
-            if self.fast_ta != fast_ta:
-                self.fast_ta = fast_ta
-                changed_flags = True
-            if self.fast_ms != fast_ms:
-                self.fast_ms = fast_ms
-                changed_flags = True
-            if changed_flags:
+            # Same two-sighting gate as the main flags.  15B exists for
+            # fast switching, but stations that use it send it in bursts,
+            # so confirmation still lands within one burst while a lone
+            # corrupted 15B can no longer flap the fast flags.
+            if self._confirmed_set('fast_tp', tp):
+                changed = True
+            if self._confirmed_set('fast_ta', fast_ta):
+                changed = True
+            if self._confirmed_set('fast_ms', fast_ms):
                 changed = True
             if self._update_di(address, fast_di):
                 changed = True
@@ -4662,11 +4809,14 @@ class RBDSDecoder:
             if oda_aid == RT_PLUS_AID:
                 if self._handle_rt_plus(b, c, d):
                     changed = True
-            else:
+            elif oda_aid in self._oda_payloads or len(self._oda_payloads) < 32:
                 # Capture the lower 5 bits of B (the payload nibble — the
                 # rest of B is group-type / TP / PTY which we already
                 # decoded) plus all of C and D.  Bump count and stamp
                 # last-seen so the UI can show traffic activity per AID.
+                # Capped at 32 AIDs (the number of registrable slots) so
+                # this dict can't grow without bound across spurious
+                # re-registrations on a long-running noisy receiver.
                 entry = self._oda_payloads.setdefault(oda_aid, {
                     'aid': oda_aid,
                     'aid_hex': f"0x{oda_aid:04X}",
@@ -5106,10 +5256,10 @@ class RBDSDecoder:
         }.get(address)
         if attr is None:
             return False
-        if getattr(self, attr) != di_bit:
-            setattr(self, attr, di_bit)
-            return True
-        return False
+        # Routed through the two-sighting gate: each DI bit repeats once
+        # per PS cycle (~1 s), so confirmation costs one extra cycle and
+        # stops a single corrupt Group 0 from flapping e.g. stereo/mono.
+        return self._confirmed_set(attr, di_bit)
 
     def _update_clock_time(
         self,

--- a/app_core/radio/demodulation.py
+++ b/app_core/radio/demodulation.py
@@ -4587,10 +4587,23 @@ class RBDSDecoder:
                 # corrupted Block C here would otherwise register a
                 # garbage AID that then accumulates payload state forever.
                 confirm_key = f"oda_slot_{oda_group_type}_{oda_version}"
-                if self._confirm_value(confirm_key, self._oda_app_map.get(key), aid):
+                old_aid = self._oda_app_map.get(key)
+                if self._confirm_value(confirm_key, old_aid, aid):
                     self._oda_app_map[key] = aid
-                    # Cap mirrors the 32 possible (group_type, version)
-                    # slots; re-registrations beyond that are noise.
+                    # Evict the superseded AID (unless another slot still
+                    # carries it) so oda_apps/_oda_payloads track only
+                    # currently-registered applications.  Without this,
+                    # slot churn fills the cap with stale AIDs and a
+                    # *current* AID can no longer be listed or have its
+                    # payload traffic tracked.
+                    if (old_aid is not None and old_aid != aid
+                            and old_aid not in self._oda_app_map.values()):
+                        if old_aid in self.oda_apps:
+                            self.oda_apps.remove(old_aid)
+                        self._oda_payloads.pop(old_aid, None)
+                    # With eviction above, oda_apps is bounded by the 32
+                    # possible (group_type, version) slots; the explicit
+                    # cap stays as belt-and-suspenders.
                     if aid not in self.oda_apps and len(self.oda_apps) < 32:
                         self.oda_apps.append(aid)
                     changed = True
@@ -4791,6 +4804,24 @@ class RBDSDecoder:
                 changed = True
             if self._confirmed_set('fast_ms', fast_ms):
                 changed = True
+            # Accumulate the dedicated fast_di_bits nibble (bit per PS
+            # segment address) through the same gate, so the UI's 15B
+            # panel reflects what arrived on the fast channel.
+            current_fast_di = (
+                None if self.fast_di_bits is None
+                else bool((self.fast_di_bits >> address) & 0x1)
+            )
+            if self._confirm_value(f'fast_di_{address}', current_fast_di, fast_di):
+                bits = self.fast_di_bits or 0
+                if fast_di:
+                    bits |= (1 << address)
+                else:
+                    bits &= ~(1 << address)
+                self.fast_di_bits = bits
+                changed = True
+            # 15B carries the same decoder-identification bits as Group 0
+            # (EN 50067 §3.1.5.2), so they legitimately update the main DI
+            # fields too — also behind the confirmation gate.
             if self._update_di(address, fast_di):
                 changed = True
             if self._update_ps_name(address, d):
@@ -5023,7 +5054,7 @@ class RBDSDecoder:
             fast_tp=self.fast_tp,
             fast_ta=self.fast_ta,
             fast_ms=self.fast_ms,
-            fast_di_bits=None,
+            fast_di_bits=self.fast_di_bits,
             rt_plus_item_running=self._rt_plus_item_running,
             rt_plus_item_toggle=self._rt_plus_item_toggle,
             rt_plus_tags=(

--- a/static/js/core/nav-enhance.js
+++ b/static/js/core/nav-enhance.js
@@ -1,0 +1,392 @@
+/**
+ * EAS Station™ — Global navigation enhancements
+ *
+ *  1. Command palette (Ctrl/Cmd+K): fuzzy-search every page reachable from
+ *     the navbar and jump straight to it, bypassing nested dropdowns.
+ *  2. Breadcrumb trail: derives "Section › Group › Page" for the current
+ *     URL from the navbar structure and renders it under the navbar.
+ *
+ * Both features index the *rendered* navbar DOM rather than a separate page
+ * registry, so they automatically respect permission-based visibility
+ * (links the current user can't see are never indexed) and stay correct
+ * whenever the navbar changes.
+ */
+(function () {
+    'use strict';
+
+    // ---- Page index from the navbar DOM -----------------------------------
+
+    function cleanText(el) {
+        return (el ? el.textContent : '').replace(/\s+/g, ' ').trim();
+    }
+
+    function buildIndex() {
+        const entries = [];
+        const seen = new Set();
+        const nav = document.querySelector('.navbar');
+        if (!nav) return entries;
+
+        function add(label, href, trail) {
+            if (!label || !href || href === '#' || href.startsWith('javascript:')) return;
+            const key = `${label}|${href}`;
+            if (seen.has(key)) return;
+            seen.add(key);
+            entries.push({ label, href, trail: trail || [] });
+        }
+
+        nav.querySelectorAll('.navbar-nav > .nav-item').forEach((item) => {
+            const toggle = item.querySelector(':scope > .nav-link');
+            const section = cleanText(toggle);
+            const menu = item.querySelector(':scope > .dropdown-menu');
+
+            if (!menu) {
+                if (toggle) add(section, toggle.getAttribute('href'), []);
+                return;
+            }
+
+            let group = '';
+            menu.querySelectorAll(':scope > li').forEach((li) => {
+                const header = li.querySelector(':scope > .dropdown-header');
+                if (header) {
+                    group = cleanText(header);
+                    return;
+                }
+                const link = li.querySelector(':scope > a.dropdown-item[href]');
+                if (!link) return;
+                const trail = [section];
+                if (group) trail.push(group);
+                add(cleanText(link), link.getAttribute('href'), trail);
+            });
+        });
+
+        return entries;
+    }
+
+    // ---- Styles (injected so the feature stays self-contained) ------------
+
+    function injectStyles() {
+        const style = document.createElement('style');
+        style.textContent = `
+            .eas-breadcrumbs {
+                padding: .35rem 1rem;
+                font-size: .82rem;
+                border-bottom: 1px solid var(--bs-border-color, rgba(128,128,128,.25));
+                background: var(--bs-tertiary-bg, transparent);
+                display: flex;
+                align-items: center;
+                gap: .35rem;
+                flex-wrap: wrap;
+            }
+            .eas-breadcrumbs a { text-decoration: none; }
+            .eas-breadcrumbs .eas-crumb-sep { opacity: .45; }
+            .eas-breadcrumbs .eas-crumb-current { font-weight: 600; }
+            .eas-palette-backdrop {
+                position: fixed; inset: 0; z-index: 10500;
+                background: rgba(0,0,0,.45);
+                display: flex; align-items: flex-start; justify-content: center;
+                padding-top: 12vh;
+            }
+            .eas-palette {
+                width: min(620px, 92vw);
+                background: var(--bs-body-bg, #fff);
+                color: var(--bs-body-color, #111);
+                border: 1px solid var(--bs-border-color, rgba(128,128,128,.35));
+                border-radius: 10px;
+                box-shadow: 0 18px 50px rgba(0,0,0,.35);
+                overflow: hidden;
+            }
+            .eas-palette input {
+                width: 100%;
+                border: none; outline: none;
+                background: transparent; color: inherit;
+                font-size: 1.05rem;
+                padding: .85rem 1rem;
+                border-bottom: 1px solid var(--bs-border-color, rgba(128,128,128,.25));
+            }
+            .eas-palette ul {
+                list-style: none; margin: 0; padding: .35rem;
+                max-height: 50vh; overflow-y: auto;
+            }
+            .eas-palette li {
+                display: flex; align-items: baseline; gap: .6rem;
+                padding: .45rem .65rem;
+                border-radius: 6px;
+                cursor: pointer;
+            }
+            .eas-palette li.active {
+                background: var(--bs-primary, #0d6efd);
+                color: #fff;
+            }
+            .eas-palette li.active .eas-palette-trail { color: rgba(255,255,255,.75); }
+            .eas-palette-trail {
+                font-size: .75rem;
+                color: var(--bs-secondary-color, #888);
+                margin-left: auto;
+                white-space: nowrap;
+            }
+            .eas-palette-empty {
+                padding: 1rem; text-align: center;
+                color: var(--bs-secondary-color, #888);
+                font-size: .9rem;
+            }
+            .eas-palette-hint {
+                padding: .35rem .9rem;
+                font-size: .72rem;
+                color: var(--bs-secondary-color, #888);
+                border-top: 1px solid var(--bs-border-color, rgba(128,128,128,.25));
+                display: flex; gap: 1rem;
+            }
+            .eas-palette-hint kbd {
+                font-size: .7rem; padding: .05rem .35rem;
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    // ---- Breadcrumbs -------------------------------------------------------
+
+    function pathOf(href) {
+        try {
+            const u = new URL(href, window.location.origin);
+            return { path: u.pathname.replace(/\/+$/, '') || '/', search: u.search };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function findCurrentEntry(entries) {
+        const here = pathOf(window.location.href);
+        if (!here) return null;
+        let pathMatch = null;
+        for (const entry of entries) {
+            const target = pathOf(entry.href);
+            if (!target || target.path !== here.path) continue;
+            // Query-string–distinguished pages (e.g. /logs?type=audit) need
+            // the search to match too; a bare path match is the fallback.
+            if (target.search && target.search === here.search) return entry;
+            if (!target.search && !pathMatch) pathMatch = entry;
+        }
+        return pathMatch;
+    }
+
+    function renderBreadcrumbs(entries) {
+        if (window.location.pathname === '/') return;
+        const entry = findCurrentEntry(entries);
+        if (!entry || !entry.trail.length) return;
+        const main = document.querySelector('main.page-shell');
+        if (!main) return;
+
+        const nav = document.createElement('nav');
+        nav.className = 'eas-breadcrumbs';
+        nav.setAttribute('aria-label', 'Breadcrumb');
+
+        const frag = document.createDocumentFragment();
+        const home = document.createElement('a');
+        home.href = '/';
+        home.innerHTML = '<i class="fas fa-gauge-high" aria-hidden="true"></i> Dashboard';
+        frag.appendChild(home);
+
+        for (const part of entry.trail) {
+            const sep = document.createElement('span');
+            sep.className = 'eas-crumb-sep';
+            sep.textContent = '›';
+            frag.appendChild(sep);
+            const span = document.createElement('span');
+            span.textContent = part;
+            frag.appendChild(span);
+        }
+
+        const sep = document.createElement('span');
+        sep.className = 'eas-crumb-sep';
+        sep.textContent = '›';
+        frag.appendChild(sep);
+        const current = document.createElement('span');
+        current.className = 'eas-crumb-current';
+        current.setAttribute('aria-current', 'page');
+        current.textContent = entry.label;
+        frag.appendChild(current);
+
+        nav.appendChild(frag);
+        main.parentNode.insertBefore(nav, main);
+    }
+
+    // ---- Command palette ---------------------------------------------------
+
+    function scoreEntry(entry, query) {
+        // Lower is better; null means no match. Match against the label
+        // first, then the trail, then the URL.
+        const q = query.toLowerCase();
+        const label = entry.label.toLowerCase();
+        const haystacks = [
+            { text: label, weight: 0 },
+            { text: entry.trail.join(' ').toLowerCase(), weight: 40 },
+            { text: entry.href.toLowerCase(), weight: 60 },
+        ];
+        let best = null;
+        for (const { text, weight } of haystacks) {
+            if (!text) continue;
+            const idx = text.indexOf(q);
+            if (idx >= 0) {
+                const s = weight + idx + text.length * 0.01;
+                if (best === null || s < best) best = s;
+                continue;
+            }
+            // Subsequence fallback ("sdrdiag" → "SDR Diagnostics").
+            let ti = 0, ok = true;
+            for (const ch of q) {
+                ti = text.indexOf(ch, ti);
+                if (ti < 0) { ok = false; break; }
+                ti += 1;
+            }
+            if (ok) {
+                const s = weight + 100 + text.length * 0.01;
+                if (best === null || s < best) best = s;
+            }
+        }
+        return best;
+    }
+
+    function createPalette(entries) {
+        let backdrop = null;
+        let activeIdx = 0;
+        let results = [];
+
+        function close() {
+            if (backdrop) {
+                backdrop.remove();
+                backdrop = null;
+            }
+        }
+
+        function navigate(entry) {
+            if (entry) window.location.href = entry.href;
+        }
+
+        function render(listEl, query) {
+            results = !query
+                ? entries.slice(0, 12)
+                : entries
+                    .map(e => ({ e, s: scoreEntry(e, query) }))
+                    .filter(r => r.s !== null)
+                    .sort((a, b) => a.s - b.s)
+                    .slice(0, 12)
+                    .map(r => r.e);
+            activeIdx = 0;
+
+            if (!results.length) {
+                listEl.innerHTML = '<div class="eas-palette-empty">No matching pages</div>';
+                return;
+            }
+            listEl.innerHTML = '';
+            results.forEach((entry, i) => {
+                const li = document.createElement('li');
+                li.className = i === activeIdx ? 'active' : '';
+                li.setAttribute('role', 'option');
+                const label = document.createElement('span');
+                label.textContent = entry.label;
+                li.appendChild(label);
+                if (entry.trail.length) {
+                    const trail = document.createElement('span');
+                    trail.className = 'eas-palette-trail';
+                    trail.textContent = entry.trail.join(' › ');
+                    li.appendChild(trail);
+                }
+                li.addEventListener('mouseenter', () => {
+                    listEl.querySelectorAll('li').forEach(n => n.classList.remove('active'));
+                    li.classList.add('active');
+                    activeIdx = i;
+                });
+                li.addEventListener('click', () => navigate(entry));
+                listEl.appendChild(li);
+            });
+        }
+
+        function moveActive(listEl, delta) {
+            if (!results.length) return;
+            activeIdx = (activeIdx + delta + results.length) % results.length;
+            listEl.querySelectorAll('li').forEach((n, i) => {
+                n.classList.toggle('active', i === activeIdx);
+                if (i === activeIdx) n.scrollIntoView({ block: 'nearest' });
+            });
+        }
+
+        function open() {
+            if (backdrop) { close(); return; }
+            backdrop = document.createElement('div');
+            backdrop.className = 'eas-palette-backdrop';
+            backdrop.addEventListener('mousedown', (ev) => {
+                if (ev.target === backdrop) close();
+            });
+
+            const box = document.createElement('div');
+            box.className = 'eas-palette';
+            box.setAttribute('role', 'dialog');
+            box.setAttribute('aria-label', 'Page search');
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.placeholder = 'Jump to a page…';
+            input.setAttribute('aria-label', 'Search pages');
+
+            const list = document.createElement('ul');
+            list.setAttribute('role', 'listbox');
+
+            const hint = document.createElement('div');
+            hint.className = 'eas-palette-hint';
+            hint.innerHTML = '<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>'
+                + '<span><kbd>Enter</kbd> open</span><span><kbd>Esc</kbd> close</span>';
+
+            input.addEventListener('input', () => render(list, input.value.trim()));
+            input.addEventListener('keydown', (ev) => {
+                if (ev.key === 'ArrowDown') { ev.preventDefault(); moveActive(list, 1); }
+                else if (ev.key === 'ArrowUp') { ev.preventDefault(); moveActive(list, -1); }
+                else if (ev.key === 'Enter') { ev.preventDefault(); navigate(results[activeIdx]); }
+                else if (ev.key === 'Escape') { ev.preventDefault(); close(); }
+            });
+
+            box.appendChild(input);
+            box.appendChild(list);
+            box.appendChild(hint);
+            backdrop.appendChild(box);
+            document.body.appendChild(backdrop);
+            render(list, '');
+            input.focus();
+        }
+
+        document.addEventListener('keydown', (ev) => {
+            if ((ev.ctrlKey || ev.metaKey) && !ev.shiftKey && !ev.altKey
+                    && (ev.key === 'k' || ev.key === 'K')) {
+                ev.preventDefault();
+                open();
+            } else if (ev.key === 'Escape' && backdrop) {
+                close();
+            }
+        });
+
+        return { open, close };
+    }
+
+    function addNavbarButton(palette) {
+        const host = document.querySelector('.navbar .navbar-sections');
+        if (!host) return;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-sm btn-outline-secondary d-none d-lg-inline-flex align-items-center gap-1 ms-2';
+        btn.setAttribute('aria-label', 'Search pages (Ctrl+K)');
+        btn.title = 'Search pages (Ctrl+K)';
+        btn.innerHTML = '<i class="fas fa-magnifying-glass" aria-hidden="true"></i>'
+            + '<kbd class="small" style="font-size:.65rem;">Ctrl K</kbd>';
+        btn.addEventListener('click', palette.open);
+        host.appendChild(btn);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const entries = buildIndex();
+        if (!entries.length) return;
+        injectStyles();
+        renderBreadcrumbs(entries);
+        const palette = createPalette(entries);
+        addNavbarButton(palette);
+        window.EASCommandPalette = palette;
+    });
+})();

--- a/static/js/rbds_visualization.js
+++ b/static/js/rbds_visualization.js
@@ -1016,6 +1016,17 @@
                 : '—';
             const drops = isPresent(metadata.rbds_sync_lost_count) ? metadata.rbds_sync_lost_count : '—';
             const dropped = isPresent(metadata.rbds_chunks_dropped) ? metadata.rbds_chunks_dropped : '—';
+            // Field-churn telemetry from the decoder's two-sighting
+            // confirmation gate.  PI/PTY changing while tuned to one
+            // station is suspicious, so those get a warning tint.
+            const piChurn = isPresent(metadata.rbds_pi_change_count) ? Number(metadata.rbds_pi_change_count) : null;
+            const ptyChurn = isPresent(metadata.rbds_pty_change_count) ? Number(metadata.rbds_pty_change_count) : null;
+            const taToggles = isPresent(metadata.rbds_ta_toggle_count) ? metadata.rbds_ta_toggle_count : '—';
+            const glitches = isPresent(metadata.rbds_glitches_rejected) ? metadata.rbds_glitches_rejected : '—';
+            const churnText = (piChurn === null && ptyChurn === null)
+                ? '—'
+                : `${piChurn === null ? '—' : piChurn} / ${ptyChurn === null ? '—' : ptyChurn}`;
+            const churnWarn = (piChurn > 0 || ptyChurn > 0) ? 'text-warning' : '';
 
             syncBlock = (
                 `<div class="rbds-health__section" aria-label="Decoder synchronisation health">` +
@@ -1034,6 +1045,9 @@
                 `<div><dt>Synced for</dt><dd class="font-monospace">${escapeHtml(syncedFor)}</dd></div>` +
                 `<div><dt>Sync drops</dt><dd class="font-monospace">${escapeHtml(drops)}</dd></div>` +
                 `<div><dt>Queue chunks dropped</dt><dd class="font-monospace ${Number(dropped) > 0 ? 'text-warning' : ''}">${escapeHtml(dropped)}</dd></div>` +
+                `<div><dt title="Confirmed PI / PTY changes since tune — should stay 0 on a stationary tune">PI / PTY changes</dt><dd class="font-monospace ${churnWarn}">${escapeHtml(churnText)}</dd></div>` +
+                `<div><dt title="Confirmed Traffic Announcement on/off transitions">TA toggles</dt><dd class="font-monospace">${escapeHtml(taToggles)}</dd></div>` +
+                `<div><dt title="Single-sighting field values contradicted before confirmation — false reads the voting gate stopped">Noise reads rejected</dt><dd class="font-monospace">${escapeHtml(glitches)}</dd></div>` +
                 `</dl>` +
                 `</div>`
             );

--- a/templates/admin/radio_diagnostics.html
+++ b/templates/admin/radio_diagnostics.html
@@ -377,6 +377,55 @@ sudo systemctl restart eas-station</code></pre>
     </div>
 </div>
 
+<!-- RBDS History modal — lives outside the auto-refreshed containers so the
+     chart and scroll position survive the periodic re-render of the RBDS
+     decoder cards. Opened from the per-source "History" button. -->
+<div class="modal fade" id="rbdsHistoryModal" tabindex="-1" aria-labelledby="rbdsHistoryModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="rbdsHistoryModalLabel">
+                    <i class="fas fa-clock-rotate-left me-2" aria-hidden="true"></i>RBDS History
+                </h5>
+                <select id="rbdsHistoryRange" class="form-select form-select-sm w-auto ms-3" aria-label="History time range">
+                    <option value="60" selected>Last hour</option>
+                    <option value="360">Last 6 hours</option>
+                    <option value="1440">Last 24 hours</option>
+                </select>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div id="rbdsHistoryStatus" class="text-center text-muted py-3">
+                    <i class="fas fa-spinner fa-spin me-2" aria-hidden="true"></i>Loading history…
+                </div>
+                <div id="rbdsHistoryContent" style="display:none;">
+                    <h6 class="text-muted">Block Error Rate</h6>
+                    <div style="position:relative;height:220px;">
+                        <canvas id="rbdsHistoryChart" aria-label="Raw and net block error rate over time" role="img"></canvas>
+                    </div>
+                    <h6 class="text-muted mt-4">Field Changes
+                        <span class="small fw-normal">(PS, RadioText, TA, PI, PTY, lock transitions)</span>
+                    </h6>
+                    <div class="table-responsive" style="max-height:280px;overflow-y:auto;">
+                        <table class="table table-sm table-hover align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Time</th>
+                                    <th scope="col">Field</th>
+                                    <th scope="col">From</th>
+                                    <th scope="col">To</th>
+                                </tr>
+                            </thead>
+                            <tbody id="rbdsHistoryEvents"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='vendor/chartjs/chart-v3.min.js') }}"></script>
 <script>
 (() => {
     let autoRefreshHandle = null;
@@ -790,6 +839,11 @@ sudo systemctl restart eas-station</code></pre>
                         <header class="d-flex align-items-center gap-2 mb-2">
                             <h5 class="mb-0">${escape(displayName)}</h5>
                             ${ident ? `<code class="text-muted small">${escape(ident)}</code>` : ''}
+                            <button type="button" class="btn btn-sm btn-outline-info ms-auto"
+                                    data-rbds-history-source="${escape(s.name)}"
+                                    data-rbds-history-label="${escape(displayName)}">
+                                <i class="fas fa-clock-rotate-left me-1" aria-hidden="true"></i>History
+                            </button>
                         </header>
                         ${stationCard}
                         ${healthCard}
@@ -812,6 +866,149 @@ sudo systemctl restart eas-station</code></pre>
                 </div>
             `;
         }
+    }
+
+    // ---- RBDS history modal ----------------------------------------------
+    // BLER trend + field-change log served by
+    // /api/audio/sources/<name>/rbds/history. The modal lives outside the
+    // auto-refreshed container so the chart survives card re-renders; the
+    // History buttons inside the cards are wired via event delegation for
+    // the same reason.
+    let rbdsHistorySource = null;
+    let rbdsHistoryChart = null;
+
+    function escapeHistText(s) {
+        return (window.RBDSViz && window.RBDSViz.escapeHtml)
+            ? window.RBDSViz.escapeHtml(s)
+            : String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    }
+
+    async function loadRbdsHistory() {
+        const statusEl = document.getElementById('rbdsHistoryStatus');
+        const contentEl = document.getElementById('rbdsHistoryContent');
+        const eventsEl = document.getElementById('rbdsHistoryEvents');
+        const rangeEl = document.getElementById('rbdsHistoryRange');
+        if (!rbdsHistorySource || !statusEl || !contentEl) return;
+
+        statusEl.style.display = '';
+        statusEl.innerHTML = '<i class="fas fa-spinner fa-spin me-2" aria-hidden="true"></i>Loading history…';
+        contentEl.style.display = 'none';
+
+        try {
+            const minutes = rangeEl ? rangeEl.value : 60;
+            const resp = await fetch(
+                `/api/audio/sources/${encodeURIComponent(rbdsHistorySource)}/rbds/history?minutes=${minutes}`,
+                { cache: 'no-store' }
+            );
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+            const data = await resp.json();
+            const points = Array.isArray(data.points) ? data.points : [];
+            const events = Array.isArray(data.events) ? data.events : [];
+
+            if (!points.length && !events.length) {
+                statusEl.innerHTML = '<i class="fas fa-circle-info me-2" aria-hidden="true"></i>'
+                    + 'No stored RBDS snapshots in this window yet.';
+                return;
+            }
+
+            const labels = points.map(p => {
+                const d = p.t ? new Date(p.t) : null;
+                return d ? d.toLocaleTimeString() : '—';
+            });
+            const pct = v => (v === null || v === undefined) ? null : Number(v) * 100;
+
+            if (rbdsHistoryChart) {
+                rbdsHistoryChart.destroy();
+                rbdsHistoryChart = null;
+            }
+            const canvas = document.getElementById('rbdsHistoryChart');
+            if (canvas && window.Chart) {
+                rbdsHistoryChart = new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                label: 'Raw BLER %',
+                                data: points.map(p => pct(p.raw_bler)),
+                                borderColor: '#f0ad4e',
+                                backgroundColor: 'rgba(240,173,78,.15)',
+                                pointRadius: 0,
+                                borderWidth: 1.5,
+                                tension: .25,
+                                spanGaps: true,
+                            },
+                            {
+                                label: 'Net BLER % (after FEC)',
+                                data: points.map(p => pct(p.net_bler)),
+                                borderColor: '#d9534f',
+                                backgroundColor: 'rgba(217,83,79,.15)',
+                                pointRadius: 0,
+                                borderWidth: 1.5,
+                                tension: .25,
+                                spanGaps: true,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        interaction: { mode: 'index', intersect: false },
+                        scales: {
+                            y: { beginAtZero: true, ticks: { callback: v => v + '%' } },
+                            x: { ticks: { maxTicksLimit: 10, autoSkip: true } },
+                        },
+                        plugins: { legend: { labels: { boxWidth: 18 } } },
+                    },
+                });
+            }
+
+            if (eventsEl) {
+                // Newest first — that's what an operator scrolls back for.
+                eventsEl.innerHTML = events.slice().reverse().map(ev => {
+                    const t = ev.t ? new Date(ev.t).toLocaleTimeString() : '—';
+                    const fmt = v => (typeof v === 'boolean') ? (v ? 'On' : 'Off') : String(v ?? '—');
+                    return `
+                        <tr>
+                            <td class="font-monospace small">${escapeHistText(t)}</td>
+                            <td>${escapeHistText(ev.field)}</td>
+                            <td class="small text-muted">${escapeHistText(fmt(ev.from))}</td>
+                            <td class="small">${escapeHistText(fmt(ev.to))}</td>
+                        </tr>
+                    `;
+                }).join('') || '<tr><td colspan="4" class="text-muted text-center">No field changes in this window.</td></tr>';
+            }
+
+            statusEl.style.display = 'none';
+            contentEl.style.display = '';
+        } catch (error) {
+            console.error('Failed to load RBDS history:', error);
+            statusEl.innerHTML = `<i class="fas fa-exclamation-triangle me-2" aria-hidden="true"></i>`
+                + `Couldn't load history: ${escapeHistText(error.message)}`;
+        }
+    }
+
+    document.addEventListener('click', (ev) => {
+        const btn = ev.target.closest('[data-rbds-history-source]');
+        if (!btn) return;
+        rbdsHistorySource = btn.getAttribute('data-rbds-history-source');
+        const label = btn.getAttribute('data-rbds-history-label') || rbdsHistorySource;
+        const titleEl = document.getElementById('rbdsHistoryModalLabel');
+        if (titleEl) {
+            titleEl.innerHTML = '<i class="fas fa-clock-rotate-left me-2" aria-hidden="true"></i>'
+                + `RBDS History — ${escapeHistText(label)}`;
+        }
+        const modalEl = document.getElementById('rbdsHistoryModal');
+        if (modalEl && window.bootstrap) {
+            bootstrap.Modal.getOrCreateInstance(modalEl).show();
+        }
+        loadRbdsHistory();
+    });
+
+    const rbdsHistoryRangeEl = document.getElementById('rbdsHistoryRange');
+    if (rbdsHistoryRangeEl) {
+        rbdsHistoryRangeEl.addEventListener('change', loadRbdsHistory);
     }
 
     async function loadDiagnostics() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -275,6 +275,9 @@
     <script defer src="{{ url_for('static', filename='js/core/health.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/core/utils.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/core/units.js') }}?v={{ static_asset_version }}"></script>
+    <!-- Command palette (Ctrl/Cmd+K) + breadcrumb trail, both derived from
+         the rendered navbar so they respect permission-based visibility -->
+    <script defer src="{{ url_for('static', filename='js/core/nav-enhance.js') }}?v={{ static_asset_version }}"></script>
     <script defer src="{{ url_for('static', filename='js/loading-error-utils.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/accessibility-utils.js') }}"></script>
     <!-- Tab-title alert-count badge + new-alert toasts (depends on websocket + showToast above) -->

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -1321,9 +1321,12 @@ def test_group_0a_decodes_ta_ms_and_ps():
 
     # segment 0, TA=1, MS=1, DI=0 → low 5 bits = 0b11000 = 0x18
     b = _pack_block_b(group_type=0, version_b=False, tp=True, pty=5, low_bits=0x18)
+    # Single-shot fields (PI/PTY/TP/TA/MS) go through the two-sighting
+    # confirmation gate, so the same group must be observed twice before
+    # the values are published.
+    decoder.process_group((pi, b, 0x0000, (ord("E") << 8) | ord("A")))
     decoder.process_group((pi, b, 0x0000, (ord("E") << 8) | ord("A")))
 
-    # The flags read from any Group 0 land immediately.
     data = decoder.get_current_data()
     assert data.pi_code == "4FB5"
     assert data.pty == 5
@@ -1348,9 +1351,11 @@ def test_group_2_does_not_clobber_ta_ms():
     decoder = RBDSDecoder()
     pi = 0x4FB5
 
-    # First seed the decoder with a Group 0A carrying TA=0, MS=0
+    # First seed the decoder with a Group 0A carrying TA=0, MS=0 (twice,
+    # to satisfy the two-sighting confirmation gate)
     b0 = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0b00000)
     decoder.process_group((pi, b0, 0x0000, 0x2020))  # "  " PS chars
+    decoder.process_group((pi, b0, 0x0000, 0x2020))
     assert decoder.ta is False
     assert decoder.ms is False
 
@@ -1445,6 +1450,9 @@ def test_pi_to_call_sign_out_of_range():
 def test_decoder_populates_call_sign_from_pi():
     decoder = RBDSDecoder()
     b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
+    # PI needs two consecutive sightings before it (and the derived call
+    # sign) are published.
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
     decoder.process_group((0x5862, b, 0x0000, 0x2020))
     assert decoder.get_current_data().call_sign == "WBKS"
 
@@ -1495,11 +1503,13 @@ def test_decoder_pty_name_from_group_10a():
 def test_decoder_di_bits_from_group_0():
     decoder = RBDSDecoder()
 
-    # Address 3 -> stereo bit (d0). DI bit = 1 on segment 3.
-    for addr, di in [(0, True), (1, False), (2, False), (3, True)]:
-        low = (di << 2) | addr  # bit 2 = DI, bits 1..0 = address
-        b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=low)
-        decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    # Address 3 -> stereo bit (d0). DI bit = 1 on segment 3.  Each DI bit
+    # goes through the two-sighting gate, so run two full PS cycles.
+    for _cycle in range(2):
+        for addr, di in [(0, True), (1, False), (2, False), (3, True)]:
+            low = (di << 2) | addr  # bit 2 = DI, bits 1..0 = address
+            b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=low)
+            decoder.process_group((0x5862, b, 0x0000, 0x2020))
 
     data = decoder.get_current_data()
     assert data.di_dynamic_pty is True    # address 0
@@ -1683,6 +1693,8 @@ def test_group_0a_decodes_af_list():
     # AF codes: 1 = 87.7 MHz, 2 = 87.8 MHz
     af_c = (1 << 8) | 2
     b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
+    # An AF only joins the published list on its second sighting.
+    decoder.process_group((0x5862, b, af_c, 0x2020))
     decoder.process_group((0x5862, b, af_c, 0x2020))
     data = decoder.get_current_data()
     assert data.af_list is not None
@@ -1701,11 +1713,13 @@ def test_group_0a_af_list_capped_at_spec_maximum():
     """
     decoder = RBDSDecoder()
     b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
-    # Push 60 unique AF codes (1..120, two per group). Without the cap this
-    # would leave 60 entries in af_list; with the cap it stops at 25.
+    # Push 60 unique AF codes (1..120, two per group), each group sent
+    # twice so the codes clear the second-sighting gate. Without the cap
+    # this would leave 60 entries in af_list; with the cap it stops at 25.
     for code1 in range(1, 121, 2):
         code2 = code1 + 1
         af_c = (code1 << 8) | code2
+        decoder.process_group((0x5862, b, af_c, 0x2020))
         decoder.process_group((0x5862, b, af_c, 0x2020))
     data = decoder.get_current_data()
     assert data.af_list is not None
@@ -1760,8 +1774,10 @@ def test_group_1a_decodes_linkage():
 def test_group_3a_registers_oda_app():
     """Group 3A, AID=0x4BD7 (RDS-TMC) → oda_apps contains 0x4BD7."""
     decoder = RBDSDecoder()
-    # Block B: group_type=3, version_b=False, ODA group type bits in low 5
+    # Block B: group_type=3, version_b=False, ODA group type bits in low 5.
+    # Registrations clear the two-sighting gate on the second 3A group.
     b = _pack_block_b(group_type=3, version_b=False, tp=False, pty=0, low_bits=0x10)
+    decoder.process_group((0x5862, b, 0x4BD7, 0x0000))
     decoder.process_group((0x5862, b, 0x4BD7, 0x0000))
     data = decoder.get_current_data()
     assert data.oda_apps is not None
@@ -1804,11 +1820,15 @@ def test_group_14a_decodes_eon_ps():
     decoder = RBDSDecoder()
     eon_pi = 0x1234
     ps = "WXYZ-FM "
-    for variant in range(4):
-        low_bits = variant  # bits 3-0 = variant; bit 4 = eon_tp
-        b = _pack_block_b(group_type=14, version_b=False, tp=False, pty=0, low_bits=low_bits)
-        c1, c2 = ps[variant * 2], ps[variant * 2 + 1]
-        decoder.process_group((0x5862, b, eon_pi, (ord(c1) << 8) | ord(c2)))
+    # Two passes: the first sighting of a new EON PI only stages it, so
+    # variant 0 of pass one is consumed by the admission gate and its PS
+    # chars land on pass two.
+    for _cycle in range(2):
+        for variant in range(4):
+            low_bits = variant  # bits 3-0 = variant; bit 4 = eon_tp
+            b = _pack_block_b(group_type=14, version_b=False, tp=False, pty=0, low_bits=low_bits)
+            c1, c2 = ps[variant * 2], ps[variant * 2 + 1]
+            decoder.process_group((0x5862, b, eon_pi, (ord(c1) << 8) | ord(c2)))
     data = decoder.get_current_data()
     assert data.eon_list is not None
     assert len(data.eon_list) == 1
@@ -1822,6 +1842,8 @@ def test_group_14b_updates_eon_ta():
     # Block B bit 3 = eon_ta=1
     low_bits = (1 << 3)
     b = _pack_block_b(group_type=14, version_b=True, tp=False, pty=0, low_bits=low_bits)
+    # A new EON PI is admitted on its second sighting.
+    decoder.process_group((0x5862, b, eon_pi, 0x0000))
     decoder.process_group((0x5862, b, eon_pi, 0x0000))
     data = decoder.get_current_data()
     assert data.eon_list is not None
@@ -1832,8 +1854,10 @@ def test_group_14b_updates_eon_ta():
 def test_group_15b_updates_fast_tp():
     """Group 15B with TP=1, TA=0 → fast_tp=True, fast_ta=False."""
     decoder = RBDSDecoder()
-    # version_b=True, tp=True (bit 10 of B), bit 4 of low_bits = TA=0
+    # version_b=True, tp=True (bit 10 of B), bit 4 of low_bits = TA=0.
+    # Fast flags clear the two-sighting gate on the second 15B group.
     b = _pack_block_b(group_type=15, version_b=True, tp=True, pty=0, low_bits=0x00)
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
     decoder.process_group((0x5862, b, 0x0000, 0x2020))
     data = decoder.get_current_data()
     assert data.fast_tp is True
@@ -2042,3 +2066,147 @@ def test_burst_fec_no_false_positives_on_non_contiguous_errors():
     )
 
     worker.stop()
+
+
+# ---------------------------------------------------------------------------
+# Two-sighting confirmation gate (false-read hardening)
+#
+# Single-shot fields (PI, PTY, TP, TA, MS, DI bits, fast flags, ODA
+# registrations, AF entries, EON networks) must be observed in two
+# consecutive groups before they are published, so one corrupted block
+# that slips past the CRC — or is "repaired" into the wrong codeword by
+# burst FEC — can never flip a published value on its own.
+# ---------------------------------------------------------------------------
+
+
+def test_confirmation_gate_holds_fields_until_second_sighting():
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=0, version_b=False, tp=True, pty=5, low_bits=0x18)
+
+    decoder.process_group((0x4FB5, b, 0x0000, 0x2020))
+    data = decoder.get_current_data()
+    assert data.pi_code is None
+    assert data.pty is None
+    assert data.tp is None
+    assert data.ta is None
+    assert data.ms is None
+
+    decoder.process_group((0x4FB5, b, 0x0000, 0x2020))
+    data = decoder.get_current_data()
+    assert data.pi_code == "4FB5"
+    assert data.pty == 5
+    assert data.tp is True
+    assert data.ta is True
+    assert data.ms is True
+
+
+def test_single_corrupt_group_cannot_flip_ta():
+    """A lone TA=1 sighting must not toggle the published TA flag."""
+    decoder = RBDSDecoder()
+    b_off = _pack_block_b(group_type=0, version_b=False, tp=False, pty=5, low_bits=0x00)
+    decoder.process_group((0x4FB5, b_off, 0x0000, 0x2020))
+    decoder.process_group((0x4FB5, b_off, 0x0000, 0x2020))
+    assert decoder.ta is False
+
+    # One corrupted-but-CRC-passing group flips bit 4 → TA=1 candidate.
+    b_on = _pack_block_b(group_type=0, version_b=False, tp=False, pty=5, low_bits=0x10)
+    decoder.process_group((0x4FB5, b_on, 0x0000, 0x2020))
+    assert decoder.ta is False, "single sighting must only stage, not publish"
+
+    # The next clean group contradicts the staged candidate: it is
+    # discarded and counted as a rejected noise read.
+    decoder.process_group((0x4FB5, b_off, 0x0000, 0x2020))
+    assert decoder.ta is False
+    assert decoder.glitches_rejected >= 1
+    assert decoder.ta_toggle_count == 0
+
+    # A real TA change (two consecutive sightings) still goes through
+    # and is counted as churn.
+    decoder.process_group((0x4FB5, b_on, 0x0000, 0x2020))
+    decoder.process_group((0x4FB5, b_on, 0x0000, 0x2020))
+    assert decoder.ta is True
+    assert decoder.ta_toggle_count == 1
+
+
+def test_single_corrupt_pi_rejected_and_real_change_counted():
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    assert decoder.pi_code == "5862"
+    assert decoder.call_sign == "WBKS"
+    # Initial resolution is not churn.
+    assert decoder.pi_change_count == 0
+
+    # One corrupted PI block A — stays staged, published PI unchanged.
+    decoder.process_group((0xFFFF, b, 0x0000, 0x2020))
+    assert decoder.pi_code == "5862"
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    assert decoder.pi_code == "5862"
+    assert decoder.glitches_rejected >= 1
+
+    # A genuine retune to another station confirms after two sightings
+    # and increments the churn counter.
+    decoder.process_group((0x54A8, b, 0x0000, 0x2020))
+    decoder.process_group((0x54A8, b, 0x0000, 0x2020))
+    assert decoder.pi_code == "54A8"
+    assert decoder.call_sign == "WAAA"
+    assert decoder.pi_change_count == 1
+
+
+def test_af_entry_requires_second_sighting():
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
+    af_c = (1 << 8) | 2  # 87.7 / 87.8 MHz
+    decoder.process_group((0x5862, b, af_c, 0x2020))
+    assert decoder.get_current_data().af_list is None, (
+        "AF codes from a single group must stay staged"
+    )
+    decoder.process_group((0x5862, b, af_c, 0x2020))
+    data = decoder.get_current_data()
+    assert 87.7 in data.af_list
+    assert 87.8 in data.af_list
+
+
+def test_af_method_b_marker_pair_needs_two_groups():
+    """A Method-B marker pair (af1 == af2) is two copies of the same code
+    in ONE block — it must not self-confirm within a single group."""
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=0, version_b=False, tp=False, pty=0, low_bits=0)
+    af_c = (10 << 8) | 10  # code 10 = 88.6 MHz
+    decoder.process_group((0x5862, b, af_c, 0x2020))
+    assert decoder.get_current_data().af_list is None
+    decoder.process_group((0x5862, b, af_c, 0x2020))
+    assert 88.6 in decoder.get_current_data().af_list
+
+
+def test_oda_registration_requires_two_sightings():
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=3, version_b=False, tp=False, pty=0, low_bits=0x10)
+    decoder.process_group((0x5862, b, 0x4BD7, 0x0000))
+    assert decoder.get_current_data().oda_apps is None
+    decoder.process_group((0x5862, b, 0x4BD7, 0x0000))
+    assert 0x4BD7 in decoder.get_current_data().oda_apps
+
+
+def test_eon_phantom_pi_not_admitted_on_single_sighting():
+    """Group 14 Block C carries the cross-referenced PI directly, so a
+    corrupted block would inject a phantom network. New PIs must be seen
+    twice before an EON entry is created."""
+    decoder = RBDSDecoder()
+    b = _pack_block_b(group_type=14, version_b=True, tp=False, pty=0, low_bits=0)
+
+    decoder.process_group((0x5862, b, 0x1111, 0x0000))
+    assert decoder.get_current_data().eon_list is None
+
+    # A different (garbage) PI next — neither has two sightings yet.
+    decoder.process_group((0x5862, b, 0x2222, 0x0000))
+    assert decoder.get_current_data().eon_list is None
+
+    # Second sighting of the first PI admits it; the garbage one never
+    # repeats and never becomes an entry.
+    decoder.process_group((0x5862, b, 0x1111, 0x0000))
+    data = decoder.get_current_data()
+    assert data.eon_list is not None
+    assert len(data.eon_list) == 1
+    assert data.eon_list[0]['pi'] == "1111"

--- a/tests/test_rbds_demodulation.py
+++ b/tests/test_rbds_demodulation.py
@@ -2210,3 +2210,41 @@ def test_eon_phantom_pi_not_admitted_on_single_sighting():
     assert data.eon_list is not None
     assert len(data.eon_list) == 1
     assert data.eon_list[0]['pi'] == "1111"
+
+
+def test_oda_reregistration_evicts_superseded_aid():
+    """When a slot re-registers to a new AID, the old AID must leave
+    oda_apps and _oda_payloads (unless another slot still carries it),
+    otherwise slot churn fills the cap with stale entries."""
+    decoder = RBDSDecoder()
+    b3 = _pack_block_b(group_type=3, version_b=False, tp=False, pty=0, low_bits=0x16)  # slot 11A
+
+    # Register AID 0xC563 on 11A (two sightings) and give it payload state.
+    decoder.process_group((0x5862, b3, 0xC563, 0x0000))
+    decoder.process_group((0x5862, b3, 0xC563, 0x0000))
+    assert 0xC563 in decoder.oda_apps
+    b11 = _pack_block_b(group_type=11, version_b=False, tp=False, pty=0, low_bits=0x00)
+    decoder.process_group((0x5862, b11, 0x1234, 0x5678))
+    assert 0xC563 in decoder._oda_payloads
+
+    # Re-register the same slot to RT+ (two sightings).
+    decoder.process_group((0x5862, b3, 0xCD46, 0x0000))
+    decoder.process_group((0x5862, b3, 0xCD46, 0x0000))
+
+    assert 0xCD46 in decoder.oda_apps
+    assert 0xC563 not in decoder.oda_apps
+    assert 0xC563 not in decoder._oda_payloads
+
+
+def test_group_15b_populates_fast_di_bits():
+    """15B DI bits land in the dedicated fast_di_bits nibble (and, per
+    EN 50067, also update the main DI fields) after two sightings."""
+    decoder = RBDSDecoder()
+    # address 3 (stereo position), DI bit = 1 → low bits = (1 << 2) | 3
+    b = _pack_block_b(group_type=15, version_b=True, tp=False, pty=0, low_bits=(1 << 2) | 3)
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    assert decoder.get_current_data().fast_di_bits is None
+    decoder.process_group((0x5862, b, 0x0000, 0x2020))
+    data = decoder.get_current_data()
+    assert data.fast_di_bits == (1 << 3)
+    assert data.di_stereo is True

--- a/tests/test_rbds_history_api.py
+++ b/tests/test_rbds_history_api.py
@@ -1,0 +1,171 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 Timothy Kramer (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""Tests for the RBDS history API (/api/audio/sources/<name>/rbds/history).
+
+The endpoint derives a BLER trend series and a field-change event log from
+the AudioSourceMetrics snapshots the audio service persists once a second.
+"""
+
+import logging
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_core.extensions import db
+from app_core.models import AudioSourceMetrics
+from app_utils import utc_now
+from webapp.admin import audio_ingest as audio_admin
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(type_, compiler, **kwargs):  # pragma: no cover - sqlalchemy hook
+    return "TEXT"
+
+
+@pytest.fixture(autouse=True)
+def _quiet_audio_globals(monkeypatch):
+    monkeypatch.setattr(audio_admin, "_initialization_started", True)
+    monkeypatch.setattr(audio_admin, "_start_audio_sources_background", lambda app: None)
+
+
+@pytest.fixture
+def history_app(tmp_path: Path):
+    database_path = tmp_path / "rbds_history.db"
+    app = Flask("rbds-history-test")
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{database_path}",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+
+    with app.app_context():
+        AudioSourceMetrics.__table__.create(bind=db.engine)
+        audio_admin.register_audio_ingest_routes(app, logging.getLogger("rbds-history-test"))
+        yield app
+        db.session.remove()
+        AudioSourceMetrics.__table__.drop(bind=db.engine)
+
+
+def _add_snapshot(ts, metadata, source_name="sdr-test"):
+    db.session.add(AudioSourceMetrics(
+        source_name=source_name,
+        source_type="sdr",
+        peak_level_db=-6.0,
+        rms_level_db=-18.0,
+        peak_level_linear=0.5,
+        rms_level_linear=0.12,
+        sample_rate=48000,
+        channels=2,
+        frames_captured=0,
+        timestamp=ts,
+        source_metadata=metadata,
+    ))
+
+
+def test_history_returns_points_and_events(history_app):
+    with history_app.app_context():
+        base = utc_now() - timedelta(minutes=10)
+        for i in range(8):
+            md = {
+                'rbds_lock_state': 'LOCKED',
+                'rbds_raw_bler': 0.01 * i,
+                'rbds_net_bler': 0.001 * i,
+                'rbds_glitches_rejected': i,
+                'rbds_pi_code': '5862',
+                'rbds_ta': i >= 4,                      # toggles at i=4
+                'rbds_ps_name': 'WXTEST' if i < 6 else 'NEWPS',  # changes at i=6
+            }
+            _add_snapshot(base + timedelta(seconds=30 * i), md)
+        db.session.commit()
+
+        client = history_app.test_client()
+        resp = client.get('/api/audio/sources/sdr-test/rbds/history?minutes=60')
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data['source'] == 'sdr-test'
+        assert data['sample_count'] == 8
+        assert len(data['points']) == 8
+        assert data['points'][3]['raw_bler'] == pytest.approx(0.03)
+
+        changes = [(ev['field'], ev['to']) for ev in data['events']]
+        assert ('TA', True) in changes
+        assert ('PS', 'NEWPS') in changes
+        # PI never changed, so it must not appear as an event.
+        assert not any(field == 'PI' for field, _ in changes)
+
+
+def test_history_skips_non_rbds_snapshots_and_partial_gaps(history_app):
+    with history_app.app_context():
+        base = utc_now() - timedelta(minutes=5)
+        _add_snapshot(base, {'rbds_lock_state': 'LOCKED', 'rbds_ta': False})
+        # Snapshot with no RBDS keys at all — not an RBDS sample, skipped.
+        _add_snapshot(base + timedelta(seconds=30), {'stereo_pilot_locked': True})
+        # Snapshot where the publisher omitted rbds_ta — must not fabricate
+        # a change event when the value reappears unchanged.
+        _add_snapshot(base + timedelta(seconds=60), {'rbds_lock_state': 'LOCKED'})
+        _add_snapshot(base + timedelta(seconds=90), {'rbds_lock_state': 'LOCKED', 'rbds_ta': False})
+        db.session.commit()
+
+        client = history_app.test_client()
+        resp = client.get('/api/audio/sources/sdr-test/rbds/history')
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data['sample_count'] == 3
+        assert data['events'] == []
+
+
+def test_history_unknown_source_and_bad_minutes(history_app):
+    with history_app.app_context():
+        client = history_app.test_client()
+        resp = client.get('/api/audio/sources/no-such-source/rbds/history?minutes=banana')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['minutes'] == 60  # malformed value falls back to default
+        assert data['points'] == []
+        assert data['events'] == []
+
+
+def test_history_downsamples_long_series(history_app):
+    with history_app.app_context():
+        base = utc_now() - timedelta(minutes=30)
+        for i in range(1000):
+            _add_snapshot(
+                base + timedelta(seconds=i),
+                {'rbds_lock_state': 'LOCKED', 'rbds_raw_bler': 0.01},
+            )
+        db.session.commit()
+
+        client = history_app.test_client()
+        resp = client.get('/api/audio/sources/sdr-test/rbds/history?minutes=60')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['sample_count'] == 1000
+        assert len(data['points']) <= 500

--- a/webapp/admin/audio_ingest.py
+++ b/webapp/admin/audio_ingest.py
@@ -27,7 +27,7 @@ import os
 import re
 import time
 import requests
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Blueprint, Flask, jsonify, render_template, request, current_app, Response, stream_with_context
@@ -1731,6 +1731,115 @@ def api_get_audio_source(source_name: str):
     except Exception as exc:
         logger.error('Error getting audio source %s: %s', source_name, exc)
         return jsonify({'error': str(exc)}), 500
+
+
+# RBDS metadata fields whose snapshot-to-snapshot changes are surfaced as
+# history events.  (key, human label) — ordering controls event ordering
+# when several fields change in the same snapshot.
+_RBDS_EVENT_FIELDS = (
+    ('rbds_lock_state', 'Lock'),
+    ('rbds_pi_code', 'PI'),
+    ('rbds_call_sign', 'Call sign'),
+    ('rbds_ps_name', 'PS'),
+    ('rbds_radio_text', 'RadioText'),
+    ('rbds_program_type_name', 'PTY'),
+    ('rbds_ta', 'TA'),
+    ('rbds_ews_channel', 'EWS channel'),
+)
+
+# Keep the BLER series small enough to chart comfortably; snapshots are
+# written about once a second, so an hour is ~3600 raw rows.
+_RBDS_HISTORY_MAX_POINTS = 480
+_RBDS_HISTORY_MAX_EVENTS = 300
+
+
+@audio_ingest_bp.route('/api/audio/sources/<path:source_name>/rbds/history', methods=['GET'])
+def api_get_rbds_history(source_name: str):
+    """Historical RBDS telemetry for one audio source.
+
+    Derives two views from the ``audio_source_metrics`` snapshots that the
+    audio service already persists (the UI previously only ever showed the
+    latest snapshot):
+
+    - ``points``: downsampled raw/net BLER (and glitch counter) series for
+      trend charts.
+    - ``events``: field-change log (PS / RadioText / TA / PI / PTY / lock
+      transitions), i.e. the things an operator wants to scroll back
+      through after the fact.
+
+    Query string: ``minutes`` (default 60, clamped 5..1440).
+    """
+    try:
+        minutes = int(request.args.get('minutes', 60))
+    except (TypeError, ValueError):
+        minutes = 60
+    minutes = max(5, min(minutes, 1440))
+    cutoff = utc_now() - timedelta(minutes=minutes)
+
+    try:
+        rows = (
+            db.session.query(
+                AudioSourceMetrics.timestamp,
+                AudioSourceMetrics.source_metadata,
+            )
+            .filter(
+                AudioSourceMetrics.source_name == source_name,
+                AudioSourceMetrics.timestamp >= cutoff,
+            )
+            .order_by(AudioSourceMetrics.timestamp.asc())
+            .limit(90000)
+            .all()
+        )
+    except Exception as exc:
+        logger.error('Error querying RBDS history for %s: %s', source_name, exc)
+        return jsonify({'error': str(exc)}), 500
+
+    raw_points: List[Dict[str, Any]] = []
+    events: List[Dict[str, Any]] = []
+    prev_values: Dict[str, Any] = {}
+
+    for ts, md in rows:
+        md = md or {}
+        if 'rbds_lock_state' not in md and 'rbds_blocks_total' not in md:
+            continue
+        iso_ts = ts.isoformat() if ts is not None else None
+
+        raw_points.append({
+            't': iso_ts,
+            'raw_bler': md.get('rbds_raw_bler'),
+            'net_bler': md.get('rbds_net_bler'),
+            'glitches': md.get('rbds_glitches_rejected'),
+        })
+
+        for key, label in _RBDS_EVENT_FIELDS:
+            cur = md.get(key)
+            # Missing keys mean the publisher omitted the field for this
+            # snapshot, not that the value reverted — keep the previous
+            # value so partial snapshots don't fabricate flap events.
+            if cur is None or cur == '':
+                continue
+            if key in prev_values and prev_values[key] != cur:
+                events.append({
+                    't': iso_ts,
+                    'field': label,
+                    'from': prev_values[key],
+                    'to': cur,
+                })
+            prev_values[key] = cur
+
+    sample_count = len(raw_points)
+    if sample_count > _RBDS_HISTORY_MAX_POINTS:
+        stride = -(-sample_count // _RBDS_HISTORY_MAX_POINTS)  # ceil div
+        raw_points = raw_points[::stride]
+
+    return jsonify({
+        'source': source_name,
+        'minutes': minutes,
+        'sample_count': sample_count,
+        'points': raw_points,
+        'events': events[-_RBDS_HISTORY_MAX_EVENTS:],
+    })
+
 
 @audio_ingest_bp.route('/api/audio/sources/<path:source_name>', methods=['PATCH'])
 def api_update_audio_source(source_name: str):


### PR DESCRIPTION
## RBDS decoder hardening

Adds a two-consecutive-sighting confirmation gate so a lone corrupted block that passes CRC (or is mis-repaired by burst FEC) can no longer flip published RBDS fields:

- **PI, PTY, TP, TA, MS, DI bits, 15B fast flags** now require two consecutive identical observations before publishing. These fields repeat continuously on-air, so confirmation costs one group spacing (~90 ms for PI/PTY/TP, ~1 s per DI bit).
- **AF frequencies** are staged on first sighting and only join the published list on the second, with within-group dedup so a Method-B marker pair can't self-confirm from one possibly-corrupt block.
- **ODA registrations (3A)** confirm per slot; superseded AIDs are evicted from `oda_apps`/`_oda_payloads` on slot re-registration, and both are capped at the 32 registrable slots.
- **EON networks**: new cross-referenced PIs (Group 14 Block C is injected verbatim) are staged and admitted on second sighting; the EON table is capped.
- **Group 15B** DI bits now populate the dedicated `fast_di_bits` nibble (previously always `None`) through the same gate.

## Field-churn telemetry

`RBDSDecoderStats` gains `pi_change_count`, `pty_change_count`, `ta_toggle_count`, and `glitches_rejected`, serialized through both metadata publishers as `rbds_*` keys and rendered on the decoder health card. PI/PTY churn warns when non-zero on a stationary tune; "Noise reads rejected" shows how many single-sighting false reads the gate stopped.

## RBDS history (new)

- `GET /api/audio/sources/<name>/rbds/history?minutes=N` derives a downsampled raw/net BLER trend series and a field-change event log (PS, RadioText, TA, PI, PTY, lock transitions) from the `audio_source_metrics` snapshots already persisted once a second.
- SDR Diagnostics page: per-source **History** button opens a modal with a Chart.js BLER chart, newest-first event table, and 1h/6h/24h range selector. The modal lives outside the auto-refreshed containers so it survives card re-renders.

## Navigation (new)

- **Command palette** (Ctrl/Cmd+K, plus a navbar button): fuzzy-search every page reachable from the navbar — labels, section trails, and URLs — and jump straight there.
- **Breadcrumb trail** under the navbar: "Dashboard › Section › Group › Page", with query-string-aware matching (e.g. `/logs?type=audit`).
- Both index the *rendered* navbar DOM rather than a separate page registry, so permission-hidden links are never indexed and there's nothing extra to maintain.

## Tests

- 10 existing decoder tests updated for two-sighting semantics
- 9 new decoder tests (gate behavior, corrupt TA/PI rejection with churn counting, AF second-sighting, Method-B marker pair, ODA confirmation + eviction, EON phantom-PI rejection, 15B fast-DI)
- 4 new history-API tests on a sqlite fixture mirroring the existing audio-route harness
- RBDS suites: 90/90 passing

https://claude.ai/code/session_015CsW22yFNyTQdNvinJRh3Y