### PR TITLE
Fix stream audio sources busy-polling FFmpeg pipe, freeing ~1 CPU core

### DIFF
--- a/app_core/audio/sources.py
+++ b/app_core/audio/sources.py
@@ -1535,16 +1535,19 @@ class StreamSourceAdapter(AudioSourceAdapter):
         the HTTP connection before audio data starts flowing. Setting _had_data_activity=True
         prevents the capture loop from excessive sleeping during connection establishment.
         """
-        # CRITICAL: Set this True for stream sources to prevent capture loop from sleeping
-        # while FFmpeg is connecting to the network stream. FFmpeg needs time to:
-        # 1. Resolve DNS
-        # 2. Establish TCP connection
-        # 3. Send HTTP request
-        # 4. Receive response headers
-        # 5. Begin receiving audio stream
-        # This can take 5-10 seconds for remote streams. During this time, we want the
-        # capture loop to keep polling frequently rather than sleeping 50ms between attempts.
-        self._had_data_activity = True  # Stream sources are always "active" even when connecting
+        # Only skip the capture loop's idle-sleep while FFmpeg is still
+        # establishing the connection (DNS, TCP, HTTP headers -- can take
+        # 5-10s for remote streams) -- not for the stream's entire runtime.
+        # This used to be unconditional, which meant that once a stream
+        # connected, this thread never slept again: every empty read spun
+        # straight back into stdout.read() with no delay, burning a full
+        # CPU core's worth of GIL time 24/7 and starving other threads in
+        # this process (including the SDR/RBDS decode threads) of scheduling
+        # opportunities. _last_connection_time is set the first time real
+        # audio data arrives, so it's already the right signal for "still
+        # connecting vs. steady-state" -- reuse it here instead of pinning
+        # the flag on.
+        self._had_data_activity = self._last_connection_time is None
 
         process = self._ffmpeg_process
         if process is None or process.poll() is not None:


### PR DESCRIPTION
## Summary
Investigated SDR/RBDS decode stability (SYNC LOST roughly every 20-40s, sustained). Ruled out audio-broadcast-queue underruns (negligible) and USB/kernel-level errors (none in dmesg); found a real, independent, well-evidenced software bug in the shared process instead.

`StreamSourceAdapter._read_audio_chunk()` (for the WNCI/ERN-LUC internet-radio stream sources) set `self._had_data_activity = True` **unconditionally on every call**, not just while FFmpeg was still connecting. The shared capture loop (`ingest.py`) only sleeps 50ms between reads when that flag is false — so once a stream connected, it never went back to false, and these two threads spun straight back into `stdout.read()` with **zero delay, for the rest of the process's life**.

`py-spy` thread dump + `pidstat` per-thread profiling on the live station showed:
- `audio-WNCI` / `audio-ERN-LUC`: ~35-41% CPU **each**, just polling an idle pipe
- The RBDS decode thread and the SDR-sample-reading thread (same process, same GIL) losing 9-19% of their time to scheduling wait behind them

All three signal paths (2 internet streams, 1 SDR/RBDS) share a single Python process, so this contention is a plausible contributor to the RBDS sync-loss rate under separate investigation — though I want to be upfront that I can't rule out some genuine RF-side component too; more observation time is needed to know how much of that this actually fixes.

`_last_connection_time` is already set the moment the first real audio chunk arrives, so it's the correct signal for "still connecting" vs. "steady state" — reused it instead of pinning the flag permanently on.

## Verification
- Restarted `eas-station-audio.service`, confirmed both streams reconnect ("Stream connected successfully").
- `pidstat -t`, 5s samples before/after: `audio-WNCI` and `audio-ERN-LUC` dropped from ~35-41% CPU each to <1% each. Process total CPU: **~149% → ~44%** — roughly a full CPU core freed on a 4-core station.
- `eas-station-eas.service` continued reporting `audio_flowing=True, health=100.0%` throughout — no regression to EAS monitoring.
- RBDS sync recovered normally post-restart; running a clean streak of "sync OK, 0 bad blocks" checks at time of writing. Flagging this as a promising early sign, not a confirmed fix of the sync-loss rate — that needs longer observation.

## Test plan
- [x] `py_compile` on the changed file
- [x] Live restart, confirmed both streams reconnect
- [x] Before/after CPU profiling via `pidstat -t` and `py-spy dump`
- [x] Confirmed no regression to `audio_flowing`/EAS monitoring
- [ ] Longer-term RBDS sync-loss rate comparison (hours, not the ~2 minutes observed in this session) — recommend watching `RBDS SYNC LOST` frequency in the coming days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream handling after connection establishment.
  * Prevented unnecessary continuous polling when no new audio data is available.
  * Restored appropriate idle behavior during steady-state streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->