### PR TITLE
Fix audio service silent crash on shutdown, add failure recovery hook

### DIFF
--- a/eas_monitoring_service.py
+++ b/eas_monitoring_service.py
@@ -2243,4 +2243,14 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    _exit_code = main()
+    # Bypass normal interpreter finalization: numba/llvmlite's native JIT
+    # teardown races with CPython shutdown on aarch64 and can abort the
+    # process (SIGABRT / "terminate called without an active exception")
+    # *after* the graceful-shutdown code above has already completed. That
+    # abort happens outside any Python exception handler and is invisible
+    # to the app's own logging, and because it occurs while systemd already
+    # has a stop job in flight for this unit, Restart=always does not fire.
+    # os._exit() skips the problematic native teardown entirely.
+    logging.shutdown()
+    os._exit(_exit_code)

--- a/scripts/service_failure_recovery.sh
+++ b/scripts/service_failure_recovery.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Invoked via OnFailure= when a critical EAS Station service enters the
+# 'failed' state. This exists because Restart=always does not re-trigger
+# when a unit dies while systemd already has a stop job in flight for it
+# (e.g. a crash during shutdown mid-way through a full-stack restart) -
+# that case leaves the unit down with no automatic recovery and no loud
+# signal, since the crash itself typically produces no ERROR-level
+# application log. This makes the failure visible and attempts one
+# recovery restart.
+set -euo pipefail
+
+UNIT="${1:?usage: service_failure_recovery.sh <unit-name-without-.service>}.service"
+
+logger -t eas-station-recovery -p daemon.crit \
+    "${UNIT} entered failed state (result=$(systemctl show -p Result --value "${UNIT}" 2>/dev/null || echo unknown)); attempting recovery"
+
+sleep 2
+
+if systemctl is-active --quiet "${UNIT}"; then
+    logger -t eas-station-recovery -p daemon.info "${UNIT} is already active again, no action needed"
+    exit 0
+fi
+
+if systemctl start "${UNIT}"; then
+    logger -t eas-station-recovery -p daemon.info "${UNIT} recovery restart succeeded"
+else
+    logger -t eas-station-recovery -p daemon.crit "${UNIT} recovery restart FAILED - manual intervention required"
+fi

--- a/systemd/eas-station-audio.service
+++ b/systemd/eas-station-audio.service
@@ -6,6 +6,12 @@ After=network.target redis.service eas-station-sdr.service
 Requires=redis.service
 Wants=eas-station-sdr.service
 
+# Fire a recovery hook if this unit ever ends up in 'failed' state.
+# Notably covers crashes that happen while a stop job is already in
+# flight (e.g. mid-shutdown during a full-stack restart), where
+# Restart=always does not re-trigger on its own.
+OnFailure=eas-station-failure-recovery@%N.service
+
 [Service]
 Type=simple
 User=eas-station

--- a/systemd/eas-station-failure-recovery@.service
+++ b/systemd/eas-station-failure-recovery@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=EAS Station Failure Recovery for %i
+Documentation=https://github.com/KR8MER/eas-station
+
+[Service]
+Type=oneshot
+ExecStart=/opt/eas-station/scripts/service_failure_recovery.sh %i


### PR DESCRIPTION
## Summary
- `eas-station-audio.service` crashed with `SIGABRT` (`terminate called without an active exception`) during shutdown, immediately after its own graceful-shutdown logging had already completed successfully — almost certainly numba/llvmlite's native JIT teardown racing with CPython interpreter finalization on aarch64.
- Because the crash happened while systemd already had a stop job in flight (mid-restart of `eas-station.target`), `Restart=always` never re-triggered, and because the abort is a C++ runtime abort rather than a Python exception, nothing at ERROR level ever recorded it — the service just sat dead and silent for ~2 minutes until the next manual start.

## Changes
- `eas_monitoring_service.py`: exit via `os._exit()` after graceful shutdown instead of `sys.exit()`, bypassing the native teardown where the abort occurs.
- `systemd/eas-station-audio.service`: add `OnFailure=` so any future failed state (not just this one) gets logged loudly and triggers a recovery restart attempt instead of failing silently.
- `systemd/eas-station-failure-recovery@.service` + `scripts/service_failure_recovery.sh`: the recovery hook itself.

## Test plan
- [x] `python -m py_compile eas_monitoring_service.py`
- [x] `systemd-analyze verify` on both unit files (clean, no errors)
- [x] `systemctl show eas-station-audio.service -p OnFailure` resolves to the correct instance
- [x] Recovery script exercised directly (as root, matching how systemd invokes it) against a dummy unit name — confirms failure logging + restart-attempt + outcome logging all work
- [x] Live `eas-station-audio.service` left running throughout, undisturbed (same PID/uptime before and after)
- [ ] Full crash scenario not reproduced live, since that would require deliberately crashing production EAS monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for the station audio service when it unexpectedly stops.
  * Recovery checks whether the service has already restored itself before attempting a restart.
  * Added status and outcome logging to support troubleshooting when manual intervention is required.

* **Reliability Improvements**
  * Improved application shutdown handling to ensure logging is completed and the process exits cleanly.
  * Recovery is also triggered for failures occurring during service shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->