### PR TITLE
Claude/audio stuttering skipping ah0cl5

### DIFF
--- a/app_core/audio/broadcast_adapter.py
+++ b/app_core/audio/broadcast_adapter.py
@@ -362,6 +362,19 @@ class BroadcastAudioAdapter:
             # Return copy of recent audio without consuming from buffer
             return buffer[:available_samples].copy()
 
+    def has_pending_audio(self, num_samples: int) -> bool:
+        """True when a read_audio(num_samples) call would return promptly.
+
+        Used by the unified EAS monitor's catch-up drain: after a stall the
+        subscription queue holds a backlog of chunks, and the monitor keeps
+        reading while this returns True so the backlog is consumed faster
+        than real time instead of growing without bound.  Checks the
+        internal buffer and the subscription queue without blocking.
+        """
+        if self._chunk_total_samples >= num_samples:
+            return True
+        return not self._subscriber_queue.empty()
+
     def get_active_source(self) -> Optional[str]:
         """Get name of currently active audio source."""
         # Broadcast queues don't track source name - return broadcast name

--- a/app_core/audio/eas_monitor_v3.py
+++ b/app_core/audio/eas_monitor_v3.py
@@ -369,6 +369,20 @@ class SourceWatcher:
             logger.error(f"Error reading audio from '{self.source_name}': {e}")
             return None
 
+    def has_pending_audio(self, num_samples: int) -> bool:
+        """True when another read_audio() would return promptly (backlog waiting)."""
+        try:
+            return self._adapter.has_pending_audio(num_samples)
+        except Exception:
+            return False
+
+    def backlog_chunks(self) -> int:
+        """Approximate number of unread chunks queued for this source."""
+        try:
+            return int(self._adapter.get_stats().get('queue_size', 0))
+        except Exception:
+            return 0
+
     def process_samples(self, samples: np.ndarray) -> None:
         """Feed audio samples into this source's dedicated SAME decoder."""
         self._decoder.process_samples(samples)
@@ -440,6 +454,16 @@ class UnifiedEASMonitorService:
         # Source watchers: {source_name: SourceWatcher}
         self._watchers: Dict[str, SourceWatcher] = {}
         self._watchers_lock = threading.Lock()
+
+        # Catch-up drain bounds (see _monitor_loop).  Up to 50 chunks (5 s of
+        # audio) are consumed from a backlogged source per cycle so the
+        # monitor recovers from stalls instead of falling permanently behind;
+        # the bound keeps one deeply-backlogged source from starving others.
+        self._max_chunks_per_cycle = 50
+        # Warn (rate-limited) when a source's subscription queue stays deeper
+        # than this many chunks after a drain pass.
+        self._backlog_warn_chunks = 50
+        self._last_backlog_warning: Dict[str, float] = {}
         
         # Health tracking
         self._health_tracker = HealthTracker(audio_timeout_seconds=5.0)
@@ -927,14 +951,33 @@ class UnifiedEASMonitorService:
                     time.sleep(0.1)
                     continue
                 
-                # Poll each source watcher
+                # Poll each source watcher.
+                #
+                # RECORDING-STUTTER FIX (catch-up drain): the loop used to read
+                # exactly ONE 100 ms chunk per source per cycle.  Any source
+                # that momentarily produced nothing (a stream reconnecting, an
+                # SDR service restarting, a configured-but-idle input) made its
+                # read_audio() block for the full 0.1 s timeout EVERY cycle, so
+                # one stalled sibling capped every active source's drain rate
+                # at exactly real time — zero margin — and with two stalls or
+                # any decode/GC overhead the active sources fell behind with NO
+                # way to ever catch up.  The backlog grew until the
+                # 10000-chunk subscription queue engaged drop-oldest
+                # permanently, at which point a slice of every source's audio
+                # was discarded and every recorded alert came out shredded
+                # into fragments with ~100 ms holes.  Draining the entire
+                # backlog when a source has one (bounded per cycle so one
+                # source cannot starve the others) lets the monitor recover
+                # from any stall instead of degrading forever.
                 any_audio_processed = False
                 for source_name, watcher in watchers_snapshot:
                     try:
