### PR TITLE
Fix expired IP-filter entries never being purged from the Global Ban List

### DIFF
--- a/app_core/auth/ip_filter.py
+++ b/app_core/auth/ip_filter.py
@@ -401,30 +401,42 @@ class IPFilter(db.Model):
     @staticmethod
     def cleanup_expired() -> int:
         """
-        Clean up expired filters.
-        
+        Purge expired filters from the Global Ban List entirely.
+
+        Deletes rather than deactivating: the per-request expiry checks
+        (``is_ip_allowed`` / ``is_ip_blocked``) already flip ``is_active`` to
+        False the moment an expired entry is hit, but never remove the row,
+        so previously this method (which only touched still-``is_active``
+        rows) could never reach them either -- expired entries piled up in
+        the ban list forever, just relabeled "Inactive". Matching purely on
+        ``expires_at`` (regardless of ``is_active``) sweeps those up too.
+
+        Non-expiring entries that an admin has manually disabled via the
+        toggle button (``expires_at`` is None) are untouched -- disabling
+        is a deliberate, reversible action, not an expiry.
+
         Returns:
-            Number of filters cleaned up
+            Number of filters purged.
         """
         now = utc_now()
         expired = IPFilter.query.filter(
             IPFilter.expires_at.isnot(None),
             IPFilter.expires_at < now,
-            IPFilter.is_active == True
         ).all()
-        
+
         count = 0
         unban_ips = []
         for filter_entry in expired:
-            filter_entry.is_active = False
-            db.session.add(filter_entry)
             if filter_entry.filter_type == IPFilterType.BLOCKLIST.value:
                 unban_ips.append(filter_entry.ip_address)
+            db.session.delete(filter_entry)
             count += 1
 
         db.session.commit()
 
-        # Lift the matching host-firewall bans for the now-expired entries.
+        # Lift the matching host-firewall bans for the now-purged entries.
+        # Best-effort/idempotent: some may have already been unbanned by the
+        # per-request expiry check.
         if unban_ips:
             try:
                 from app_core.auth.firewall import firewall_unban

--- a/tests/test_ip_ban_enforcement.py
+++ b/tests/test_ip_ban_enforcement.py
@@ -112,3 +112,41 @@ def test_inactive_blocklist_entry_does_not_block(app_with_filters):
         db.session.commit()
 
         assert IPFilter.is_ip_blocked("203.0.113.11") == (False, None)
+
+
+def test_cleanup_expired_purges_active_and_already_inactive_expired_entries(app_with_filters):
+    """Regression test: cleanup_expired() used to only flip is_active to False
+    on still-active expired rows, so it could never reach rows the
+    is_ip_blocked/is_ip_allowed expiry check had already deactivated -- those
+    piled up in the Global Ban List forever, just relabeled "Inactive". It
+    should delete both kinds, and leave non-expiring disabled entries alone."""
+    app, db = app_with_filters
+    from app_core.auth.ip_filter import IPFilter, IPFilterReason
+
+    with app.app_context():
+        still_active_expired = IPFilter.add_to_blocklist(
+            "203.0.113.20", reason=IPFilterReason.MANUAL.value
+        )
+        still_active_expired.expires_at = utc_now() - timedelta(hours=1)
+
+        already_inactive_expired = IPFilter.add_to_blocklist(
+            "203.0.113.21", reason=IPFilterReason.MANUAL.value
+        )
+        already_inactive_expired.expires_at = utc_now() - timedelta(hours=2)
+        already_inactive_expired.is_active = False
+
+        manually_disabled_non_expiring = IPFilter.add_to_blocklist(
+            "203.0.113.22", reason=IPFilterReason.MANUAL.value
+        )
+        manually_disabled_non_expiring.is_active = False
+
+        still_active_permanent = IPFilter.add_to_blocklist(
+            "203.0.113.23", reason=IPFilterReason.MANUAL.value
+        )
+        db.session.commit()
+
+        count = IPFilter.cleanup_expired()
+
+        assert count == 2
+        remaining_ips = {f.ip_address for f in IPFilter.query.all()}
+        assert remaining_ips == {"203.0.113.22", "203.0.113.23"}


### PR DESCRIPTION
## Summary
- `IPFilter.cleanup_expired()` (backing the Security Center's "Clean Expired" button on the Global Ban List) only ever set `is_active = False` on expired entries instead of deleting them, so the ban list never actually shrank — rows just sat forever relabeled "Inactive".
- It also only matched still-`is_active` rows, so entries the per-request expiry check (`is_ip_allowed`/`is_ip_blocked`) had already deactivated on the fly were invisible to it and piled up permanently with no way to clear them in bulk.
- Now it deletes any row whose `expires_at` is in the past, regardless of current `is_active` state, while leaving manually-disabled non-expiring entries untouched (that's a deliberate toggle via the "Disable" button, not an expiry).

## Test plan
- [x] Added `test_cleanup_expired_purges_active_and_already_inactive_expired_entries` covering: still-active-expired, already-inactive-expired, manually-disabled-non-expiring, and still-active-permanent entries — asserts only the two expired ones are purged.
- [x] `pytest tests/test_ip_ban_enforcement.py tests/test_firewall_sync_state.py tests/test_ssh_ban_resync.py tests/test_allowlist_lockout_guard.py tests/test_fail2ban_sync.py` — 15 passed.

https://claude.ai/code/session_01AwQyuYn3G4wM7dPKWtQJHd