### PR TITLE
Fix suppressed dialog/output in install.sh and update.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1428,12 +1428,12 @@ echo_progress "Installing Python packages (main venv)..."
 echo_info "This may take 5-10 minutes depending on your system"
 echo_info "Full output shown below to track progress:"
 echo ""
-if ! sudo -u "$SERVICE_USER" "$VENV_DIR/bin/pip" install --upgrade pip setuptools wheel; then
+if ! ui_stream sudo -u "$SERVICE_USER" "$VENV_DIR/bin/pip" install --upgrade pip setuptools wheel; then
     echo_error "Failed to upgrade pip, setuptools, and wheel"
     exit 1
 fi
 echo ""
-if ! sudo -u "$SERVICE_USER" "$VENV_DIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"; then
+if ! ui_stream sudo -u "$SERVICE_USER" "$VENV_DIR/bin/pip" install -r "$INSTALL_DIR/requirements.txt"; then
     echo_error "Failed to install Python dependencies"
     exit 1
 fi
@@ -1472,10 +1472,10 @@ echo_progress "Installing SDR service dependencies..."
 echo_info "Installing SDR requirements (scipy, numba may take 5-15 min to compile)..."
 echo_info "Full output shown below to track progress:"
 echo ""
-if ! sudo -u "$SERVICE_USER" "$VENV_SDR_DIR/bin/pip" install --upgrade pip; then
+if ! ui_stream sudo -u "$SERVICE_USER" "$VENV_SDR_DIR/bin/pip" install --upgrade pip; then
     echo_warning "Failed to upgrade pip in SDR venv (non-critical)"
 fi
-if ! sudo -u "$SERVICE_USER" "$VENV_SDR_DIR/bin/pip" install -r "$INSTALL_DIR/requirements-sdr.txt"; then
+if ! ui_stream sudo -u "$SERVICE_USER" "$VENV_SDR_DIR/bin/pip" install -r "$INSTALL_DIR/requirements-sdr.txt"; then
     echo_error "Failed to install SDR dependencies"
     exit 1
 fi
@@ -2156,7 +2156,7 @@ if [ "$DB_HAS_TABLES" -eq "0" ]; then
         set +e
         # Run Alembic directly (no output capture) so user sees real-time feedback
         # IMPORTANT: Run from install directory to ensure .env file is found
-        sudo -u "$SERVICE_USER" bash -c "cd '$INSTALL_DIR' && '$VENV_DIR/bin/alembic' upgrade head"
+        ui_stream sudo -u "$SERVICE_USER" bash -c "cd '$INSTALL_DIR' && '$VENV_DIR/bin/alembic' upgrade head"
         ALEMBIC_EXIT_CODE=$?
         set -e
 
@@ -2187,7 +2187,7 @@ with app.app_context():
             set -e
 
             if [ $INIT_EXIT -eq 0 ]; then
-                echo "$INIT_OUTPUT"
+                echo "$INIT_OUTPUT" | _tty_block
                 echo ""
                 echo_warning "Schema created but settings tables may be empty"
                 echo_info "Configure via web UI at /admin/hardware and /settings/audio"
@@ -2235,7 +2235,7 @@ with app.app_context():
         set -e
 
         if [ $INIT_EXIT -eq 0 ]; then
-            echo "$INIT_OUTPUT"
+            echo "$INIT_OUTPUT" | _tty_block
         else
             echo_error "Database initialization failed (exit code: $INIT_EXIT)"
             echo_info "Output: $INIT_OUTPUT"

--- a/scripts/lib/ui.sh
+++ b/scripts/lib/ui.sh
@@ -66,6 +66,55 @@ _tty() { printf '%s\n' "$1" >/dev/tty 2>/dev/null || printf '%s\n' "$1"; }
 # Write raw bytes (no trailing newline) directly to the terminal.
 _tty_raw() { printf '%s' "$1" >/dev/tty 2>/dev/null || printf '%s' "$1"; }
 
