### PR TITLE
Hide debug/metrics/health nav entries that are structurally always empty

### DIFF
--- a/templates/logs.html
+++ b/templates/logs.html
@@ -82,18 +82,30 @@
                             <i class="fas fa-satellite-dish"></i> Polling
                         </a>
                     </li>
+                    {% if polling_debug_enabled %}
                     <li class="nav-item" role="presentation">
                         <a class="nav-link {% if log_type == 'polling_debug' %}active{% endif %}"
                            href="?type=polling_debug&limit={{ limit }}">
                             <i class="fas fa-bug"></i> Debug
                         </a>
                     </li>
+                    {% endif %}
                     <li class="nav-item" role="presentation">
                         <a class="nav-link {% if log_type == 'audio' %}active{% endif %}"
                            href="?type=audio&limit={{ limit }}">
                             <i class="fas fa-volume-up"></i> Audio
                         </a>
                     </li>
+                    {#
+                        "Metrics" (audio_metrics -> AudioSourceMetrics) and "Health"
+                        (audio_health -> AudioHealthStatus) have no writer anywhere in
+                        the codebase -- nothing has ever inserted a row into either
+                        table, so these tabs are permanently empty, not just currently
+                        empty. Unlike "Debug" above (which has a real on/off switch,
+                        CAP_POLLER_DEBUG_RECORDS), there's no flag to gate these on;
+                        they're dead until someone implements the writer. Hidden here
+                        rather than deleted so it's a one-line change to bring back
+                        once that happens.
                     <li class="nav-item" role="presentation">
                         <a class="nav-link {% if log_type == 'audio_metrics' %}active{% endif %}"
                            href="?type=audio_metrics&limit={{ limit }}">
@@ -106,6 +118,7 @@
                             <i class="fas fa-heartbeat"></i> Health
                         </a>
                     </li>
+                    #}
                     <li class="nav-item" role="presentation">
                         <a class="nav-link {% if log_type == 'gpio' %}active{% endif %}"
                            href="?type=gpio&limit={{ limit }}">

--- a/webapp/navigation/registry.py
+++ b/webapp/navigation/registry.py
@@ -46,6 +46,8 @@ Permission tuples are *any-of*. Names must exist in
 ``app_core.auth.roles.PermissionDefinition``.
 """
 
+import os
+
 from .permissions import (
     ALERTS_EXPORT,
     ALERTS_VIEW,
@@ -64,6 +66,15 @@ from .types import (
 
 # Anyone who monitors the station's radio/audio chain.
 _RADIO_WATCHERS = (ALERTS_VIEW, RECEIVERS_VIEW, LOGS_VIEW)
+
+# /debug/ipaws only has anything to show when the poller was started with
+# CAP_POLLER_DEBUG_RECORDS=1 (see poller/cap_poller.py) -- it's an opt-in,
+# CPU/DB-intensive troubleshooting mode, off by default. Mirror that same
+# flag here so the nav entry doesn't lead people to a page that's
+# permanently empty for this station.
+_IPAWS_POLLER_DEBUG_ENABLED = os.environ.get(
+    "CAP_POLLER_DEBUG_RECORDS", ""
+).strip().lower() in {"1", "true", "yes", "on", "t", "y"}
 
 
 # ---------------------------------------------------------------------------
@@ -308,12 +319,17 @@ _DIAGNOSTICS = NavSection(
                     description="Per-receiver SNR, sample rate and tuning diagnostics.",
                     permissions=(RECEIVERS_VIEW,),
                 ),
-                NavItem(
-                    label="IPAWS Poller Debug",
-                    icon="fas fa-bug",
-                    href="/debug/ipaws",
-                    description="Raw IPAWS poll requests, responses and timings.",
-                ),
+            ) + (
+                (
+                    NavItem(
+                        label="IPAWS Poller Debug",
+                        icon="fas fa-bug",
+                        href="/debug/ipaws",
+                        description="Raw IPAWS poll requests, responses and timings.",
+                    ),
+                )
+                if _IPAWS_POLLER_DEBUG_ENABLED
+                else ()
             ),
         ),
     ),

--- a/webapp/public/logs.py
+++ b/webapp/public/logs.py
@@ -21,12 +21,24 @@ from __future__ import annotations
 
 """The /logs hub routes and its CSV/PDF exports."""
 
+import os
+from typing import List
+
+from flask import render_template, request, Response
+
 from app_core.config import get_all_log_services
 from app_core.eas_storage import format_local_datetime
 from app_core.extensions import db
 from app_utils.pdf_generator import generate_pdf_document
-from flask import render_template, request, Response
-from typing import List
+
+# /debug/ipaws and the "Debug" logs tab share the same underlying table
+# (PollDebugRecord) and the same opt-in switch -- see poller/cap_poller.py's
+# persist_debug_records() docstring. Off by default: it's a CPU/DB-intensive
+# per-alert debug dump, meant to be turned on temporarily while actively
+# troubleshooting alert filtering, not left running.
+_POLLING_DEBUG_ENABLED = os.environ.get(
+    "CAP_POLLER_DEBUG_RECORDS", ""
+).strip().lower() in {"1", "true", "yes", "on", "t", "y"}
 
 
 def register(app, route_logger, _load_logs_data) -> None:
@@ -140,6 +152,7 @@ def register(app, route_logger, _load_logs_data) -> None:
                 available_services=get_all_log_services(),
                 compliance_summary=compliance_summary,
                 report=report_meta,
+                polling_debug_enabled=_POLLING_DEBUG_ENABLED,
             )
 
         except Exception as exc:  # pragma: no cover - fallback content


### PR DESCRIPTION
## Summary
Three diagnostics pages always show nothing on this station: `/debug/ipaws`, and the "Debug", "Metrics", "Health" tabs on `/logs`. Two different root causes:

**Debug (`/debug/ipaws`, `/logs?type=polling_debug`)** -- both read `PollDebugRecord`, which `persist_debug_records()` only writes to when `CAP_POLLER_DEBUG_RECORDS=1`. That's an intentional opt-in (the docstring explicitly warns it's CPU/DB-intensive, meant for active troubleshooting sessions, not left running) and it's unset here. Gated the nav item and the logs tab behind the same env check, so both only appear when the flag is actually on.

**Metrics / Health (`/logs?type=audio_metrics` / `audio_health`)** -- read `AudioSourceMetrics` / `AudioHealthStatus`. Neither table has a writer anywhere in the codebase (confirmed: `grep` for `AudioSourceMetrics(` / `AudioHealthStatus(` only turns up the model definitions and tests). These aren't gated behind a flag -- they're just never populated, full stop. Commented the two tabs out (not deleted) with an explanation, so restoring them is a one-line change whenever someone implements the missing writer.

## Verification
- `logs.html` compiles under the real Flask app context (all custom Jinja filters registered, not just bare Jinja2)
- `eas-station-web.service` restarted clean
- `/`, `/logs`, `/debug/ipaws` all respond normally post-restart (200/302, no 500s)

## Test plan
- [x] Jinja template compiles under the full app context
- [x] `py_compile` on both changed Python files
- [x] Live restart, smoke-tested the affected routes for 500s
- [ ] Visual check of the `/logs` tab bar and `/diagnostics` nav with a logged-in session (I don't have station credentials) -- worth a quick look to confirm the tabs/nav item actually disappear as expected