### PR TITLE
Fix Zigbee coordinator crash-on-startup and audio service DEBUG log spam

### DIFF
--- a/eas_monitoring_service.py
+++ b/eas_monitoring_service.py
@@ -60,7 +60,7 @@ from app_core.logging_context import (
     install_alert_filter,
 )
 logging.basicConfig(
-    level=logging.DEBUG,  # Changed from INFO to DEBUG to show diagnostic logs
+    level=logging.INFO,
     format=LOG_FORMAT_WITH_ALERT,
     handlers=[
         logging.StreamHandler(sys.stdout)

--- a/services/zigbee/controller.py
+++ b/services/zigbee/controller.py
@@ -108,13 +108,21 @@ class ZigpyController:
 
         os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
 
-        config = ControllerApplication.SCHEMA({
+        # Pass the raw config dict -- ControllerApplication.__init__() already
+        # runs it through self.SCHEMA(config) itself. Pre-validating here too
+        # double-runs the schema: the first pass turns the default OTA
+        # provider entries from dicts into live ZigpyOtaProvider objects, and
+        # the second pass (inside ControllerApplication.__init__) then tries
+        # to validate those objects as if they were still dicts, crashing
+        # with "AttributeError: 'ZigpyOtaProvider' object has no attribute
+        # 'get'" on every startup.
+        config = {
             "database_path": self._db_path,
             "device": {
                 "path": self.port,
                 "baudrate": self.baudrate,
             },
-        })
+        }
 
         self._app = ControllerApplication(config)
         self._app.add_listener(self)


### PR DESCRIPTION
## Summary

**Zigbee coordinator crash (`services/zigbee/controller.py`)**
`ZigpyController._start_app()` called `ControllerApplication.SCHEMA(...)` on the config dict *and then* passed the result to `ControllerApplication(config)`, whose own `__init__` runs `self.SCHEMA(config)` again. Double-validating breaks the default OTA provider list: the first pass turns those entries from plain dicts into live `ZigpyOtaProvider` objects, and the second pass then tries to validate those objects as if they were still dicts, raising `AttributeError: 'ZigpyOtaProvider' object has no attribute 'get'` on every single startup. The wrapping service process catches the exception and stays "active" in systemd, so this was invisible to `systemctl status` and to the system-health page's top-level status/issues rollup — only visible in the buried `hardware_subsystems.zigbee.data.coordinator_running` flag, which sat at `false` indefinitely. Fix: pass the raw dict once and let `ControllerApplication` validate it itself.

I initially misdiagnosed this as a `zigpy`/`zigpy-znp` version incompatibility and pinned `zigpy<2.0` in `requirements.txt`. That was wrong — the crash reproduces identically on `zigpy==1.6.0`, confirming it's the double-validation bug above, not a dependency issue. That pin is **not** included in this PR; `requirements.txt` is unchanged.

**Audio service DEBUG log spam (`eas_monitoring_service.py`)**
`logging.basicConfig(level=logging.DEBUG, ...)` was hardcoded with a comment noting it was "changed from INFO to DEBUG to show diagnostic logs" and never reverted. This overrides `.env`'s `LOG_LEVEL=INFO` entirely, and — unlike the sibling `eas_service.py`, which correctly hardcodes `INFO` — logs every FM-stereo-demod decode step for every audio chunk across all sources, continuously. Real, ongoing CPU and journal-volume cost on a station that already runs close to its 4-core budget. Reverted to `INFO`.

## Verification
- Restarted `eas-station-zigbee.service`: coordinator now reaches `"Zigpy coordinator running on /dev/ttyUSB0 (channel 15, PAN ID 0x1a62)"` with no exception. Confirmed via `get_system_health()`'s own `coordinator_running` flag: `False` → `True`.
- Restarted `eas-station-audio.service`: confirmed zero `[DEBUG]` lines from the new process (grepped by PID to rule out tail-end lines from the outgoing process). `eas-station-eas.service` continued reporting `audio_flowing=True, health=100.0%` throughout — no regression to the EAS monitoring path from either restart.

## Test plan
- [x] `py_compile` on both changed files
- [x] Live restart of both services, confirmed fix + no regression via each service's own status output
- [x] Reproduced the "double-validation" theory in isolation (`ControllerApplication.SCHEMA()` called twice on the same dict raises the exact same `AttributeError`) before committing to this as the real root cause