+# Run a command with its output visible on the terminal AND still captured
+# in the log file. Both install.sh and update.sh redirect stdout/stderr to
+# LOG_FILE early on (`exec 1>>"$LOG_FILE" 2>&1`), which silently swallows
+# any subprocess that isn't explicitly re-routed like this one is -- a
+# long-running step (pip install, apt-get install, alembic migrations)
+# would otherwise print a "this may take a while, output shown below"
+# message and then show nothing for its entire duration: indistinguishable
+# from a hang, and in alembic's case defeating the point of running it
+# uncaptured in the first place (so Ctrl+C can interrupt it).
+#
+# Falls back to running the command unmodified (log-only, i.e. today's
+# behavior) when /dev/tty isn't writable, same as _tty()'s own fallback --
+# e.g. a fully detached/unattended run.
+#
+# Exit code is the wrapped command's, not tee's -- relies on PIPESTATUS,
+# which is bash-specific (both callers are already #!/bin/bash).
+ui_stream() {
+    if [ -w /dev/tty ] 2>/dev/null; then
+        # `-w /dev/tty` only checks permission bits, not whether a real
+        # controlling terminal is attached (e.g. under some service/sandbox
+        # contexts /dev/tty exists and is "writable" but has no backing
+        # terminal). tee's own stderr is silenced so that case degrades to
+        # "log-only" quietly instead of printing "tee: /dev/tty: No such
+        # device or address" on every line; the wrapped command's real
+        # stderr is unaffected since it was already merged into stdout by
+        # the `2>&1` before the pipe.
+        "$@" 2>&1 | tee -a /dev/tty 2>/dev/null
+        return "${PIPESTATUS[0]}"
+    fi
+    "$@"
+}
+
+# Echo an already-captured block of text (e.g. `git fetch` output stashed in
+# a variable for error handling) to both stdout -- which is the log file,
+# via the install/update scripts' `exec 1>>LOG 2>&1` -- and the terminal.
+# Unlike ui_stream(), there's no live command to pipe here; the output was
+# already captured earlier (often filtered with `head -N` first), so this
+# just fans the same already-truncated text out to /dev/tty too. Same silent
+# log-only fallback as _tty()/ui_stream() when /dev/tty isn't writable.
+# Usage: echo "$CAPTURED_OUTPUT" | head -20 | _tty_block
+_tty_block() {
+    local block
+    block=$(cat)
+    echo "$block"
+    if [ -w /dev/tty ] 2>/dev/null; then
+        printf '%s\n' "$block" >>/dev/tty 2>/dev/null
+    fi
+}
+
 # ── whiptail wrapper ───────────────────────────────────────────────────────
 # Forces TUI output to /dev/tty so ncurses is never swallowed by the install
 # log redirect. Callers that capture user input still use the standard

--- a/update.sh
+++ b/update.sh
@@ -242,10 +242,51 @@ if [ -d ".git" ]; then
     
     if [ $FETCH_STATUS -eq 0 ]; then
         echo_success "Fetched latest changes from remote"
+    elif echo "$FETCH_OUTPUT" | grep -q "couldn't find remote ref"; then
+        # The branch this checkout is sitting on no longer exists upstream --
+        # normal fallout of this project's PR workflow, where feature
+        # branches get deleted on merge. Falling back to main is the correct
+        # recovery in every case: main is where every PR lands, so "my
+        # branch is gone" always means "that work is already on main (or
+        # abandoned)", never "I need to preserve local branch state".
+        echo_warning "Branch '$CURRENT_BRANCH' no longer exists on the remote"
+        echo_info "This usually means it was a feature/PR branch that already merged and was deleted."
+        echo_info "Falling back to main..."
+        echo ""
+
+        set +e
+        sudo -u "$SERVICE_USER" git checkout main 2>&1
+        CHECKOUT_STATUS=$?
+        set -e
+
+        if [ $CHECKOUT_STATUS -ne 0 ]; then
+            echo_error "Could not switch to main -- manual recovery needed:"
+            echo_info "  cd $INSTALL_DIR"
+            echo_info "  sudo -u $SERVICE_USER git checkout main"
+            echo_info "  sudo -u $SERVICE_USER git reset --hard origin/main"
+            exit 1
+        fi
+
+        CURRENT_BRANCH="main"
+        echo_success "Switched to main"
+
+        set +e
+        FETCH_OUTPUT=$(sudo -u "$SERVICE_USER" git fetch origin "$CURRENT_BRANCH:refs/remotes/origin/$CURRENT_BRANCH" 2>&1)
+        FETCH_STATUS=$?
+        set -e
+
+        if [ $FETCH_STATUS -eq 0 ]; then
+            echo_success "Fetched latest changes from remote"
+        else
+            echo_error "Git fetch failed even after falling back to main"
+            echo_error "Git output:"
+            echo "$FETCH_OUTPUT" | head -20 | _tty_block
+            exit 1
+        fi
     else
         echo_error "Git fetch failed - cannot update"
         echo_error "Git output:"
-        echo "$FETCH_OUTPUT" | head -20
+        echo "$FETCH_OUTPUT" | head -20 | _tty_block
         echo ""
         echo_warning "Possible causes:"
         echo_warning "  1. Git directory ownership issue (should be owned by $SERVICE_USER)"
@@ -351,7 +392,7 @@ if [ -d ".git" ]; then
     else
         echo_error "Git reset failed - update incomplete"
         echo_error "Git output:"
-        echo "$RESET_OUTPUT" | head -20
+        echo "$RESET_OUTPUT" | head -20 | _tty_block
         echo ""
         echo_warning "Possible causes:"
         echo_warning "  1. Git directory ownership issue (should be owned by $SERVICE_USER)"
