### PR TITLE
Stretch Security Center traffic dashboard refresh from 60s to 120s

### DIFF
--- a/app_core/analytics/traffic_stats.py
+++ b/app_core/analytics/traffic_stats.py
@@ -61,11 +61,15 @@ _STATUS_FAMILIES = {2: "2xx Success", 3: "3xx Redirect", 4: "4xx Client Error", 
 # of queries. Analytics tolerate a few seconds of staleness, and the cache is
 # invalidated immediately on any data-changing action (purge / anonymize).
 #
-# The TTL sits just under the page's 60s auto-refresh so a second viewer (or the
-# other Gunicorn worker) landing between one operator's ticks is served from the
-# cache instead of re-running ~35 aggregations. At 30s it expired before the
-# next refresh in every case, so concurrent viewers never shared a payload.
-_DASHBOARD_CACHE_TTL_SECONDS = 55
+# The TTL sits just under the page's auto-refresh interval (120s, see
+# REFRESH_MS in templates/security/_traffic_scripts.html) so a second viewer
+# (or the other Gunicorn worker) landing between one operator's ticks is
+# served from the cache instead of re-running ~35 aggregations. At 30s
+# against the old 60s interval it expired before the next refresh in every
+# case, so concurrent viewers never shared a payload -- keep this margin
+# (comfortably under, not equal to, the refresh interval) if either value
+# changes again.
+_DASHBOARD_CACHE_TTL_SECONDS = 115
 _DASHBOARD_CACHE_MAX = 64
 _dashboard_cache: Dict[Any, tuple] = {}
 _dashboard_cache_lock = threading.Lock()

--- a/templates/security/_traffic_scripts.html
+++ b/templates/security/_traffic_scripts.html
@@ -1129,7 +1129,14 @@
         // largest recurring CPU cost the web process carried. Skipping a hidden
         // refresh costs nothing: the next visible tick reloads the data, and
         // becoming visible triggers an immediate reload if the data went stale.
-        const REFRESH_MS = 60000;
+        //
+        // 120s (was 60s): even while the pane genuinely is visible, traffic
+        // analytics don't need sub-2-minute freshness, and this station's CPU
+        // budget is tight enough that halving the query volume for an actively
+        // open dashboard is worth the extra minute of staleness. Keep this in
+        // sync with _DASHBOARD_CACHE_TTL_SECONDS in traffic_stats.py -- that
+        // TTL is deliberately set just under this interval.
+        const REFRESH_MS = 120000;
         let lastLoadedAt = 0;
 
         function trafficPaneVisible() {


### PR DESCRIPTION
## Summary
The Traffic tab on the Security Center dashboard already has good visibility-gating (per the existing comment, skipping refreshes for backgrounded tabs "was the single largest recurring CPU cost the web process carried" before that fix landed). The remaining cost is smaller but still real: every 60 seconds while the pane genuinely is visible, one refresh runs ~35 aggregation queries over `web_request_log`.

Traffic analytics don't need sub-2-minute freshness, and this station's CPU budget is tight enough (context from earlier fixes this session: RTL-SDR buffer overflows, the audio-service busy-poll bug) that halving the query volume for an actively-open dashboard is a reasonable trade for an extra minute of staleness.

Moved `REFRESH_MS` from 60000 to 120000, and `_DASHBOARD_CACHE_TTL_SECONDS` from 55 to 115 to match -- kept deliberately just under the refresh interval (not equal to it), preserving the original relationship, just recalibrated to the new cadence, so a second concurrent viewer (or the other Gunicorn worker) landing between one operator's ticks still gets served from cache instead of re-running everything.

**Flagging a mistake I almost made:** my first pass at this just proposed bumping the TTL alone, before I'd read the comment explaining *why* 55s was chosen (deliberately just under the *old* 60s interval, tuned from an earlier 30s that didn't work). That change would have made a single viewer's own next auto-refresh also serve stale cached data -- directly contradicting the documented intent. This version keeps both values in sync instead of breaking that relationship.

## Verification
- `security_center.html` (which includes `_traffic_scripts.html`) compiles under the real Flask app context
- `eas-station-web.service` restarts clean; `/security/center` responds normally post-restart (302 to login, no 500s)

## Test plan
- [x] `py_compile` on the changed Python file
- [x] Jinja template compiles under the full app context
- [x] Live restart, smoke-tested the route for 500s
- [ ] Manual check with a logged-in session: confirm the Traffic tab still auto-refreshes (just on the new 120s cadence) and that a second browser tab/window sees cache-sharing behavior as expected