### PR TITLE
Disable CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` with `reviews.auto_review.enabled: false` — CodeRabbit's supported way to stop it posting automatic reviews on PRs.

Note: this only covers the CodeRabbit half of the "remove pytest from CI + remove CodeRabbit" request. The pytest-removal half (editing `.github/workflows/tests.yml`) is still blocked — pushing changes to workflow files needs the `workflow` OAuth scope, which this session's `gh` token doesn't have. That change is sitting locally; I'll need you to either run `gh auth refresh -h github.com -s workflow` to grant it, or apply/push that one file yourself.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_011Pu7DnvrUc2SDt1anPzLu5