### PR TITLE
Update operational contacts and policy text for EAS Station, LLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,6 @@ NOAA/NWS · FEMA/IPAWS · PostGIS Team · U.S. Census Bureau (TIGER/Line) · Put
 
 <div align="center">
   <strong>Made with ☕ and 📻 for Amateur Radio Emergency Communications</strong><br>
-  <strong>Contact:</strong> <a href="mailto:Timothy.Kramer@easstation.com">Timothy.Kramer@easstation.com</a> · (419) 890-1890<br>
+  <strong>Contact:</strong> <a href="mailto:sales@easstation.com">sales@easstation.com</a> · (419) 890-1890<br>
   <strong>73 de KR8MER</strong> 📡
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ EAS Station™ integrates multiple alert sources (NOAA Weather, IPAWS Federal) a
 3. **Run diagnostics** - Use built-in diagnostic tools
 4. **Ask for help** - [GitHub Discussions](https://github.com/KR8MER/eas-station/discussions)
 5. **Report bugs** - [GitHub Issues](https://github.com/KR8MER/eas-station/issues)
-6. **Contact the maintainer** - [Timothy.Kramer@easstation.com](mailto:Timothy.Kramer@easstation.com) · (419) 890-1890
+6. **Contact** - [sales@easstation.com](mailto:sales@easstation.com) · (419) 890-1890 (general/licensing) · [security@easstation.com](mailto:security@easstation.com) (security)
 
 ---
 

--- a/docs/policies/PRIVACY_POLICY.md
+++ b/docs/policies/PRIVACY_POLICY.md
@@ -2,7 +2,7 @@
 
 _Last updated: February 14, 2026_
 
-EAS Station™ is a self-hosted project that runs entirely under your control. The maintainers do not operate a hosted service, collect analytics, or receive telemetry from deployments. This policy explains how to handle data while testing the software in lab environments.
+EAS Station™ is a self-hosted project maintained by EAS Station, LLC (KR8MER) that runs entirely under your control. EAS Station, LLC does not operate a hosted service, collect analytics, or receive telemetry from deployments. This policy explains how to handle data while testing the software in lab environments.
 
 ## 1. Project Scope
 - The maintainers do not collect or process any information from your installations.
@@ -33,5 +33,6 @@ EAS Station™ is a self-hosted project that runs entirely under your control. T
 - You are solely responsible for implementing appropriate backups and safeguards.
 
 ## 7. Contact
+- This policy is provided by EAS Station, LLC (KR8MER).
 - Submit privacy-related questions through the GitHub issue tracker.
 - Do **not** send sensitive personal data, emergency requests, or proprietary information through that channel.

--- a/docs/process/CONTRIBUTING.md
+++ b/docs/process/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Be respectful and constructive. EAS Station™ is maintained by volunteers suppo
 
 - The EAS Station™ source code is dual-licensed under the [GNU Affero General Public License v3 (AGPL-3.0)](../../LICENSE) for open-source use and a [Commercial License](../../LICENSE-COMMERCIAL) for proprietary use. EAS Station, LLC (KR8MER) retains the project copyright.
 - By contributing, you agree that your submissions will be licensed under the AGPL-3.0 license and may be redistributed under those terms.
+- **Commercial relicensing grant:** Because EAS Station™ is dual-licensed, by submitting a contribution you also grant EAS Station, LLC (KR8MER) a perpetual, worldwide, irrevocable, royalty-free, non-exclusive right to relicense and distribute your contribution under the [Commercial License](../../LICENSE-COMMERCIAL) (and any future versions of it), in addition to the AGPL-3.0. You retain copyright in your contribution. This grant lets the project keep offering a commercial license for the combined work without requiring a separate agreement for each contribution.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -27,6 +27,14 @@ tracks releases under the 2.x series.
   maintainer" biography and portrait (`templates/about.html`,
   `docs/reference/ABOUT.md`) were intentionally left intact, as they describe
   the human maintainer rather than asserting ownership.
+- **Updated operational contacts and policy text for the LLC.** The security
+  vulnerability contact is now `security@easstation.com`
+  (`docs/security/SECURITY.md`), the general public contact in `README.md` and
+  `docs/README.md` is the business inbox `sales@easstation.com` and business
+  line, the privacy policy (`docs/policies/PRIVACY_POLICY.md`) now names
+  EAS Station, LLC as the maintaining entity, and `docs/process/CONTRIBUTING.md`
+  adds a commercial-relicensing grant so contributions can be included under the
+  dual-license commercial terms.
 
 ## [2.119.2] - 2026-06-19 - Firewall sync state ignores unmirrorable bans
 

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -673,7 +673,7 @@ When deploying security features to existing EAS Station™:
 
 For security issues or questions:
 - Review audit logs for suspicious activity
-- Contact the maintainer: Timothy.Kramer@easstation.com
+- Contact security: security@easstation.com
 - File GitHub issue: https://github.com/KR8MER/eas-station/issues
 
 **Security Vulnerabilities:** Report privately via email, not public issues.


### PR DESCRIPTION
## Summary

Follow-up to the ownership transfer to **EAS Station, LLC (KR8MER)** (the 426-file copyright/attribution change already merged into `main` via #2324). This PR updates the operational contacts and policy text so they match the new entity.

## Changes (6 files, +14/-4)

- `docs/security/SECURITY.md` — security vulnerability contact is now `security@easstation.com`
- `README.md` — general public contact is the business inbox `sales@easstation.com` (business line retained)
- `docs/README.md` — general contact updated to `sales@easstation.com`; `security@easstation.com` added for security reports
- `docs/policies/PRIVACY_POLICY.md` — names EAS Station, LLC (KR8MER) as the maintaining entity
- `docs/process/CONTRIBUTING.md` — adds a commercial-relicensing grant so outside contributions can be included under the dual-license commercial terms
- `docs/reference/CHANGELOG.md` — documents the above under the 2.119.3 entry

The personal "about the maintainer" biography and its contact email (`templates/about.html`, `docs/reference/ABOUT.md`) are intentionally left intact — they describe the human maintainer rather than the entity.

## Notes (out of scope — external/legal follow-ups)

- A written IP assignment from the individual to EAS Station, LLC is still needed for the LLC to actually own pre-formation (2025) code; the header text change does not create the transfer.
- Governing law was already Ohio in `TERMS_OF_USE.md` and `LICENSE-COMMERCIAL`, so venue language was unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)