### PR TITLE
Revert RTL-SDR MTU increase — caused sustained RBDS sync loss

### DIFF
--- a/app_core/radio/drivers.py
+++ b/app_core/radio/drivers.py
@@ -1272,21 +1272,20 @@ class _SoapySDRReceiver(ReceiverInterface):
             # AirSpy: uses internal buffering, bufflen may not be supported
             # RTL-SDR: supports bufflen parameter
             if self.driver_hint == "rtlsdr":
-                # RTL-SDR gets its own (larger) MTU rather than reusing the
-                # AirSpy-tuned value above. At 16384 samples across the
-                # driver's ~15 internal buffers, a Python-side scheduling
-                # hiccup longer than ~240ms at a typical 1.024 Msps IQ rate
-                # is enough to overrun them (SOAPY_SDR_OVERFLOW / error -4,
-                # tracked in connection_health.stream_errors) -- observed in
-                # practice at a steady ~1-per-6-minutes on this station, even
-                # with the system otherwise idle. Doubling it doubles that
-                # headroom for the same reason a bigger read buffer helps
-                # any producer/consumer pairing with an occasionally-late
-                # consumer: it doesn't fix whatever causes the scheduling
-                # delay, it just gives more room to absorb it before data
-                # actually gets dropped.
-                rtlsdr_stream_mtu = stream_mtu * 2
-                stream_args["bufflen"] = str(rtlsdr_stream_mtu)
+                # REVERTED (see commit history): doubling this to 32768
+                # eliminated SOAPY_SDR_OVERFLOW entirely (0 in 41 minutes,
+                # was ~1/6min) but broke RBDS decode -- RBDS SYNC LOST went
+                # from 0 in the prior 10.5 hours to a sustained ~5/minute
+                # immediately after the change and never recovered. Larger,
+                # less-frequent read chunks from SoapySDR most likely
+                # disrupted the RBDS bit-clock recovery's PLL-style timing,
+                # which depends on finer-grained, more frequent sample
+                # delivery than the coarser USB-buffer-overflow problem
+                # cared about. Back to the shared 16384 MTU (same as
+                # AirSpy) until a fix is found that doesn't trade one
+                # regression for a worse one -- RBDS is the more important
+                # of the two by a wide margin.
+                stream_args["bufflen"] = str(stream_mtu)
 
             stream = device.setupStream(
                 SoapySDR.SOAPY_SDR_RX,


### PR DESCRIPTION
## Summary
Reverts #2370. That change worked exactly as designed for its stated goal -- `SOAPY_SDR_OVERFLOW` (`connection_health.stream_errors`) went from ~1-per-6-minutes to **zero** over a clean 41-minute post-restart window. But over that same window, `RBDS SYNC LOST` went from **0** (the prior 10.5 hours, following #2367's gain fix) to a **sustained ~5/minute that never recovered** -- not the normal one-time post-restart resync noise every restart today has shown, a real ongoing regression measured for the full window.

## Root cause theory
Not fully proven, but consistent with the evidence: larger, less-frequent USB read chunks from SoapySDR most likely disrupt the RBDS bit-clock recovery's PLL-style timing, which depends on finer-grained, more frequent sample delivery -- a different sensitivity than the USB-buffer-overflow problem the MTU change was solving for. I didn't anticipate this interaction when proposing #2370, and I want to be upfront that my framing of that change as "pure buffering, no interaction with the RF/timing path" was wrong.

## Verification
- Reverted the config, restarted `eas-station-sdr.service`
- RBDS sync loss dropped back to 2 events in the ~25s immediately following restart (matching the normal one-time settling pattern every restart today has shown), then a clean streak of "sync OK, 0 bad blocks"
- Gain readback still correct (`25.4dB / agc_mode=False`), unaffected by this revert
- `audio_flowing` stayed `True`, `health=100.0%` throughout

## Why not try a smaller MTU increase instead
RBDS stability is worth far more than eliminating a stream-error counter that wasn't causing measurable harm in the first place -- the app-level ring buffer never overflowed either before or after #2370 (`overflow_count` stayed 0 in both cases). Leaving the `stream_errors` question open rather than re-attempting a fix blind; it deserves a slower, more careful investigation with a longer verification window next time, given how narrowly this one missed a real interaction with a completely different subsystem.

## Test plan
- [x] `py_compile` on the changed file
- [x] Live restart, confirmed RBDS recovers to the normal pattern
- [x] Confirmed no regression to gain settings or EAS audio monitoring
- [x] Directly measured RBDS sync-loss rate before/after this revert to confirm it actually fixes the regression, not just assumed