### PR TITLE
Fix manual SDR gain silently overridden by AGC

### DIFF
--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -1092,12 +1092,30 @@ class _SoapySDRReceiver(ReceiverInterface):
             external_lna_db = float(self.config.external_lna_db or 0.0)
             if self.config.gain is not None:
                 try:
+                    # Explicitly drop out of AGC before pinning a manual gain.
+                    # Without this, a device that opened in (or defaulted to)
+                    # AGC mode keeps its gain loop running and silently
+                    # overrides whatever setGain() below requests -- the call
+                    # succeeds and logs normally, but the requested gain never
+                    # actually takes hold. The external-LNA branch below this
+                    # one already does this; this branch didn't.
+                    if device.hasGainMode(SoapySDR.SOAPY_SDR_RX, channel):
+                        device.setGainMode(SoapySDR.SOAPY_SDR_RX, channel, False)
                     device.setGain(SoapySDR.SOAPY_SDR_RX, channel, float(self.config.gain))
+                    try:
+                        readback_gain = device.getGain(SoapySDR.SOAPY_SDR_RX, channel)
+                        readback_mode = device.getGainMode(SoapySDR.SOAPY_SDR_RX, channel)
+                    except Exception:
+                        readback_gain = None
+                        readback_mode = None
                     self._interface_logger.info(
-                        "Set gain to %.1f dB for %s (external LNA: %+.1f dB)",
+                        "Set gain to %.1f dB for %s (external LNA: %+.1f dB) "
+                        "[readback: gain=%s agc_mode=%s]",
                         float(self.config.gain),
                         self.config.identifier,
                         external_lna_db,
+                        readback_gain,
+                        readback_mode,
                     )
                 except Exception as exc:
                     self._interface_logger.warning(


### PR DESCRIPTION
## Summary
Investigating RBDS sync-loss stability on the "wbks" RTL-SDR receiver. `radio_receivers.gain` was `NULL` for this receiver, meaning hardware AGC was active. RTL2832U/R820T2 hardware AGC is known to run hot; `signal_strength` (mean IQ magnitude, ~1.17 against a theoretical max of ~1.41 for normalized complex samples) suggested the front end might be overloading, which would explain RDS specifically struggling even while the much stronger FM pilot/audio stayed locked (RDS sits on a subcarrier ~30dB below the main signal -- exactly what clipping-induced intermodulation noise would hit hardest).

Set `gain = 25.4` (DB) as a conservative manual value. First attempt: `setGain()` succeeded and logged normally, but `signal_strength` didn't move at all. Root cause: `_SoapySDRReceiver`'s manual-gain branch never called `setGainMode(False)` before `setGain()` -- the neighboring external-LNA branch does this correctly, this one didn't. If the device opened in (or defaulted to) AGC mode, the active gain loop could silently override the manual value forever, with `setGain()` still returning success and logging as if it worked.

Fix: call `setGainMode(False)` first (guarded by `hasGainMode()`, matching the existing pattern). Also added a `getGain()`/`getGainMode()` readback right after `setGain()`, logged alongside the existing message -- this is literally how I confirmed the fix actually worked, since `signal_strength` turned out not to be a reliable validation signal on its own (RTL-SDR's well-documented DC-offset/LO-leakage artifact from its zero-IF architecture dominates a naive mean-magnitude calculation regardless of real gain).

## Verification
- Live readback after the fix: `Set gain to 25.4 dB for wbks ... [readback: gain=25.4 agc_mode=False]` -- confirms the driver itself now reports the requested gain/mode, not just "call didn't throw."
- `RBDS SYNC LOST` frequency: ~2.3/min sustained baseline -> **0 events across two separate ~3 minute steady-state windows** post-restart (excluding the normal ~60s resync transient every restart produces, restart-to-restart, all session).
- No regression: `eas-station-eas.service` continued reporting `audio_flowing=True, health=100.0%` throughout.

## Test plan
- [x] `py_compile` on the changed file
- [x] Live restart, confirmed gain readback matches requested value/mode
- [x] RBDS sync-loss rate measured before/after over multiple windows
- [x] Confirmed no regression to EAS audio monitoring
- [ ] Longer-term observation (hours/days) recommended to confirm this holds up outside the ~3 minute windows observed in this session, and to rule out the RF-side variability (multipath, etc.) I can't fully control for