### PR TITLE
Add Raspberry Pi health telemetry: throttle, bootloader, fan, RP1 voltages

### DIFF
--- a/app_utils/system/raspberry_pi.py
+++ b/app_utils/system/raspberry_pi.py
@@ -1,0 +1,256 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""Raspberry Pi-specific health telemetry.
+
+None of this applies to a generic/bare-metal or VM deployment -- every
+collector here is gated on actually running on a Pi (see
+``collect_raspberry_pi_health``) and the whole section is simply omitted
+otherwise, the same way ``_collect_platform_details`` in hardware.py falls
+back cleanly between DMI (generic x86) and device-tree (ARM/Pi) metadata.
+
+Covers four things nothing else in this package surfaces:
+
+* Under-voltage / throttling history (``vcgencmd get_throttled``) -- the
+  single most common root cause of "flaky Pi" reports in the field. Reports
+  both the *current* state and whether it has *ever* happened since boot,
+  which a point-in-time reading can't tell you.
+* Bootloader/EEPROM update availability (``rpi-eeprom-update``).
+* Case fan RPM (``psutil.sensors_fans()`` -- already free, just never wired
+  up anywhere in this codebase).
+* RP1 (Pi 5's I/O southbridge) ADC voltage channels, for the rare case
+  those are worth a second look during hardware troubleshooting. Exposed as
+  plain labelled channels rather than guessing which rail is which -- the
+  kernel driver doesn't publish per-channel labels and getting that wrong
+  would be worse than not showing it.
+"""
+
+import re
+import subprocess
+from typing import Any, Dict, List, Optional
+
+import psutil
+
+from .common import _coerce_int
+
+# vcgencmd get_throttled bit -> (key, human label). Bits 0-3 are the current
+# state; the same bits shifted up to 16-19 mean "has happened since boot".
+# Documented at https://www.raspberrypi.com/documentation/computers/os.html#get_throttled
+_THROTTLE_BITS = (
+    (0, "under_voltage", "Under-voltage detected"),
+    (1, "frequency_capped", "ARM frequency capped"),
+    (2, "throttled", "Currently throttled"),
+    (3, "soft_temp_limit", "Soft temperature limit active"),
+)
+
+
+def _is_raspberry_pi(platform_details: Optional[Dict[str, Any]]) -> bool:
+    """Gate for every collector in this module.
+
+    Checked against both the device-tree "compatible" list and the
+    product/board name string, since which one is populated depends on
+    whether hardware.py found the info via device-tree or DMI.
+    """
+
+    if not platform_details:
+        return False
+
+    compatible = platform_details.get("compatible")
+    if isinstance(compatible, list) and any(
+        "raspberrypi" in str(entry).lower() for entry in compatible
+    ):
+        return True
+
+    for key in ("product_name", "board_name", "sys_vendor"):
+        value = platform_details.get(key)
+        if value and "raspberry" in str(value).lower():
+            return True
+
+    return False
+
+
+def _run(command: List[str], logger, timeout: float = 5.0) -> Optional[str]:
+    """Run a short-lived read-only command, returning stdout or None."""
+
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        if logger:
+            logger.debug("%s timed out", " ".join(command))
+        return None
+    except (OSError, PermissionError) as exc:
+        if logger:
+            logger.debug("%s failed: %s", " ".join(command), exc)
+        return None
+    return completed.stdout or None
+
+
+def _collect_throttle_status(logger) -> Optional[Dict[str, Any]]:
+    """Parse ``vcgencmd get_throttled`` into named current/historical flags."""
+
+    stdout = _run(["vcgencmd", "get_throttled"], logger)
+    if not stdout:
+        return None
+
+    match = re.search(r"throttled=(0x[0-9a-fA-F]+)", stdout)
+    if not match:
+        return None
+
+    mask = _coerce_int(match.group(1))
+    if mask is None:
+        return None
+
+    current: Dict[str, bool] = {}
+    ever: Dict[str, bool] = {}
+    any_current = False
+    any_ever = False
+    for bit, key, _label in _THROTTLE_BITS:
+        now_flag = bool(mask & (1 << bit))
+        ever_flag = bool(mask & (1 << (bit + 16)))
+        current[key] = now_flag
+        ever[key] = ever_flag
+        any_current = any_current or now_flag
+        any_ever = any_ever or ever_flag
+
+    return {
+        "raw_mask": f"0x{mask:x}",
+        "current": current,
+        "ever_since_boot": ever,
+        "healthy": not any_ever,
+        "currently_degraded": any_current,
+    }
+
+
+def _collect_bootloader_status(logger) -> Optional[Dict[str, Any]]:
+    """Parse ``rpi-eeprom-update``'s plain-text report.
+
+    Read-only by default (no ``-a``); never applies anything. Runs fine as
+    an unprivileged user -- it only reads the current EEPROM version and
+    the bundled firmware image under /usr/lib/firmware, both world-readable.
+    """
+
+    stdout = _run(["rpi-eeprom-update"], logger, timeout=10.0)
+    if not stdout:
+        return None
+
+    update_available = "UPDATE AVAILABLE" in stdout
+
+    current_match = re.search(r"CURRENT:\s*(.+?)\s*\(\d+\)", stdout)
+    latest_match = re.search(r"LATEST:\s*(.+?)\s*\(\d+\)", stdout)
+
+    return {
+        "update_available": update_available,
+        "current_date": current_match.group(1).strip() if current_match else None,
+        "latest_date": latest_match.group(1).strip() if latest_match else None,
+    }
+
+
+def _collect_fan_status(logger) -> Optional[Dict[str, Any]]:
+    """Case/board fan RPM, if one is present (already free via psutil)."""
+
+    try:
+        fans = psutil.sensors_fans()
+    except Exception as exc:  # pragma: no cover - depends on psutil support
+        if logger:
+            logger.debug("psutil fan query failed: %s", exc)
+        return None
+
+    if not fans:
+        return None
+
+    entries = []
+    for name, readings in fans.items():
+        for reading in readings:
+            rpm = getattr(reading, "current", None)
+            if rpm is None:
+                continue
+            entries.append({
+                "label": getattr(reading, "label", None) or name,
+                "rpm": rpm,
+            })
+
+    return entries or None
+
+
+def _collect_rp1_voltages(logger) -> Optional[List[Dict[str, Any]]]:
+    """RP1 (Pi 5 I/O controller) ADC channels, in millivolts.
+
+    Exposed as plain labelled channels -- the rp1_adc hwmon driver doesn't
+    publish per-channel in*_label files, so which physical rail each one
+    reads isn't something we can state with confidence.
+    """
+
+    from pathlib import Path
+
+    hwmon_root = Path("/sys/class/hwmon")
+    if not hwmon_root.exists():
+        return None
+
+    for hwmon_dir in sorted(hwmon_root.glob("hwmon*")):
+        name_path = hwmon_dir / "name"
+        try:
+            name = name_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if name != "rp1_adc":
+            continue
+
+        channels = []
+        for in_path in sorted(hwmon_dir.glob("in*_input")):
+            value_mv = _coerce_int(_run_read(in_path))
+            if value_mv is None:
+                continue
+            channel_match = re.match(r"in(\d+)_input$", in_path.name)
+            channel_num = channel_match.group(1) if channel_match else in_path.name
+            channels.append({
+                "label": f"RP1 ADC channel {channel_num}",
+                "millivolts": value_mv,
+            })
+        return channels or None
+
+    return None
+
+
+def _run_read(path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def collect_raspberry_pi_health(
+    logger, platform_details: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Bundle every Pi-specific collector, or None on non-Pi hardware."""
+
+    if not _is_raspberry_pi(platform_details):
+        return None
+
+    return {
+        "throttle_status": _collect_throttle_status(logger),
+        "bootloader": _collect_bootloader_status(logger),
+        "fans": _collect_fan_status(logger),
+        "rp1_voltages": _collect_rp1_voltages(logger),
+    }

--- a/app_utils/system/snapshot.py
+++ b/app_utils/system/snapshot.py
@@ -37,6 +37,7 @@ from .dependencies import _collect_dependency_versions
 from .hardware import _collect_hardware_inventory
 from .network import _collect_network_traffic, _select_primary_interface
 from .osinfo import _collect_operating_system_details
+from .raspberry_pi import collect_raspberry_pi_health
 from .rtc import _collect_rtc_status
 from .services import _collect_systemd_services
 from .smart import _collect_smart_health
@@ -403,6 +404,9 @@ def build_system_health_snapshot(db, logger) -> SystemHealth:
             "dependencies": _collect_dependency_versions(logger),
             "gps": _collect_gps_status(logger),
             "rtc": _collect_rtc_status(logger),
+            "raspberry_pi": collect_raspberry_pi_health(
+                logger, hardware_info.get("platform")
+            ),
         }
         
         # Add shields.io badges and distro logo

