### PR TITLE
Give RTL-SDR its own (larger) USB stream MTU

### DIFF
--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -1272,7 +1272,21 @@ class _SoapySDRReceiver(ReceiverInterface):
             # AirSpy: uses internal buffering, bufflen may not be supported
             # RTL-SDR: supports bufflen parameter
             if self.driver_hint == "rtlsdr":
-                stream_args["bufflen"] = str(stream_mtu)
+                # RTL-SDR gets its own (larger) MTU rather than reusing the
+                # AirSpy-tuned value above. At 16384 samples across the
+                # driver's ~15 internal buffers, a Python-side scheduling
+                # hiccup longer than ~240ms at a typical 1.024 Msps IQ rate
+                # is enough to overrun them (SOAPY_SDR_OVERFLOW / error -4,
+                # tracked in connection_health.stream_errors) -- observed in
+                # practice at a steady ~1-per-6-minutes on this station, even
+                # with the system otherwise idle. Doubling it doubles that
+                # headroom for the same reason a bigger read buffer helps
+                # any producer/consumer pairing with an occasionally-late
+                # consumer: it doesn't fix whatever causes the scheduling
+                # delay, it just gives more room to absorb it before data
+                # actually gets dropped.
+                rtlsdr_stream_mtu = stream_mtu * 2
+                stream_args["bufflen"] = str(rtlsdr_stream_mtu)
 
             stream = device.setupStream(
                 SoapySDR.SOAPY_SDR_RX,


### PR DESCRIPTION
## Summary
The USB transfer size (`bufflen`) for RTL-SDR receivers was reusing a value the code comment says was explicitly tuned for AirSpy. At 16384 samples across the driver's ~15 internal buffers, that's ~240ms of headroom at this station's 1.024 Msps IQ rate -- long enough that an occasional Python-side scheduling hiccup trips `SOAPY_SDR_OVERFLOW` (error -4), silently dropping one buffer's worth of IQ samples.

Investigated the actual rate: a steady ~1 overflow every 6 minutes over a clean, restart-free 10.65-hour window (109 events, no bursting/clustering). Ruled out cron/systemd timers and logging intervals as the cause -- nothing else on the system fires on a ~6 minute cadence. Live thread profiling still shows the reader thread losing meaningful time to scheduling wait even with the rest of the system otherwise idle.

**Not currently causing measurable harm**: the app-level ring buffer never overflowed in the same window (`overflow_count` stayed 0), and RBDS held zero sync-loss events over the same 10.65 hours (following [#2367](https://github.com/KR8MER/eas-station/pull/2367)'s gain fix) -- a single ~16ms gap doesn't come close to RBDS's bad-block threshold. This is optional headroom, not a fix for something broken.

Doubled the RTL-SDR MTU so the reader thread has more slack to absorb whatever's causing the occasional delay (still investigating that root cause separately -- GC pause is the leading suspect but unconfirmed). AirSpy's `stream_mtu` value and code path are untouched; this only changes the `rtlsdr` branch.

## Verification
- Restarted `eas-station-sdr.service`: receiver still tunes and locks normally, gain readback still shows `25.4dB / agc_mode=False` (unaffected by this change)
- `eas-station-eas.service` continued reporting `audio_flowing=True, health=100.0%` with no interruption across the restart

## Test plan
- [x] `py_compile` on the changed file
- [x] Live restart, confirmed receiver locks and gain settings are unaffected
- [x] Confirmed no regression to EAS audio monitoring across the restart
- [ ] Watch `connection_health.stream_errors` over the next several hours to confirm the rate actually drops (will report back)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RTL-SDR stream buffering to help prevent data overflow during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->