### PR TITLE
Fix systemd unit files installed with executable bit, causing recurring warnings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1795,6 +1795,15 @@ cp "$INSTALL_DIR/systemd/"*.service /etc/systemd/system/
 cp "$INSTALL_DIR/systemd/"*.target /etc/systemd/system/
 cp "$INSTALL_DIR/systemd/"*.timer /etc/systemd/system/ 2>/dev/null || true
 
+# The earlier "chmod -R 755 $INSTALL_DIR" (setting up the install tree) makes
+# these executable along with everything else, which cp then propagates into
+# /etc/systemd/system. systemd warns "Unknown key ... marked executable" for
+# every such unit on every reload/boot. Unit files aren't meant to be run
+# directly, so strip the bit back off after copying.
+for src in "$INSTALL_DIR/systemd/"*.service "$INSTALL_DIR/systemd/"*.target "$INSTALL_DIR/systemd/"*.timer; do
+    [ -f "$src" ] && chmod 644 "/etc/systemd/system/$(basename "$src")"
+done
+
 systemctl daemon-reload
 echo_success "Systemd service files installed"
 

--- a/update.sh
+++ b/update.sh
@@ -766,6 +766,12 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
     cp "$INSTALL_DIR/systemd/"*.target /etc/systemd/system/ 2>/dev/null || true
     cp "$INSTALL_DIR/systemd/"*.timer /etc/systemd/system/ 2>/dev/null || true
 
+    # Guard against a stale executable bit riding along from $INSTALL_DIR
+    # (see install.sh) and tripping systemd's "marked executable" warning.
+    for src in "$INSTALL_DIR/systemd/"*.service "$INSTALL_DIR/systemd/"*.target "$INSTALL_DIR/systemd/"*.timer; do
+        [ -f "$src" ] && chmod 644 "/etc/systemd/system/$(basename "$src")"
+    done
+
     # Phase 4 retired the monolithic eas-station-hardware.service in favour of
     # five per-subsystem units bundled under eas-station-hardware.target.
     # Existing installs still have the old unit on disk and enabled — strip it


### PR DESCRIPTION
## Summary
- Every boot / daemon-reload logs a stream of warnings like:
  `Configuration file /etc/systemd/system/eas-station-audio.service is marked executable. Please remove executable permission bits. Proceeding anyway.`
  for `eas-station-*.service`, `eas-station.target`, and `certbot.service`/`certbot.timer`.
- Root cause: `install.sh`'s `chmod -R 755 "$INSTALL_DIR"` (run to set up ownership/permissions for the whole install tree) also makes every file under `systemd/` executable, including the unit files. `cp "$INSTALL_DIR/systemd/"*.service /etc/systemd/system/` then propagates that mode into the live systemd directory. The files are tracked as `100644` (non-executable) in git — this is purely a side effect of the blanket `chmod -R 755`, not intentional.
- Fix: after copying the unit files into `/etc/systemd/system`, explicitly `chmod 644` them back down, in both `install.sh` (where the blanket chmod actually happens) and `update.sh` (defense in depth, in case update flows are ever restructured to also touch permissions).

## Verification
- `bash -n` on both scripts.
- Reproduced and fixed the live symptom on the station directly: cleared the executable bit on the affected `/etc/systemd/system/*` files and ran `systemctl daemon-reload` — the warnings stopped appearing and `systemctl --failed` remained empty.

## Test plan
- [x] `bash -n install.sh` / `bash -n update.sh`
- [x] Manually verified the fix eliminates the warning on a live install
- [ ] Not re-run through a full `install.sh` end-to-end in this session (no spare box to install fresh on) — the change is a straightforward `chmod` appended after existing `cp` calls, low risk, but flagging that a full fresh-install dry run wasn't performed