### PR TITLE
Slow system_health.html polling from 30s to 60s, retune cache TTL

### DIFF
--- a/app_core/system_health.py
+++ b/app_core/system_health.py
@@ -60,7 +60,14 @@ _HEALTH_WORKER_LOCK = threading.Lock()
 # push (and again on every /api/system_health request) put far more load on
 # the box than the underlying data ever changes.  A short TTL collapses all
 # concurrent callers onto a single computation while still feeling live.
-_HEALTH_SNAPSHOT_TTL_SECONDS = 30.0
+#
+# Measured cost: ~1.1s per snapshot (smartctl + systemd queries dominate).
+# 50s, kept comfortably under the /system_health page's 60s poll interval
+# (see REFRESH_INTERVAL_MS in templates/system_health.html) and above the
+# WebSocket push thread's 60s SYSTEM_HEALTH_INTERVAL, so both callers
+# reliably land inside the same cache window instead of each triggering
+# their own full (expensive) rebuild.
+_HEALTH_SNAPSHOT_TTL_SECONDS = 50.0
 _HEALTH_SNAPSHOT_LOCK = threading.Lock()
 _HEALTH_SNAPSHOT_CACHE: Optional[Dict[str, Any]] = None
 _HEALTH_SNAPSHOT_TIMESTAMP: float = 0.0

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -2761,7 +2761,12 @@
         }
 
         const initialHealthData = {{ health_data_raw | tojson }} || {};
-        const REFRESH_INTERVAL_MS = 30000;
+        // 60s (was 30s): matches the WebSocket push thread's own
+        // SYSTEM_HEALTH_INTERVAL, and keeps this page's polling inside
+        // _HEALTH_SNAPSHOT_TTL_SECONDS's cache window instead of usually
+        // missing it and triggering a fresh ~1.1s snapshot build (smartctl
+        // + systemd queries) on every tick.
+        const REFRESH_INTERVAL_MS = 60000;
         const numberFormatter = new Intl.NumberFormat();
         let lastUpdatedTime = null;
 


### PR DESCRIPTION
## Summary
While looking for other optimizations after the traffic dashboard fix, found a similar but more expensive case. `build_system_health_snapshot()` measured at **~1.1s per call** (it shells out to `smartctl`, queries every systemd service, and reads RTC/GPS state -- meaningfully more expensive than a typical DB-backed dashboard).

The existing in-process cache exists specifically to "collapse concurrent callers onto a single computation" (per its own docstring), but was set to 30s TTL against `system_health.html`'s own 30s poll interval -- landing right on the boundary, so consecutive polls from the same open tab were frequently missing the cache and triggering a fresh ~1.1s rebuild on close to every tick.

Also notable: unlike most other pages in this app, `system_health.html` doesn't use the WebSocket push channel at all -- it polls purely over HTTP, independent of a separate `system_health_update` WebSocket broadcast that already runs on a 60s cadence (`SYSTEM_HEALTH_INTERVAL`, used elsewhere for a header status badge). Moved this page's poll interval to 60s to match that existing cadence rather than inventing a new number, and the cache TTL to 50s -- comfortably under both the 60s poll and the WebSocket thread's own 60s tick.

I checked with the user before changing this one, since (unlike the traffic dashboard's 55s/60s, which had explicit prior-tuning history in a comment) there was no documented reason for the 30s/30s pairing here, and I wanted to confirm the approach rather than guess.

## Verification
- `system_health.html` compiles under the real Flask app context
- `eas-station-web.service` restarts clean; `/system_health` responds normally post-restart (302 to login, no 500s)
- Directly measured `build_system_health_snapshot()` timing (1.145s) rather than assuming

## Test plan
- [x] `py_compile` on the changed Python file
- [x] Jinja template compiles under the full app context
- [x] Live restart, smoke-tested the route for 500s
- [x] Directly measured the snapshot-build cost to confirm this is worth caching well
- [ ] Manual check with a logged-in session: confirm the page still auto-refreshes normally on the new 60s cadence