@@ -665,7 +706,7 @@ done
 # Show output (no -qq) so user can see progress and diagnose any issues
 # Array expansion is safe and prevents command injection
 if [ ${#AVAILABLE_PACKAGES[@]} -gt 0 ]; then
-    DEBIAN_FRONTEND=noninteractive apt-get install -y "${AVAILABLE_PACKAGES[@]}"
+    ui_stream env DEBIAN_FRONTEND=noninteractive apt-get install -y "${AVAILABLE_PACKAGES[@]}"
     if [ $? -ne 0 ]; then
         echo_warning "Batch package install failed - retrying individually..."
         for pkg in "${AVAILABLE_PACKAGES[@]}"; do
@@ -692,7 +733,7 @@ if [ -f "$INSTALL_DIR/venv/bin/pip" ]; then
     echo_info "Full output shown below:"
     echo ""
     # Show full output so user can see progress (no grep filter)
-    sudo -u "$SERVICE_USER" "$INSTALL_DIR/venv/bin/pip" install --upgrade -r "$INSTALL_DIR/requirements.txt"
+    ui_stream sudo -u "$SERVICE_USER" "$INSTALL_DIR/venv/bin/pip" install --upgrade -r "$INSTALL_DIR/requirements.txt"
     echo ""
     echo_success "Main venv dependencies updated"
 
@@ -1090,7 +1131,7 @@ with app.app_context():
     # Run Alembic directly (no output capture) so user sees real-time feedback
     # and can interrupt with Ctrl+C if needed
     # IMPORTANT: Run from install directory to ensure .env file is found
-    sudo -u "$SERVICE_USER" bash -c "cd '$INSTALL_DIR' && '$INSTALL_DIR/venv/bin/alembic' upgrade head"
+    ui_stream sudo -u "$SERVICE_USER" bash -c "cd '$INSTALL_DIR' && '$INSTALL_DIR/venv/bin/alembic' upgrade head"
     ALEMBIC_EXIT_CODE=$?
     set -e
 


### PR DESCRIPTION
## Summary
- Both scripts redirect stdout/stderr to a log file early on (`exec 1>>LOG 2>&1`), which silently swallowed several steps that claimed to show real-time output on the terminal: apt-get/pip installs and Alembic migrations printed "output shown below" and then nothing appeared for the entire duration — indistinguishable from a hang, and for Alembic specifically defeating the whole point of running it uncaptured (so Ctrl+C can cancel and roll back a migration in progress).
- Captured error output (git fetch/reset failures, db init fallback output) had the same problem: it landed in the log but never reached the terminal, so an operator hitting a real failure only saw a generic message with no detail.
- Adds two helpers to `scripts/lib/ui.sh`:
  - `ui_stream()` — tees a live command's output to `/dev/tty` while preserving its exit code via `PIPESTATUS`. Falls back to log-only silently when `/dev/tty` isn't writable (unattended/detached runs), matching the existing `_tty()` helper's behavior. Also silences `tee`'s own stderr for the case where `/dev/tty` passes a `-w` check but has no real controlling terminal behind it.
  - `_tty_block()` — fans an already-captured text blob (e.g. git fetch output stashed in a variable for error handling, possibly `head`-truncated) out to `/dev/tty` the same way.
- Applies these at 11 call sites across `install.sh` / `update.sh`: apt-get install, main-venv pip install, SDR-venv pip install, Alembic `upgrade head` (both scripts), and 5 captured-error-output dumps (git fetch failure, git fetch failure after main fallback, git reset failure, and two db `create_all()` fallback outputs).
- Also fixes the outage that started this investigation: `update.sh` fetches the current branch by exact name (`git fetch origin "$CURRENT_BRANCH:refs/remotes/origin/$CURRENT_BRANCH"`), which fails hard if that branch was a merged-and-deleted PR branch. It now detects `couldn't find remote ref` and falls back to `main` automatically — `main` is always where PR work lands, so a missing branch never means real work would be lost.

## Test plan
- [x] `bash -n` on both `install.sh` and `update.sh`
- [x] Standalone functional test of `ui_stream()`: exit codes correctly preserved (success/failure/multi-arg) via `PIPESTATUS`
- [x] Confirmed a bare `VAR=val` positional argument does *not* get treated as an env-var prefix when re-executed via `"$@"` in a function (hence `ui_stream env DEBIAN_FRONTEND=noninteractive apt-get install ...` rather than `ui_stream DEBIAN_FRONTEND=noninteractive ...`)
- [ ] Full `sudo ./update.sh` / `sudo ./install.sh` run on real hardware to see the streamed output live (not exercised here — this session already caused one live outage running `update.sh` directly; recommend testing on non-production hardware first)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_014GuhM2aQwFL1pWaXjkQpH8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation and update commands now provide clearer, real-time progress output in the terminal and logs.
  * Added recovery when the configured Git branch is unavailable by falling back to the `main` branch.
  * Added validation and clear error messages for Git recovery failures.

* **Bug Fixes**
  * Improved visibility and reliability for package installation, dependency setup, migrations, and repository updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->