-                        # Try to read audio from this source
-                        samples = watcher.read_audio(self._chunk_size)
+                        chunks_read = 0
+                        while chunks_read < self._max_chunks_per_cycle:
+                            samples = watcher.read_audio(self._chunk_size)
+                            if samples is None or len(samples) == 0:
+                                break
 
-                        if samples is not None and len(samples) > 0:
                             # Update per-source ring buffer BEFORE decoding so the
                             # audio is available if the decoder fires an alert callback
                             # synchronously during process_samples().
@@ -970,9 +1013,36 @@ class UnifiedEASMonitorService:
                             )
 
                             any_audio_processed = True
-                        else:
+                            chunks_read += 1
+
+                            # Only keep reading while a backlog is actually
+                            # waiting — never block on the timeout for a
+                            # second chunk that hasn't been produced yet.
+                            if not watcher.has_pending_audio(self._chunk_size):
+                                break
+
+                        if chunks_read == 0:
                             # No audio available from this source
                             self._health_tracker.update_no_audio(source_name)
+                        else:
+                            # Surface sustained backlogs: a queue that stays deep
+                            # means the monitor is consuming slower than real time
+                            # (CPU starvation or a chronically stalled sibling) and
+                            # recordings are at risk once the queue limit is hit.
+                            backlog = watcher.backlog_chunks()
+                            if backlog >= self._backlog_warn_chunks:
+                                now_mono = time.monotonic()
+                                last = self._last_backlog_warning.get(source_name, 0.0)
+                                if now_mono - last >= 60.0:
+                                    logger.warning(
+                                        "EAS monitor backlog for '%s': %d chunks "
+                                        "(~%.1f s) queued behind real time — "
+                                        "catching up at %d chunks/cycle",
+                                        source_name, backlog,
+                                        backlog * self._chunk_duration_ms / 1000.0,
+                                        self._max_chunks_per_cycle,
+                                    )
+                                    self._last_backlog_warning[source_name] = now_mono
 
                     except Exception as e:
                         logger.error(
@@ -1103,6 +1173,7 @@ class UnifiedEASMonitorService:
                         "decoder_synced": dec_stats.get('synced', False),
                         "decoder_in_message": dec_stats.get('in_message', False),
                         "decoder_bytes_decoded": dec_stats.get('bytes_decoded', 0),
+                        "queue_backlog_chunks": watcher.backlog_chunks(),
                     }
 
         # Return status in MultiMonitorManager-compatible format

