### PR TITLE
Fix fail2ban apply reporting spurious failure on a slow jail startup

### DIFF
--- a/tests/test_fail2ban_apply_race.py
+++ b/tests/test_fail2ban_apply_race.py
@@ -1,0 +1,68 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+Regression test for a race in the fail2ban "Save & Apply Configuration" flow.
+
+Background: ``configure_fail2ban()`` writes jail.local, restarts fail2ban, then
+checks ``_loaded_jails()`` once to confirm the ``eas-station`` actuator jail
+came up before reporting success. ``systemctl restart`` returns as soon as
+systemd considers the unit started, which can be a beat before fail2ban-server
+has actually finished parsing jail.local and bringing every jail up -- so a
+single immediate check could report a good apply as a failure (observed live:
+the jail appeared in ``fail2ban-client status`` about a second after the
+restart returned, well after the single check had already given up). This test
+pins ``_wait_for_jail_loaded`` to tolerate that startup lag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("flask")
+
+
+def test_wait_for_jail_loaded_tolerates_late_startup(monkeypatch):
+    from webapp.admin import fail2ban
+
+    # First two checks: jail not up yet. Third: it has finally loaded.
+    calls = {"n": 0}
+
+    def fake_loaded_jails():
+        calls["n"] += 1
+        return {"eas-station"} if calls["n"] >= 3 else set()
+
+    monkeypatch.setattr(fail2ban, "_loaded_jails", fake_loaded_jails)
+    monkeypatch.setattr(fail2ban.time, "sleep", lambda _seconds: None)
+
+    assert fail2ban._wait_for_jail_loaded("eas-station") is True
+    assert calls["n"] == 3
+
+
+def test_wait_for_jail_loaded_gives_up_eventually(monkeypatch):
+    from webapp.admin import fail2ban
+
+    monkeypatch.setattr(fail2ban, "_loaded_jails", lambda: set())
+    monkeypatch.setattr(fail2ban.time, "sleep", lambda _seconds: None)
+
+    assert fail2ban._wait_for_jail_loaded("eas-station", retries=3) is False
+
+
+def test_wait_for_jail_loaded_returns_immediately_when_already_up(monkeypatch):
+    from webapp.admin import fail2ban
+
+    calls = {"n": 0}
+
+    def fake_loaded_jails():
+        calls["n"] += 1
+        return {"eas-station"}
+
+    monkeypatch.setattr(fail2ban, "_loaded_jails", fake_loaded_jails)
+
+    def fail_if_called(_seconds):
+        raise AssertionError("should not sleep when the jail is already loaded")
+
+    monkeypatch.setattr(fail2ban.time, "sleep", fail_if_called)
+
+    assert fail2ban._wait_for_jail_loaded("eas-station") is True
+    assert calls["n"] == 1

--- a/webapp/admin/fail2ban.py
+++ b/webapp/admin/fail2ban.py
@@ -135,6 +135,25 @@ def _loaded_jails() -> set[str]:
     return {j.strip() for j in match.group(1).replace(",", " ").split() if j.strip()}
 
 
+def _wait_for_jail_loaded(jail: str, retries: int = 6, delay: float = 0.5) -> bool:
+    """Poll ``_loaded_jails()`` briefly, returning True once *jail* appears.
+
+    ``systemctl restart`` returns as soon as systemd considers the fail2ban
+    unit started, which can be a beat before fail2ban-server has finished
+    parsing jail.local and actually brought every jail up. Checking
+    ``_loaded_jails()`` exactly once right after the restart raced that
+    startup and could report a good apply as a failure (observed live: the
+    jail showed up ~1s later, and the apply had already given up).
+    """
+    if jail in _loaded_jails():
+        return True
+    for _ in range(retries):
+        time.sleep(delay)
+        if jail in _loaded_jails():
+            return True
+    return False
+
+
 def _jail_banned_ips(jail: str) -> list[str]:
     ok, out = _run(["fail2ban-client", "status", jail])
     if not ok:
@@ -574,7 +593,9 @@ def configure_fail2ban():
     # Verify the jail actually loaded before claiming success — a valid-looking
     # write can still fail to produce a running jail (missing logpath, bad
     # banaction, etc.). Don't report "enabled" if it isn't really enforcing.
-    if settings.enabled and EAS_JAIL not in _loaded_jails():
+    jail_loaded = (not settings.enabled) or _wait_for_jail_loaded(EAS_JAIL)
+
+    if settings.enabled and not jail_loaded:
         detail = _actuator_error()
         logger.error("eas-station jail did not load after configure: %s", detail)
         return jsonify({


### PR DESCRIPTION
## Summary
- `configure_fail2ban()` (the Security Center's "Save & Apply Configuration") writes `jail.local`, restarts fail2ban, then checks `_loaded_jails()` exactly once to confirm the `eas-station` actuator jail came up before reporting success.
- `systemctl restart` returns as soon as systemd considers the unit started, which can be a beat before fail2ban-server has actually finished parsing `jail.local` and bringing every jail up.
- Reproduced live on a real host: after a config write + restart, the single immediate check reported "the eas-station firewall jail did not load" and the apply returned a 500 — but re-checking `fail2ban-client status` about a second later showed the jail *was* loaded. The apply had already given up and skipped resyncing bans into it.
- Extracted the check into `_wait_for_jail_loaded()`, which polls up to 3s (6 x 0.5s) before giving up, instead of checking exactly once.

## Test plan
- [x] Added `tests/test_fail2ban_apply_race.py`: jail loads on the 3rd check (tolerated), jail never loads (still correctly reported as failed), jail already loaded (no unnecessary sleep).
- [x] `pytest tests/test_fail2ban_apply_race.py tests/test_fail2ban_sync.py tests/test_firewall_sync_state.py tests/test_ssh_ban_resync.py tests/test_ip_ban_enforcement.py tests/test_allowlist_lockout_guard.py` — 17 passed.
- [x] Verified live on the production host this was found on: re-ran the apply flow after this fix and it correctly reported success without the earlier false negative.

https://claude.ai/code/session_01AwQyuYn3G4wM7dPKWtQJHd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fail2ban configuration handling when jails take longer to start.
  * The system now briefly retries checking jail availability before reporting a failure.
  * Already-loaded jails continue without unnecessary delay.

* **Tests**
  * Added coverage for delayed startup, eventual failure, and immediate success scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->