### PR TITLE
Add ENDEC feeds and hwsetup services to system health monitoring

### DIFF
--- a/app_core/config/services.py
+++ b/app_core/config/services.py
@@ -45,6 +45,8 @@ EAS_SERVICES = [
     f'{SERVICE_PREFIX}-gps.service',
     f'{SERVICE_PREFIX}-displays.service',
     f'{SERVICE_PREFIX}-gpio.service',
+    f'{SERVICE_PREFIX}-endec-feeds.service',
+    f'{SERVICE_PREFIX}-hwsetup.service',
 ]
 
 # Poller services (Unified poller for NOAA + IPAWS)


### PR DESCRIPTION
## Summary
- `eas-station-endec-feeds.service` and `eas-station-hwsetup.service` are installed and running via systemd, but were never added to `EAS_SERVICES` in `app_core/config/services.py`.
- As a result, the System Health page's service list/count never included them even though they run continuously alongside the other hardware subsystem units.

## Test plan
- [x] Verified both units are `active running` via `systemctl`
- [x] Confirmed `get_eas_services()` now returns both services after the change
- [x] Restarted `eas-station-web.service` on the running deployment and verified it started cleanly with no errors
- [ ] Visually confirm both services render on the System Health page in a browser