### PR TITLE
Fix unclosed sqlite3 connection ResourceWarning in GPIO audit-log tests

### DIFF
--- a/tests/test_gpio_activation_logging.py
+++ b/tests/test_gpio_activation_logging.py
@@ -103,7 +103,15 @@ def audit_db(monkeypatch):
 
     monkeypatch.setattr(app_models, "GPIOActivationLog", GPIOActivationLogStub)
 
-    return app, db, GPIOActivationLogStub
+    yield app, db, GPIOActivationLogStub
+
+    # Explicit teardown: a `return`-only fixture leaves the in-memory
+    # sqlite3.Connection to be closed whenever the garbage collector gets
+    # around to it, which pytest's own end-of-session gc.collect() flags as
+    # "ResourceWarning: unclosed database". Disposing the engine here closes
+    # it deterministically, in the same test run that opened it.
+    with app.app_context():
+        db.engine.dispose()
 
 
 def _make_controller(audit_db, monkeypatch):


### PR DESCRIPTION
## Summary
Found while reviewing the GPIO subsystem's code quality: `test_gpio_activation_logging.py`'s `audit_db` fixture created an in-memory Flask-SQLAlchemy database (`sqlite://`) but only `return`ed it, with no teardown. The connection got closed whenever the garbage collector happened to reclaim it, which pytest's own end-of-session `gc.collect()` flags as `ResourceWarning: unclosed database`.

Converted to a `yield` fixture with an explicit `db.engine.dispose()` after the yield, so the connection closes deterministically at the end of each test that uses it, rather than waiting on GC timing at the end of the whole session.

## Verification
- Isolated the warning to this specific file by running each of the 5 GPIO test files individually
- Full GPIO suite (107 tests, 5 files) still passes after the fix
- `ResourceWarning: unclosed database` no longer appears in the run

## Test plan
- [x] `test_gpio_activation_logging.py` (12 tests) passes standalone, no warning
- [x] Full GPIO suite (107 tests across 5 files) passes, no warning