### PR TITLE
Bare-metal install fails on Debian Trixie (amd64)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1111,6 +1111,7 @@ BASE_PACKAGES=(
     git
     curl
     wget
+    rsync
 )
 
 # Add GPIO packages only if hardware is present


### PR DESCRIPTION
This was on a fresh install using 'netinstall'. Adding 'rsync' to the list of BASE_PACKAGES fixed it.

Date:	Tue Jun 16 13:26:00 -0400

    Added 'rsync' to BASE_PACKAGES in 'install.sh' to resolve bare-metal
    installation failure on Debian 13 Trixie (amd64).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer script to include a system dependency required for file synchronization during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->