### PR TITLE
Fix audio-monitor play buttons (missing nginx route + fragile WAV stream)

### DIFF
--- a/config/nginx-eas-station.conf
+++ b/config/nginx-eas-station.conf
@@ -196,6 +196,36 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
+    # Per-source live monitoring streams (Icecast MP3 mounts), e.g.
+    # /sdr-wbks.mp3, /wnci.mp3 -- one per configured audio source, named by
+    # app_core/audio/mount_points.py's sanitize_mount_name(). Used by the
+    # audio-monitor page's inline <audio> players. Without this block these
+    # fell through to location / (the Flask app), which has no route for
+    # them and redirects to /login -- the actual cause of "play does
+    # nothing" on that page. Same Icecast backend as the eas-*.mp3 block
+    # above (a separate feature -- 16kHz decoder-monitor feeds); the
+    # negative lookahead keeps this block from also matching that one's
+    # mount names, so which block "wins" doesn't depend on file order.
+    location ~* ^/(?!eas-)([a-z0-9_-]+\.mp3)$ {
+        proxy_pass http://127.0.0.1:8000/$1;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_request_buffering off;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
     # Static files (served directly by nginx for better performance)
     location /static/ {
         alias /opt/eas-station/static/;

--- a/templates/audio_monitoring.html
+++ b/templates/audio_monitoring.html
@@ -623,6 +623,7 @@ function renderAudioSources(fullRender = true) {
         const safeId = sanitizeId(source.name);
         const peakValue = source.metrics?.peak_level_db;
         const rmsValue = source.metrics?.rms_level_db;
+        const streamMount = getIcecastStreamUrl(source.name);
 
         return `
         <div class="col-lg-6 col-xl-4 mb-3">
@@ -676,19 +677,24 @@ function renderAudioSources(fullRender = true) {
 
                     <!-- Audio Player -->
                     <div class="audio-player-container" id="player-container-${source.name}">
-                        ${source.status === 'running' ? `
+                        ${source.status === 'running' && streamMount ? `
                             <audio
                                 controls
                                 id="audio-${source.name}"
                                 preload="none"
                                 data-source-name="${escapeHtml(source.name)}"
-                                src="/api/audio/stream/${encodeURIComponent(source.name)}">
+                                src="${streamMount}">
                                 Your browser does not support the audio element.
                             </audio>
                             <div class="audio-player-status small mt-2 text-muted" id="player-status-${source.name}"></div>
                             <small class="text-muted d-block mt-1">
-                                <i class="fas fa-info-circle"></i> Live stream at the source's native sample rate
+                                <i class="fas fa-info-circle"></i> Live stream via Icecast
                             </small>
+                        ` : source.status === 'running' ? `
+                            <div class="alert alert-secondary mb-0">
+                                <i class="fas fa-volume-mute"></i>
+                                No Icecast stream configured for this source -- nothing to play here yet.
+                            </div>
                         ` : `
                             <div class="alert alert-secondary mb-0">
                                 <i class="fas fa-pause-circle"></i>
@@ -1112,10 +1118,13 @@ function initializeAudioPlayers(playingStates = {}, currentTimes = {}) {
 
         const wasPlaying = Boolean(playingStates[source.name]);
 
-        // Simple: Always use Flask MP3 stream
+        // Always use the source's Icecast MP3 mount
         if (!audioEl.src || audioEl.src === '') {
-            audioEl.src = `/api/audio/stream/${encodeURIComponent(source.name)}`;
-            audioEl.load();
+            const streamMount = getIcecastStreamUrl(source.name);
+            if (streamMount) {
+                audioEl.src = streamMount;
+                audioEl.load();
+            }
         }
 
         setPlayerStatus(source.name, 'Ready. Press play to listen.', 'muted');
@@ -1204,9 +1213,12 @@ function scheduleStreamRecovery(audioEl, sourceName) {
 
         // Reconnect stream with cache buster
         setPlayerStatus(sourceName, 'Reconnecting to stream…', 'warning');
-        const cacheBuster = `?ts=${Date.now()}`;
-        audioEl.src = `/api/audio/stream/${encodeURIComponent(sourceName)}${cacheBuster}`;
-        audioEl.load();
+        const streamMount = getIcecastStreamUrl(sourceName);
+        if (streamMount) {
+            const cacheBuster = `?ts=${Date.now()}`;
+            audioEl.src = `${streamMount}${cacheBuster}`;
+            audioEl.load();
+        }
         
         if (wasPlaying) {
             audioEl.play().catch(() => {});
@@ -1262,9 +1274,12 @@ function onAudioPlaybackError(event) {
         // Use exponential backoff: 3s, 6s, 12s
         const backoffMs = 3000 * Math.pow(2, retries);
         setTimeout(() => {
-            const cacheBuster = `?ts=${Date.now()}`;
-            audioEl.src = `/api/audio/stream/${encodeURIComponent(sourceName)}${cacheBuster}`;
-            audioEl.load();
+            const streamMount = getIcecastStreamUrl(sourceName);
+            if (streamMount) {
+                const cacheBuster = `?ts=${Date.now()}`;
+                audioEl.src = `${streamMount}${cacheBuster}`;
+                audioEl.load();
+            }
             
             if (wasPlaying) {
                 audioEl.play().catch(() => {});
@@ -1275,6 +1290,22 @@ function onAudioPlaybackError(event) {
     }
 
     setPlayerStatus(sourceName, 'Unable to connect to audio stream. Please refresh the page or check the source.', 'danger');
+}
+
+function getIcecastStreamUrl(sourceName) {
+    // The inline players point at each source's Icecast MP3 mount (nginx
+    // proxies /<mount>.mp3 straight through to Icecast on :8000 -- see the
+    // "Per-source live monitoring streams" block in the nginx config).
+    //
+    // This used to point at the audio-service's own /api/audio/stream/<name>
+    // endpoint, which streams raw WAV with a 0xFFFFFFFF (unknown-length)
+    // placeholder in the RIFF/data chunk-size fields -- required since a
+    // live stream has no real total length, but not reliably handled by
+    // every browser's native <audio> WAV decoder. MP3 is a self-framing,
+    // genuinely streamable format and doesn't have that problem, and every
+    // source here already has a working Icecast mount.
+    const source = audioSources.find(s => s.name === sourceName);
+    return source?.metrics?.metadata?.icecast_mount || null;
 }
 
 function getSourceIcon(type) {


### PR DESCRIPTION
## Summary

Two independent bugs, either one enough to break the play buttons on `/audio-monitor`:

**1. Missing nginx route.** The inline players used `/api/audio/stream/<name>`, a Flask/audio-service WAV endpoint whose own docstring literally says "This endpoint should never be called -- nginx intercepts /api/audio/stream/ requests" and returns a 503 if hit directly. Switching to the station's existing per-source Icecast MP3 mounts (already proven working today for WNCI/ERN-LUC/sdr-wbks) surfaced a second, separate bug: nginx had **no route for those mount names at all**. The only `*.mp3` proxy block only matches `eas-*.mp3` (a different feature -- the 16kHz EAS-decoder-monitor feeds). Requests for `/sdr-wbks.mp3` etc. fell through to the Flask app, which has no matching route and redirects to `/login`. Added a second `location` block, scoped with a negative lookahead so it can't also swallow the `eas-*.mp3` traffic regardless of file order. Applied to both the live nginx config and the repo's `config/nginx-eas-station.conf` template (so a fresh install/reinstall gets it too).

**2. WAV isn't actually a streaming format.** Independently, the WAV endpoint writes `0xFFFFFFFF` (an "unknown length" placeholder) into the RIFF and data chunk-size fields, because a live stream has no real total length -- WAV's container format has no other way to express that. Browser support for this is inconsistent, since WAV wasn't designed for progressive/infinite streaming the way MP3 was. Pointed the inline players at the source's Icecast MP3 mount instead (self-framing format, no length-declaration problem, and every source here already has one), via a new `getIcecastStreamUrl()` helper that reads `metrics.metadata.icecast_mount` -- a field the `/api/audio/sources` payload the page already fetches was providing all along, just unused for this. Sources without an Icecast mount now show an explicit "nothing to play here yet" message instead of a silently-dead player.

## Verification
- `nginx -t` passes
- `/sdr-wbks.mp3` now returns `200` with `content-type: audio/mpeg` and real MPEG audio bytes, through the same HTTPS origin as the rest of the site (was a `302` to `/login` before)
- `eas-*.mp3` (decoder-monitor feeds) still proxies correctly, unaffected
- Jinja compiles `audio_monitoring.html` under the real Flask app context
- `eas-station-web.service` restarts clean; `/audio-monitor` responds normally post-restart (302 to login, no 500s)

**Not verified:** actual playback in a real browser -- I don't have browser tooling or station login credentials in this session. Recommend a quick manual check after merge.

## Test plan
- [x] `nginx -t`
- [x] Live HTTP test of the new mount route (headers + real audio bytes)
- [x] Confirmed the neighboring `eas-*.mp3` block is unaffected
- [x] Jinja template compiles under the full app context
- [x] Post-restart smoke test (no 500s)
- [ ] Manual browser check: click play on a couple of sources on `/audio-monitor` and confirm audio actually plays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-source live audio monitoring through Icecast MP3 streams.
  * Added automatic stream resolution, playback resumption, and recovery after stalls or errors.
  * Added clear messaging when a source does not have an available audio stream.
  * Enabled cross-origin access and improved streaming behavior for supported audio feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->