--- a/install.sh
+++ b/install.sh
@@ -1290,7 +1290,11 @@ fi
 
 # Create hardware access groups if they don't exist
 echo_progress "Ensuring hardware access groups exist..."
-HARDWARE_GROUPS="gpio i2c spi audio plugdev dialout"
+# video: /dev/vcio_gencmd (vcgencmd) is root:video 0660 -- needed for the
+# Raspberry Pi throttle/under-voltage telemetry on the health dashboard.
+# Harmless no-op on non-Pi installs (the collector self-gates on Pi
+# hardware and vcgencmd just won't be present).
+HARDWARE_GROUPS="gpio i2c spi audio plugdev dialout video"
 GROUPS_CREATED=0
 for group in $HARDWARE_GROUPS; do
     if ! getent group "$group" >/dev/null 2>&1; then

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -1372,6 +1372,113 @@
             </div>
         </div>
 
+        {% set pi_data = raspberry_pi or None %}
+        {% if pi_data %}
+        <div class="health-section-head">
+            <h2>Raspberry Pi</h2>
+            <span class="rule"></span>
+        </div>
+
+        <!-- Raspberry Pi-specific telemetry: none of this exists on a
+             generic/bare-metal x86 or VM deployment, so the whole section
+             is server-gated on raspberry_pi being non-null. -->
+        <div class="row mb-4">
+            <div class="col-lg-6 mb-3" id="pi-power-card">
+                {% set throttle = pi_data.throttle_status or None %}
+                {% set boot = pi_data.bootloader or None %}
+                <div class="card health-card h-100">
+                    <div class="card-body">
+                        <h5><i class="fas fa-bolt section-icon"></i> Power &amp; Firmware</h5>
+
+                        {% if throttle %}
+                            {% if throttle.healthy and not throttle.currently_degraded %}
+                            <div class="metric-row">
+                                <span class="metric-label">Power supply:</span>
+                                <span class="metric-value"><span class="badge bg-success">OK, never throttled</span></span>
+                            </div>
+                            {% else %}
+                                {% if throttle.currently_degraded %}
+                                <div class="alert alert-danger py-2 mb-2"><i class="fas fa-exclamation-triangle me-1"></i> Currently degraded -- see flags below</div>
+                                {% else %}
+                                <div class="alert alert-warning py-2 mb-2"><i class="fas fa-exclamation-triangle me-1"></i> Has occurred since boot -- see flags below</div>
+                                {% endif %}
+                                {% for key, label in [('under_voltage', 'Under-voltage'), ('frequency_capped', 'Frequency capped'), ('throttled', 'Throttled'), ('soft_temp_limit', 'Soft temp limit')] %}
+                                    {% if throttle.current.get(key) or throttle.ever_since_boot.get(key) %}
+                                    <div class="metric-row">
+                                        <span class="metric-label">{{ label }}:</span>
+                                        <span class="metric-value">
+                                            {% if throttle.current.get(key) %}<span class="badge bg-danger">Active now</span>{% endif %}
+                                            {% if throttle.ever_since_boot.get(key) %}<span class="badge bg-warning text-dark">Since boot</span>{% endif %}
+                                        </span>
+                                    </div>
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% else %}
+                        <div class="metric-row"><span class="metric-label text-muted"><em>Throttle status unavailable (vcgencmd)</em></span></div>
+                        {% endif %}
+
+                        <hr>
+                        {% if boot %}
+                            <div class="metric-row">
+                                <span class="metric-label">Bootloader:</span>
+                                <span class="metric-value">
+                                    {% if boot.update_available %}<span class="badge bg-warning text-dark">Update available</span>{% else %}<span class="badge bg-success">Up to date</span>{% endif %}
+                                </span>
+                            </div>
+                            {% if boot.current_date %}
+                            <div class="metric-row">
+                                <span class="metric-label">Current:</span>
+                                <span class="metric-value">{{ boot.current_date }}</span>
+                            </div>
+                            {% endif %}
+                            {% if boot.update_available and boot.latest_date %}
+                            <div class="metric-row">
+                                <span class="metric-label">Latest:</span>
+                                <span class="metric-value">{{ boot.latest_date }}</span>
+                            </div>
+                            {% endif %}
+                        {% else %}
+                        <div class="metric-row"><span class="metric-label text-muted"><em>Bootloader status unavailable</em></span></div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-lg-6 mb-3" id="pi-sensors-card">
+                {% set fans = pi_data.fans or [] %}
+                {% set rp1v = pi_data.rp1_voltages or [] %}
+                <div class="card health-card h-100">
+                    <div class="card-body">
+                        <h5><i class="fas fa-fan section-icon"></i> Fan &amp; RP1 Sensors</h5>
+
+                        {% if fans %}
+                            {% for fan in fans %}
+                            <div class="metric-row">
+                                <span class="metric-label">{{ fan.label or 'Fan' }}:</span>
+                                <span class="metric-value">{{ fan.rpm }} RPM</span>
+                            </div>
+                            {% endfor %}
+                        {% else %}
+                        <div class="metric-row"><span class="metric-label text-muted"><em>No fan detected</em></span></div>
+                        {% endif %}
+
+                        {% if rp1v %}
+                        <hr>
+                        <div class="metric-label text-muted mb-1" style="font-size: 0.8rem;">RP1 ADC channels (unlabelled by the kernel driver)</div>
+                            {% for channel in rp1v %}
+                            <div class="metric-row">
+                                <span class="metric-label">{{ channel.label }}:</span>
+                                <span class="metric-value">{{ channel.millivolts }} mV</span>
+                            </div>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         <div class="health-section-head">
             <h2>Resource Usage</h2>
             <span class="rule"></span>
