### PR TITLE
Fix cleanupExpiredFilters() silently reporting success on error

### DIFF
--- a/static/js/pages/security_center.js
+++ b/static/js/pages/security_center.js
@@ -486,6 +486,13 @@
         fetch('/security/ip-filters/cleanup', { method: 'POST' })
             .then(response => response.json())
             .then(data => {
+                // Unlike its siblings (submitIPFilter, deleteFilter,
+                // toggleFilter), this used to skip the data.error check --
+                // a permission-denied or unexpected-exception JSON response
+                // has no cleaned_up field, so `data.cleaned_up || 0` quietly
+                // reported "Cleaned up 0 expired filter(s)" as if it had
+                // succeeded, with the real error swallowed.
+                if (data.error) { notify('Error: ' + data.error, true); return; }
                 loadIPFilters();
                 notify(`Cleaned up ${data.cleaned_up || 0} expired filter(s)`);
             })


### PR DESCRIPTION
## Summary
Reported on a live demo instance: the "Clean Expired" button on `/security/center`'s Global Ban List appears to do nothing.

Found a real, verifiable bug while investigating: unlike its siblings in the same file (`submitIPFilter`, `deleteFilter`, `toggleFilter`), `cleanupExpiredFilters()` never checked the response for `data.error` before declaring success:

```js
.then(data => {
    loadIPFilters();
    notify(`Cleaned up ${data.cleaned_up || 0} expired filter(s)`);  // no error check
})
```

A permission-denied response, a CSRF failure, or an unexpected server-side exception all come back as JSON with an `error` field and no `cleaned_up` field. `data.cleaned_up || 0` reads that as `0` and displays **"Cleaned up 0 expired filter(s)"** -- masking a real failure as a false success with nothing visibly wrong.

I couldn't reproduce the underlying trigger directly -- this station's `ip_filters` table is empty (so "Clean Expired" correctly finding nothing here isn't the same bug), and I don't have access to the demo instance where it was actually reported. But the missing error check is real and verifiable on its own regardless of what's triggering the failure there, and fixing it means the next attempt on the demo instance will surface the actual error instead of a silent false "success" -- which should make the real root cause obvious immediately.

Also checked: all five `ip-filters` routes (list/create/delete/toggle/cleanup) require the same `system.manage_users` permission, so this isn't a permission mismatch specific to cleanup -- just this one handler missing a check every sibling action already has.

## Verification
- Diff matches the exact `if (data.error) { notify('Error: ' + data.error, true); return; }` pattern already used by the three sibling functions in this file
- Brace/paren balance check on the full file
- Confirmed the fix is live and served correctly (`/static/js/pages/security_center.js` returns 200, contains the new check)

## Test plan
- [x] Pattern-matched against sibling functions for consistency
- [x] Static file serves correctly post-edit (no service restart needed for a static JS file)
- [ ] Reproduce on the demo instance where this was originally reported, to confirm the real error message that was being swallowed