### PR TITLE
Fix EAS audio monitor going permanently silent on binary decode error

### DIFF
--- a/app_core/audio/redis_audio_adapter.py
+++ b/app_core/audio/redis_audio_adapter.py
@@ -93,10 +93,39 @@ class RedisAudioAdapter:
 
     def _initialize(self) -> None:
         """Initialize Redis connection and subscription."""
-        from app_core.redis_client import get_redis_client
+        import redis as redis_lib
+        from app_core.config.redis_config import (
+            get_redis_host,
+            get_redis_port,
+            get_redis_db,
+            get_redis_password,
+            RedisTimeouts,
+        )
 
         try:
-            self._redis_client = get_redis_client()
+            # Audio frames published on audio:samples:* are raw binary
+            # (magic + struct header + float32 samples), not UTF-8 text.
+            # The shared app-wide client from get_redis_client() is
+            # decode_responses=True, which makes redis-py try to UTF-8
+            # decode every pub/sub payload before it reaches our code --
+            # raw audio bytes are routinely not valid UTF-8, so that client
+            # raises UnicodeDecodeError out of pubsub.listen() itself and
+            # permanently kills this subscriber thread (no reconnect) on
+            # the first real audio chunk. Use a dedicated raw-bytes
+            # connection for this subscription instead.
+            self._redis_client = redis_lib.Redis(
+                host=get_redis_host(),
+                port=get_redis_port(),
+                db=get_redis_db(),
+                password=get_redis_password(),
+                decode_responses=False,
+                socket_connect_timeout=RedisTimeouts.CONNECT_TIMEOUT,
+                socket_timeout=RedisTimeouts.SOCKET_TIMEOUT,
+                socket_keepalive=True,
+                health_check_interval=RedisTimeouts.HEALTH_CHECK_INTERVAL,
+                retry_on_timeout=True,
+            )
+            self._redis_client.ping()
             logger.info(f"Redis audio adapter '{self.subscriber_id}' connected to Redis")
         except Exception as e:
             raise RuntimeError(f"Failed to connect to Redis: {e}") from e


### PR DESCRIPTION
## Summary
- `eas-station-eas.service` was reporting `audio_flowing=False` / `health=0.0%` indefinitely, even though `eas-station-audio.service` was running fine and actively publishing audio.
- Root cause: `RedisAudioAdapter` (the EAS monitor's audio subscriber) used the shared app-wide Redis client, which is configured with `decode_responses=True`. The `audio:samples:*` channels carry raw binary frames (magic bytes + struct header + `float32` PCM samples), not UTF-8 text. The first real audio chunk causes redis-py to raise `UnicodeDecodeError` while trying to UTF-8-decode the payload — inside `pubsub.listen()` itself, one layer below the adapter's own `try/except` around per-message parsing. That exception escapes the subscriber loop entirely and the background thread dies for good, with no reconnect logic. From that point on the EAS monitor never receives audio again until the process is restarted (and it breaks again immediately on every restart, ~2s in).
- Fix: give `RedisAudioAdapter` its own dedicated Redis connection with `decode_responses=False` for this specific subscription, instead of reusing the shared string-mode client. Connection parameters are pulled from the same `app_core.config.redis_config` helpers used elsewhere.

## Verification
Restarted `eas-station-eas.service` on the live station after applying the fix:
- Before: `audio_flowing=False, health=0.0%` immediately and indefinitely (crash ~2s after every start, confirmed via journal `UnicodeDecodeError` + `Redis audio subscriber loop exited`).
- After: `audio_flowing=True, health=100.0%` within 5s of startup, sustained with zero errors and steady throughput (~48k samples/sec) over several minutes of observation.

## Test plan
- [x] `py_compile` on the changed file
- [x] Live restart of `eas-station-eas.service`, confirmed `audio_flowing` transitions to `True` and stays there
- [x] Confirmed no `UnicodeDecodeError` / subscriber-loop-exit in logs after the fix
- [ ] Would be good to also confirm SAME/EAS tone decoding still works end-to-end against a real feed (not verified in this session — only audio delivery to the monitor was confirmed)