### PR TITLE
Fix unscrollable modals on iPad/iOS + add bulk-clear for audio alerts

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -11,20 +11,29 @@ tracks releases under the 2.x series.
 ## [2.117.0] - 2026-06-19 - Scrollable audio modals on touch devices + bulk-clear alerts
 
 ### Fixed
-- **Long modals (e.g. the "Add Audio Source" stream form) could not be scrolled
-  on iPadOS/iOS — and in Chrome on those devices — leaving the footer Save
-  button unreachable.** Bootstrap's `.modal-dialog-scrollable` turns
-  `.modal-content` into an `overflow: hidden` container around the scrolling
-  `.modal-body`. The global `.modal-content` glass styling added a
-  `backdrop-filter: blur(24px)`, and WebKit (which backs both Safari and Chrome
-  on iOS/iPadOS) has a long-standing bug where a `backdrop-filter` on an
-  `overflow: hidden` ancestor silently disables scrolling in its
-  `overflow: auto` descendant. Scrollable modals now drop the backdrop blur on
-  their content panel, restoring touch scrolling with no visible change (the
-  panel is already a solid surface colour). This fixes every
-  `.modal-dialog-scrollable` modal site-wide — Audio Sources, Stream Profiles,
-  Radio, Radio Diagnostics, Hardware Settings, and Admin
-  (`static/css/styles.css`).
+- **Long modals (e.g. the Add/Edit Audio Source stream form) could not be
+  scrolled on iPadOS/iOS — and Chrome on those devices — leaving the footer Save
+  button unreachable; dragging scrolled the page *behind* the modal instead.**
+  Three independent WebKit behaviours combined to cause this, so the fix defends
+  against all three (`static/css/styles.css`):
+  1. **Backdrop blur killed the inner scroll.** Bootstrap's
+     `.modal-dialog-scrollable` turns `.modal-content` into an `overflow: hidden`
+     container around the scrolling `.modal-body`, and WebKit silently disables
+     scrolling inside an `overflow: auto` descendant of a `backdrop-filter`ed
+     `overflow: hidden` ancestor. The global `.modal-content` glass blur is now
+     dropped on scrollable modals (no visible change — the panel is already a
+     solid surface colour).
+  2. **Scroll chained to the background.** `.modal-body` now uses
+     `overscroll-behavior: contain` (plus `-webkit-overflow-scrolling: touch`)
+     so a scroll gesture stays inside the modal.
+  3. **The page behind stayed scrollable.** Bootstrap's `.modal-open` only locks
+     `<body>`, but this layout's document scroller is `<html>`; an
+     `html:has(.modal.show) { overflow: hidden }` rule now locks the background
+     while any modal is open.
+
+  Fixes 2 and 3 are global, so this resolves the same bug for every modal
+  site-wide (Audio Sources, Stream Profiles, Radio, Radio Diagnostics, Hardware
+  Settings, Admin, and all others).
 
 ### Added
 - **"Clear All" button for unresolved audio alerts.** Silence/health alerts can

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3726,17 +3726,41 @@ textarea:focus {
     font-weight: var(--font-weight-bold);
 }
 