--- a/app_core/audio/stream_keepalive.py
+++ b/app_core/audio/stream_keepalive.py
@@ -1,0 +1,79 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""
+Keep-alive silence policy for live audio streaming endpoints.
+
+The live listen streams (web WAV stream, EAS decoder MP3 feeds) read audio
+chunks from a broadcast-queue subscription with a timeout.  The old code
+wrote a block of zeros into the stream on EVERY timeout.  Because chunks
+arrive at ~100 ms cadence and the timeouts were 100-200 ms, any scheduling
+or network jitter made the read race its own producer: a chunk arriving a
+few milliseconds late became an injected 50-100 ms silence block spliced
+into the middle of continuous audio, with the real chunk playing AFTER the
+gap.  That is audible stuttering, it happens several times per second under
+load, and every injection pushes the stream further behind real time until
+the subscription queue overflows and real audio is dropped as well.
+
+The correct behaviour, implemented by :class:`KeepAliveGate`:
+
+  * Transient jitter (queue momentarily empty): emit NOTHING.  The browser
+    or ffmpeg simply waits a few ms for the late chunk; playback continuity
+    is preserved and the stream never drifts.
+  * Source genuinely quiet (no audio for ``quiet_seconds``, e.g. the source
+    stopped): emit paced keep-alive silence so the HTTP connection, ffmpeg
+    pipeline, and browser element stay alive until audio returns.
+"""
+
+import time
+from typing import Callable, Optional
+
+
+class KeepAliveGate:
+    """Decides when a streaming endpoint may emit keep-alive silence.
+
+    Args:
+        quiet_seconds: How long a source must be continuously silent before
+            keep-alive silence is emitted.  Must be comfortably larger than
+            the chunk cadence (~0.1 s) so jitter never qualifies.
+        clock: Injectable monotonic clock (for tests).
+    """
+
+    def __init__(self, quiet_seconds: float = 1.5, clock: Optional[Callable[[], float]] = None):
+        self.quiet_seconds = float(quiet_seconds)
+        self._clock = clock or time.monotonic
+        # Treat stream start as "just heard audio" so a slow first chunk
+        # doesn't open with injected silence.
+        self._last_audio = self._clock()
+
+    def audio_received(self) -> None:
+        """Record that a real audio chunk was just delivered."""
+        self._last_audio = self._clock()
+
+    def should_emit_silence(self) -> bool:
+        """True only when the source has been quiet for ``quiet_seconds``.
+
+        A momentary queue-empty (late chunk) returns False — the caller
+        must simply wait instead of splicing zeros into the stream.
+        """
+        return (self._clock() - self._last_audio) >= self.quiet_seconds
+
+    def seconds_since_audio(self) -> float:
+        """Elapsed seconds since the last real audio chunk."""
+        return self._clock() - self._last_audio

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -59,6 +59,26 @@ tracks releases under the 2.x series.
   root cause of audible stutter on the live monitor/Icecast stream) never
   surfaced in the system logs. Drops are now logged at WARNING, rate-limited
   per subscriber, naming the exact subscriber that is consuming too slowly.
+- **Recorded alerts were shredded once the unified monitor fell behind —
+  the stored WAV itself stuttered.** The monitor loop read exactly ONE
+  100 ms chunk per source per cycle, while every source that momentarily
+  produced nothing (a stream reconnecting, an SDR service restart, a
+  configured-but-idle input) blocked the cycle for its full 0.1 s read
+  timeout. One stalled sibling capped every active source at exactly
+  real-time consumption (zero margin); two stalls or any decode/GC overhead
+  put active sources permanently behind — and there was **no catch-up
+  mechanism**, so the backlog grew monotonically until the 10 000-chunk
+  subscription queue engaged drop-oldest *permanently*. From that point a
+  slice of every source's audio was silently discarded and every recorded
+  alert came out fragmented with ~100 ms holes. A service restart cleared
+  the queues (appearing to fix it) before the system silently degraded
+  again. The loop now drains a source's entire backlog when one is waiting
+  (bounded at 50 chunks/cycle so one source cannot starve others), recovers
+  from any stall faster than real time, reports `queue_backlog_chunks`
+  per source in the monitor status API, and logs a rate-limited warning
+  whenever a backlog persists. Regression coverage in
+  `tests/test_eas_monitor_catchup.py` (2 tests — the stalled-siblings
+  scenario fails against the old one-chunk-per-cycle loop).
 - **Live listen streams stuttered by construction under any timing jitter.**
   The web WAV stream (`/api/audio/stream/<source>`) and both EAS decoder
   MP3 feeds wrote a 50–100 ms block of zeros on EVERY queue-read timeout —

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -59,6 +59,22 @@ tracks releases under the 2.x series.
   root cause of audible stutter on the live monitor/Icecast stream) never
   surfaced in the system logs. Drops are now logged at WARNING, rate-limited
   per subscriber, naming the exact subscriber that is consuming too slowly.
+- **Live listen streams stuttered by construction under any timing jitter.**
+  The web WAV stream (`/api/audio/stream/<source>`) and both EAS decoder
+  MP3 feeds wrote a 50–100 ms block of zeros on EVERY queue-read timeout —
+  and the decoder feeds' 100 ms timeout raced the ~100 ms producer cadence,
+  so a chunk arriving even a few milliseconds late was replaced with an
+  injected silence block spliced into the middle of continuous audio, with
+  the real chunk playing after the gap. Under normal scheduling/network
+  jitter this produced audible stuttering several times per second on the
+  Listen feature and pushed the stream progressively behind real time until
+  the subscription queue overflowed and real audio was dropped too. All
+  three streams now use a keep-alive gate
+  (`app_core/audio/stream_keepalive.py`): transient jitter emits nothing
+  (the browser/ffmpeg simply waits for the late chunk), and paced comfort
+  silence is emitted only after a source has been genuinely quiet for
+  1.5–2 s, keeping the connection alive when a source is down. Regression
+  coverage in `tests/test_stream_keepalive.py` (5 tests).
 
 ## [2.120.0] - 2026-06-24 - Centralize relay keying in the GPIO subprocess
 

--- a/eas_monitoring_service.py
+++ b/eas_monitoring_service.py
@@ -1363,9 +1363,23 @@ def main():
                         wav_header.write(struct.pack('<I', 0xFFFFFFFF))
                         yield wav_header.getvalue()
 
-                        # Stream audio chunks
-                        silence_duration = 0.05
-                        silence_samples = int(stream_sample_rate * stream_channels * silence_duration)
+                        # Stream audio chunks.
+                        #
+                        # STUTTER FIX: the old loop yielded a 50 ms block of zeros on
+                        # EVERY 200 ms queue timeout and every None chunk.  Chunks
+                        # arrive at ~100 ms cadence, so ordinary scheduling/network
+                        # jitter spliced silence into the middle of continuous audio
+                        # several times a minute (audible stutter) while the real
+                        # chunk played AFTER the injected gap — and every injection
+                        # pushed the stream permanently further behind live.  Now
+                        # transient jitter emits nothing (the browser just waits a
+                        # few ms); keep-alive silence is emitted only when the
+                        # source has been genuinely quiet for several seconds.
+                        from app_core.audio.stream_keepalive import KeepAliveGate
+                        keepalive = KeepAliveGate(quiet_seconds=2.0)
+                        # Keep-alive silence is paced to the 200 ms read timeout so
+                        # a dead source streams silence at roughly real time.
+                        keepalive_samples = int(stream_sample_rate * stream_channels * 0.2)
 
                         logger.debug(f"Web stream '{subscriber_id}' started, subscribed to broadcast queue")
 
@@ -1374,10 +1388,6 @@ def main():
                                 # Read from subscription queue (non-competitive)
                                 audio_chunk = subscription_queue.get(timeout=0.2)
                                 if audio_chunk is None:
-                                    # Yield silence to keep stream alive
-                                    silence_chunk = np.zeros(silence_samples, dtype=np.int16)
-                                    yield silence_chunk.tobytes()
-                                    time.sleep(silence_duration)  # Sleep for the silence duration (~50ms)
                                     continue
 
                                 if not isinstance(audio_chunk, np.ndarray):
@@ -1396,17 +1406,17 @@ def main():
 
                                 # Convert to int16 PCM (no resampling - use native sample rate)
                                 pcm_data = (np.clip(audio_chunk, -1.0, 1.0) * 32767).astype(np.int16)
+                                keepalive.audio_received()
                                 yield pcm_data.tobytes()
 
                             except queue_module.Empty:
-                                # No audio available — the queue.get timeout (200ms) already
-                                # throttled this path, just yield silence and continue.
-                                silence_chunk = np.zeros(silence_samples, dtype=np.int16)
-                                yield silence_chunk.tobytes()
+                                # Late chunk (jitter): emit nothing — never splice
+                                # silence into continuous audio.  Only a source that
+                                # has been quiet for seconds gets keep-alive silence.
+                                if keepalive.should_emit_silence():
+                                    yield np.zeros(keepalive_samples, dtype=np.int16).tobytes()
                             except Exception as e:
                                 logger.debug(f"Error in stream generator: {e}")
-                                silence_chunk = np.zeros(silence_samples, dtype=np.int16)
-                                yield silence_chunk.tobytes()
                                 time.sleep(0.05)
                     finally:
                         # Unsubscribe when client disconnects
@@ -1590,19 +1600,32 @@ def main():
                             return chunk.astype(np.float32)
 
                         # Writer thread: mixed PCM from all broadcast queues → ffmpeg stdin
+                        #
+                        # STUTTER FIX: the old loop wrote 100 ms of zeros on every
+                        # queue timeout, with the timeout (0.1 s) racing the ~100 ms
+                        # producer cadence.  A chunk arriving a few ms late became
+                        # an injected silence block spliced into continuous audio —
+                        # audible stutter, several times per second under jitter —
+                        # while the real chunk played after the gap and the stream
+                        # drifted ever further behind live.  Transient jitter now
+                        # emits nothing (ffmpeg simply waits); keep-alive silence is
+                        # only written when every source has been quiet for seconds.
+                        from app_core.audio.stream_keepalive import KeepAliveGate
+
                         def _feed_ffmpeg():
+                            keepalive = KeepAliveGate(quiet_seconds=1.5)
                             try:
                                 while _running and ffmpeg_proc.poll() is None:
                                     try:
                                         chunks = []
 
                                         if subscription_items:
-                                            # Block on the first queue to drive timing
-                                            # (chunks arrive ~every 100 ms per source;
-                                            # timeout matches silence_duration above).
+                                            # Block on the first queue to drive timing;
+                                            # generous timeout so late chunks are waited
+                                            # for instead of replaced with silence.
                                             _, first_q = subscription_items[0]
                                             try:
-                                                raw = first_q.get(timeout=0.1)  # must equal silence_duration
+                                                raw = first_q.get(timeout=0.25)
                                                 if raw is not None and len(raw) > 0:
                                                     chunks.append(_to_mono_float32(raw))
                                             except queue_module.Empty:
@@ -1618,8 +1641,11 @@ def main():
                                                     pass
 
                                         if not chunks:
-                                            ffmpeg_proc.stdin.write(silence_pcm)
+                                            if keepalive.should_emit_silence():
+                                                ffmpeg_proc.stdin.write(silence_pcm)
                                             continue
+
+                                        keepalive.audio_received()
 
                                         # Mix sources: average to prevent clipping.
                                         # All sources produce equal-sized 100ms chunks (1600 samples
@@ -1852,17 +1878,26 @@ def main():
                                 chunk = chunk.flatten()
                             return (np.clip(chunk, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
 
+                        # STUTTER FIX: identical policy to the mixed decoder stream —
+                        # never replace a late chunk with silence (that splices an
+                        # audible 100 ms gap into continuous audio and pushes the
+                        # stream behind live); only emit keep-alive silence once the
+                        # source has been genuinely quiet for seconds.
+                        from app_core.audio.stream_keepalive import KeepAliveGate
+
                         def _feed_ffmpeg():
+                            keepalive = KeepAliveGate(quiet_seconds=1.5)
                             try:
                                 while _running and ffmpeg_proc.poll() is None:
                                     try:
-                                        raw = sub_q.get(timeout=0.1)
+                                        raw = sub_q.get(timeout=0.25)
                                         if raw is None or len(raw) == 0:
-                                            ffmpeg_proc.stdin.write(silence_pcm)
-                                        else:
-                                            ffmpeg_proc.stdin.write(_to_mono_int16(raw))
+                                            continue
+                                        ffmpeg_proc.stdin.write(_to_mono_int16(raw))
+                                        keepalive.audio_received()
                                     except queue_module.Empty:
-                                        ffmpeg_proc.stdin.write(silence_pcm)
+                                        if keepalive.should_emit_silence():
+                                            ffmpeg_proc.stdin.write(silence_pcm)
                                     except (BrokenPipeError, OSError):
                                         break
                                     except Exception as exc:

--- a/tests/test_eas_monitor_catchup.py
+++ b/tests/test_eas_monitor_catchup.py
@@ -1,0 +1,160 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Regression tests for the unified EAS monitor catch-up drain.
+
+Covers the recorded-alert stutter fix: the monitor loop used to read exactly
+one 100 ms chunk per source per cycle, while every stalled sibling source
+blocked the cycle for its full 0.1 s read timeout.  One stalled source capped
+active sources at exactly real-time consumption (zero margin); two stalled
+sources or any decode overhead put them permanently behind with no catch-up,
+until the subscription queue engaged drop-oldest and every recorded alert was
+shredded into fragments with ~100 ms holes.
+
+The fix drains a source's entire backlog (bounded per cycle) whenever one is
+waiting, so the monitor recovers from stalls faster than real time.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_core.audio.broadcast_queue import BroadcastQueue
+from app_core.audio.eas_monitor_v3 import UnifiedEASMonitorService
+
+SAMPLE_RATE = 16000
+CHUNK = 1600  # 100 ms at 16 kHz
+
+
+class FakeAdapter:
+    def __init__(self, q: BroadcastQueue):
+        self._q = q
+
+    def get_eas_broadcast_queue(self) -> BroadcastQueue:
+        return self._q
+
+
+class FakeController:
+    def __init__(self, queues):
+        self._sources = {name: FakeAdapter(q) for name, q in queues.items()}
+
+
+def _make_service(queues):
+    svc = UnifiedEASMonitorService(audio_controller=FakeController(queues))
+
+    def _discover(self=svc):
+        with self._watchers_lock:
+            for name, adapter in self.audio_controller._sources.items():
+                if name not in self._watchers:
+                    self._add_watcher(name, adapter)
+
+    svc._discover_sources = _discover
+    return svc
+
+
+def _tone_chunk(i: int) -> np.ndarray:
+    t = (np.arange(CHUNK) + i * CHUNK) / SAMPLE_RATE
+    return (0.4 * np.sin(2 * np.pi * 853 * t)).astype(np.float32)
+
+
+def test_backlog_drains_despite_stalled_sibling_sources():
+    """An active source's backlog must drain faster than real time even when
+    two sibling sources are stalled (each blocking the cycle for its read
+    timeout).  The old one-chunk-per-cycle loop consumed at most 5 chunks/s
+    in this scenario — half of real time — so the backlog only ever grew."""
+    active_q = BroadcastQueue(name='eas-active', max_queue_size=10000)
+    queues = {
+        'active': active_q,
+        'stalled-1': BroadcastQueue(name='eas-stalled-1', max_queue_size=10000),
+        'stalled-2': BroadcastQueue(name='eas-stalled-2', max_queue_size=10000),
+    }
+    svc = _make_service(queues)
+    svc.start()
+    try:
+        # Wait for the watcher subscriptions before publishing.
+        deadline = time.time() + 5.0
+        while time.time() < deadline and active_q.get_stats()['subscribers'] == 0:
+            time.sleep(0.02)
+        assert active_q.get_stats()['subscribers'] == 1
+
+        # 20 s of audio published as an instantaneous backlog (what piles up
+        # while the monitor is stalled behind slow siblings).
+        n_chunks = 200
+        for i in range(n_chunks):
+            active_q.publish(_tone_chunk(i))
+
+        expected_samples = n_chunks * CHUNK
+
+        # With the catch-up drain this completes in a few seconds despite the
+        # two stalled sources; without it, consumption is capped at ~5
+        # chunks/s and would need 40+ seconds (and real deployments never
+        # catch up at all).
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            with svc._audio_rings_lock:
+                processed = svc._ring_total_added.get('active', 0)
+            if processed >= expected_samples:
+                break
+            time.sleep(0.1)
+
+        with svc._audio_rings_lock:
+            processed = svc._ring_total_added.get('active', 0)
+        assert processed >= expected_samples, (
+            f"monitor failed to catch up: {processed}/{expected_samples} samples "
+            f"processed — backlog is not being drained"
+        )
+
+        # Nothing may have been dropped: dropped chunks are audio holes in
+        # recorded alerts.
+        assert active_q.get_stats()['dropped_chunks'] == 0
+    finally:
+        svc.stop()
+
+
+def test_per_source_status_reports_backlog():
+    q = BroadcastQueue(name='eas-status', max_queue_size=10000)
+    svc = _make_service({'src': q})
+    svc.start()
+    try:
+        deadline = time.time() + 5.0
+        while time.time() < deadline and q.get_stats()['subscribers'] == 0:
+            time.sleep(0.02)
+
+        for i in range(20):
+            q.publish(_tone_chunk(i))
+
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            with svc._audio_rings_lock:
+                if svc._ring_total_added.get('src', 0) >= 20 * CHUNK:
+                    break
+            time.sleep(0.1)
+
+        status = svc.get_status()
+        assert 'src' in status['monitors']
+        assert 'queue_backlog_chunks' in status['monitors']['src']
+        # Fully drained after catch-up
+        assert status['monitors']['src']['queue_backlog_chunks'] == 0
+    finally:
+        svc.stop()

--- a/tests/test_stream_keepalive.py
+++ b/tests/test_stream_keepalive.py
@@ -1,0 +1,106 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Tests for the live-stream keep-alive silence policy.
+
+Covers the listen-stream stutter fix: the web WAV stream and the EAS
+decoder MP3 feeds used to write a 50-100 ms block of zeros on EVERY queue
+timeout, with timeouts that raced the ~100 ms producer cadence — so any
+scheduling jitter spliced silence into continuous audio (audible stutter)
+and pushed the stream permanently behind real time.  KeepAliveGate must
+report "emit nothing" for transient jitter and permit keep-alive silence
+only after sustained source quiet.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app_core.audio.stream_keepalive import KeepAliveGate
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_transient_jitter_never_emits_silence():
+    clock = FakeClock()
+    gate = KeepAliveGate(quiet_seconds=1.5, clock=clock)
+
+    # Chunks arriving with up to 400 ms of jitter — far past the old
+    # 100-200 ms timeouts that used to inject silence — must never
+    # qualify for keep-alive silence.
+    for jitter in (0.05, 0.15, 0.25, 0.40, 0.10, 0.35):
+        clock.advance(jitter)
+        assert gate.should_emit_silence() is False, f"jitter {jitter}s wrongly emitted silence"
+        gate.audio_received()
+
+
+def test_sustained_quiet_emits_silence():
+    clock = FakeClock()
+    gate = KeepAliveGate(quiet_seconds=1.5, clock=clock)
+    gate.audio_received()
+
+    clock.advance(1.49)
+    assert gate.should_emit_silence() is False
+
+    clock.advance(0.02)
+    assert gate.should_emit_silence() is True
+    # Stays true until audio returns
+    clock.advance(5.0)
+    assert gate.should_emit_silence() is True
+
+
+def test_audio_return_resets_quiet_timer():
+    clock = FakeClock()
+    gate = KeepAliveGate(quiet_seconds=1.5, clock=clock)
+
+    clock.advance(10.0)
+    assert gate.should_emit_silence() is True
+
+    gate.audio_received()
+    assert gate.should_emit_silence() is False
+    clock.advance(0.3)
+    assert gate.should_emit_silence() is False
+
+
+def test_stream_start_counts_as_recent_audio():
+    # A freshly opened stream must not open with injected silence while the
+    # first chunk is in flight.
+    clock = FakeClock()
+    gate = KeepAliveGate(quiet_seconds=1.5, clock=clock)
+    clock.advance(0.4)
+    assert gate.should_emit_silence() is False
+
+
+def test_seconds_since_audio_tracks_clock():
+    clock = FakeClock()
+    gate = KeepAliveGate(quiet_seconds=1.5, clock=clock)
+    gate.audio_received()
+    clock.advance(0.75)
+    assert abs(gate.seconds_since_audio() - 0.75) < 1e-9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live audio streaming so brief queue delays no longer create audible stutter or unwanted silence.
  * Enhanced audio playback recovery to catch up on buffered audio more smoothly after stalls.
  * Added clearer backlog reporting and warning behavior when audio queues build up.
* **New Features**
  * Live audio streams now use a smarter keep-alive behavior that only inserts silence after a sustained quiet period.
  * Status views now include per-source backlog information for better monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->