@@ -3258,6 +3365,94 @@
             `;
         }
 
+        const PI_THROTTLE_FLAGS = [
+            ['under_voltage', 'Under-voltage'],
+            ['frequency_capped', 'Frequency capped'],
+            ['throttled', 'Throttled'],
+            ['soft_temp_limit', 'Soft temp limit'],
+        ];
+
+        function renderPiPowerCard(piData) {
+            const data = piData && typeof piData === 'object' ? piData : {};
+            const throttle = data.throttle_status || null;
+            const boot = data.bootloader || null;
+
+            let throttleHtml;
+            if (!throttle) {
+                throttleHtml = '<div class="metric-row"><span class="metric-label text-muted"><em>Throttle status unavailable (vcgencmd)</em></span></div>';
+            } else if (throttle.healthy && !throttle.currently_degraded) {
+                throttleHtml = `
+                    <div class="metric-row">
+                        <span class="metric-label">Power supply:</span>
+                        <span class="metric-value"><span class="badge bg-success">OK, never throttled</span></span>
+                    </div>`;
+            } else {
+                const banner = throttle.currently_degraded
+                    ? '<div class="alert alert-danger py-2 mb-2"><i class="fas fa-exclamation-triangle me-1"></i> Currently degraded -- see flags below</div>'
+                    : '<div class="alert alert-warning py-2 mb-2"><i class="fas fa-exclamation-triangle me-1"></i> Has occurred since boot -- see flags below</div>';
+                const flagRows = PI_THROTTLE_FLAGS.map(([key, label]) => {
+                    const now = Boolean(throttle.current && throttle.current[key]);
+                    const ever = Boolean(throttle.ever_since_boot && throttle.ever_since_boot[key]);
+                    if (!now && !ever) return '';
+                    const badges = `${now ? '<span class="badge bg-danger">Active now</span>' : ''} ${ever ? '<span class="badge bg-warning text-dark">Since boot</span>' : ''}`;
+                    return `<div class="metric-row"><span class="metric-label">${escapeHtml(label)}:</span><span class="metric-value">${badges}</span></div>`;
+                }).join('');
+                throttleHtml = banner + flagRows;
+            }
+
+            let bootHtml;
+            if (!boot) {
+                bootHtml = '<div class="metric-row"><span class="metric-label text-muted"><em>Bootloader status unavailable</em></span></div>';
+            } else {
+                const statusBadge = boot.update_available
+                    ? '<span class="badge bg-warning text-dark">Update available</span>'
+                    : '<span class="badge bg-success">Up to date</span>';
+                const currentRow = boot.current_date
+                    ? `<div class="metric-row"><span class="metric-label">Current:</span><span class="metric-value">${escapeHtml(String(boot.current_date))}</span></div>`
+                    : '';
+                const latestRow = (boot.update_available && boot.latest_date)
+                    ? `<div class="metric-row"><span class="metric-label">Latest:</span><span class="metric-value">${escapeHtml(String(boot.latest_date))}</span></div>`
+                    : '';
+                bootHtml = `<div class="metric-row"><span class="metric-label">Bootloader:</span><span class="metric-value">${statusBadge}</span></div>${currentRow}${latestRow}`;
+            }
+
+            return `
+                <div class="card health-card h-100">
+                    <div class="card-body">
+                        <h5><i class="fas fa-bolt section-icon"></i> Power &amp; Firmware</h5>
+                        ${throttleHtml}
+                        <hr>
+                        ${bootHtml}
+                    </div>
+                </div>
+            `;
+        }
+
+        function renderPiSensorsCard(piData) {
+            const data = piData && typeof piData === 'object' ? piData : {};
+            const fans = Array.isArray(data.fans) ? data.fans : [];
+            const rp1v = Array.isArray(data.rp1_voltages) ? data.rp1_voltages : [];
+
+            const fanHtml = fans.length
+                ? fans.map((fan) => `<div class="metric-row"><span class="metric-label">${escapeHtml(fan.label || 'Fan')}:</span><span class="metric-value">${toNumber(fan.rpm, 0)} RPM</span></div>`).join('')
+                : '<div class="metric-row"><span class="metric-label text-muted"><em>No fan detected</em></span></div>';
+
+            const rp1Html = rp1v.length
+                ? '<hr><div class="metric-label text-muted mb-1" style="font-size: 0.8rem;">RP1 ADC channels (unlabelled by the kernel driver)</div>'
+                    + rp1v.map((ch) => `<div class="metric-row"><span class="metric-label">${escapeHtml(ch.label || '')}:</span><span class="metric-value">${toNumber(ch.millivolts, 0)} mV</span></div>`).join('')
+                : '';
+
+            return `
+                <div class="card health-card h-100">
+                    <div class="card-body">
+                        <h5><i class="fas fa-fan section-icon"></i> Fan &amp; RP1 Sensors</h5>
+                        ${fanHtml}
+                        ${rp1Html}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderHardwareInventoryCard(blockInfo) {
             const info = blockInfo && typeof blockInfo === 'object' ? blockInfo : {};
             const available = Boolean(info.available);
@@ -4764,6 +4959,18 @@
             const platformContainer = document.getElementById('platform-card');
             if (platformContainer) {
                 platformContainer.innerHTML = renderPlatformCard(hardware.platform || {});
+            }
+
+            // Raspberry Pi telemetry: containers only exist in the DOM when
+            // the server-rendered page detected Pi hardware (raspberry_pi
+            // was non-null on load), so these are no-ops everywhere else.
+            const piPowerContainer = document.getElementById('pi-power-card');
+            if (piPowerContainer && data.raspberry_pi) {
+                piPowerContainer.innerHTML = renderPiPowerCard(data.raspberry_pi);
+            }
+            const piSensorsContainer = document.getElementById('pi-sensors-card');
+            if (piSensorsContainer && data.raspberry_pi) {
+                piSensorsContainer.innerHTML = renderPiSensorsCard(data.raspberry_pi);
             }
 
             const cpuContainer = document.getElementById('cpu-card');

--- a/update.sh
+++ b/update.sh
@@ -884,7 +884,10 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
 
     # Ensure hardware access groups exist (for services that use SupplementaryGroups)
     echo_progress "Ensuring hardware access groups exist..."
-    HARDWARE_GROUPS="gpio i2c spi audio plugdev dialout"
+    # video: /dev/vcio_gencmd (vcgencmd) is root:video 0660 -- needed for the
+    # Raspberry Pi throttle/under-voltage telemetry on the health dashboard.
+    # Harmless no-op on non-Pi installs.
+    HARDWARE_GROUPS="gpio i2c spi audio plugdev dialout video"
     GROUPS_CREATED=0
     for group in $HARDWARE_GROUPS; do
         if ! getent group "$group" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
The health dashboard didn't surface any Pi-specific reliability signals, despite this station running on a Pi 5. Adds four things via a new self-gating collector (`app_utils/system/raspberry_pi.py`) that returns `None` entirely on non-Pi hardware -- so the whole section is simply absent on a generic bare-metal/VM install, the same fallback style `hardware.py` already uses between DMI and device-tree metadata.

- **Under-voltage/throttling history** (`vcgencmd get_throttled`), decoded into named current + "since boot" flags. This is the single most common root cause of "flaky Pi" reports in the field, and a point-in-time reading can't tell you whether it happened once five hours ago -- the since-boot bits can.
- **Bootloader/EEPROM update availability** (`rpi-eeprom-update`, read-only, never invoked with `-a`). Found this station's bootloader is over a year stale (current: May 2025, latest: May 2026) while building this.
- **Case fan RPM** -- already free via `psutil.sensors_fans()`, just never wired into anything in this codebase.
- **RP1 (Pi 5 I/O southbridge) ADC voltage channels** -- exposed as plain labelled channels rather than guessing which rail is which, since the kernel driver doesn't publish per-channel labels and getting that wrong during real troubleshooting would be worse than not showing it.

`vcgencmd` needs `/dev/vcio_gencmd` (root:video, 0660) -- added `eas-station` to the `video` group, both live (`usermod`) and in `install.sh`/`update.sh`'s existing `HARDWARE_GROUPS` list so fresh installs and upgrades both pick it up automatically. Everything else used here (`rpi-eeprom-update`, hwmon, device-tree) needed no privilege changes.

## UI
Two new cards on the health page (Power & Firmware, Fan & RP1 Sensors), gated the same way the existing RTC card is -- server-rendered on load via Jinja, plus a matching JS render function wired into `applyHealthData()` for the page's normal 60s auto-refresh, following the exact pattern every other card on this page already uses.

## Verification
- Collector tested in isolation: all four fields populate correctly against this live station
- Confirmed it correctly returns `None` against a fake non-Pi platform dict (Dell PowerEdge)
- Full page render tested via a real Flask request context (not just a Jinja compile check, which wouldn't catch a runtime template error from bad attribute access)
- `eas-station-web.service` restarts clean; no errors from either the HTTP route or the WebSocket push thread's own periodic snapshot build, which runs through this same collector

## Test plan
- [x] `py_compile` on all changed Python files
- [x] Isolated collector test with real hardware data
- [x] Isolated collector test confirming non-Pi gating works
- [x] Full-page render test via `test_request_context` (not just template compile)
- [x] Live restart, confirmed no errors from HTTP or WebSocket paths
- [ ] Visual check with a logged-in session: confirm both new cards render correctly and update on the 60s refresh cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Raspberry Pi health monitoring for power/throttling status, bootloader updates, fan speed, and sensor voltages.
  - Added Raspberry Pi health details to the System Health page with clear healthy, warning, degraded, and unavailable states.
  - Health monitoring is automatically shown only on supported Raspberry Pi hardware.

- **Improvements**
  - Installer and update processes now configure video-device access required for Raspberry Pi telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->