-/* iOS Safari fix: scrollable modals (`.modal-dialog-scrollable`) make
-   `.modal-content` an `overflow: hidden` container that clips the scrolling
-   `.modal-body` (`overflow-y: auto`). On iOS Safari a `backdrop-filter` on an
-   `overflow: hidden` ancestor silently disables scrolling in its
-   `overflow: auto` descendant — leaving long modals (e.g. the Add Audio Source
-   "stream" form) unscrollable, with the footer Save button stranded below the
-   viewport. The panel background is already a solid surface colour, so dropping
-   the blur here costs nothing visually while restoring touch scrolling. */
+/* ------------------------------------------------------------------
+   Touch-device modal scrolling fixes
+   ------------------------------------------------------------------
+   Symptom: on iPad/iPhone (and Chrome on those devices, which is also
+   WebKit) long modals — e.g. the Add/Edit Audio Source "stream" form —
+   could not be scrolled; dragging scrolled the PAGE behind the modal
+   instead, leaving the footer Save button unreachable. Three independent
+   WebKit behaviours conspire here, so we defend against all three. */
+
+/* 1. Scrollable modals (`.modal-dialog-scrollable`) make `.modal-content` an
+      `overflow: hidden` container clipping the scrolling `.modal-body`. WebKit
+      silently disables scrolling inside an `overflow: auto` descendant of a
+      `backdrop-filter`ed `overflow: hidden` ancestor, so the global glass blur
+      on `.modal-content` killed the body's scroll. The panel background is
+      already a solid surface colour, so dropping the blur costs nothing. */
 .modal-dialog-scrollable .modal-content {
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
+}
+
+/* 2. Keep touch momentum scrolling inside the modal body and stop the scroll
+      from chaining to the page behind it (the "background scrolls, not the
+      popup" symptom). */
+.modal-body {
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* 3. Lock the background scroll while a modal is open. Bootstrap's `.modal-open`
+      only sets `overflow: hidden` on <body>, but on this layout the document
+      scroller is <html> (body is a min-height:100vh flex column), so the page
+      behind stays scrollable on iOS. `:has()` is supported on the modern
+      iPadOS/iOS Safari and Chromium this targets. */
+html:has(.modal.show) {
+    overflow: hidden;
 }
 
 /* Dropdowns - Modern Glass Effect */


### PR DESCRIPTION
## Summary

Two user-reported issues from the Audio Sources page on iPad:

1. **The Add/Edit Audio Source modal could not be scrolled** — dragging scrolled the *page behind* the modal instead, leaving the footer **Save** button unreachable. Reproduced in both Safari and Chrome (both WebKit on iPadOS).
2. **No way to clear the 19,469 unresolved audio alerts** — they could previously only be resolved one at a time, and that list is hidden on this page.

## Modal scroll fix (`static/css/styles.css`)

The "background scrolls, not the popup" symptom came from three WebKit behaviours acting together, so the fix defends against all three:

1. **Backdrop blur disabled the inner scroll.** `.modal-dialog-scrollable` makes `.modal-content` an `overflow: hidden` container around the scrolling `.modal-body`, and WebKit silently disables scrolling inside an `overflow: auto` descendant of a `backdrop-filter`ed `overflow: hidden` ancestor. The global glass blur is now dropped on scrollable modal content (no visible change — the panel is already a solid surface colour).
2. **Scroll chained to the background.** `.modal-body` now uses `overscroll-behavior: contain` + `-webkit-overflow-scrolling: touch`.
3. **The page behind stayed scrollable.** Bootstrap's `.modal-open` only locks `<body>`, but this layout's document scroller is `<html>`. Added `html:has(.modal.show) { overflow: hidden }`.

Fixes 2 and 3 are global, so this resolves the same class of bug for **every** modal site-wide (Audio Sources, Stream Profiles, Radio, Radio Diagnostics, Hardware Settings, Admin, …).

## Bulk-clear alerts

- New `POST /api/audio/alerts/resolve-all` bulk-resolves every outstanding alert in a single query (`webapp/admin/audio_ingest.py`, permission-gated like the existing resolve route).
- **Clear All** button on the Audio Sources Alerts card (`templates/admin/audio_sources.html`) wired to a new `resolveAllAlerts()` handler with confirmation (`static/js/audio_monitoring.js`).

## Versioning / housekeeping

- `VERSION` → `2.117.0` (feature + fix), `README.md` badge updated.
- `docs/reference/CHANGELOG.md` updated under a new `[2.117.0]` heading.
- `tests/test_release_metadata.py` passes; template block names and JS syntax validated.

## Testing notes

CSS-only behaviour change for the scroll fix — needs to be verified on a physical iPad/iOS device (Safari + Chrome) after deploy, since the bug is WebKit-specific and doesn't reproduce in desktop devtools emulation. CSS is cache-busted via `?v=<version>`, so no manual hard-refresh is required once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNsM9xKuqEqTLtoV7XhddS)_