### PR TITLE
Fix certbot renewal admin panel: jitter timeouts and silent Verify button

### DIFF
--- a/templates/admin/certbot.html
+++ b/templates/admin/certbot.html
@@ -385,7 +385,11 @@ document.getElementById('certbotSettingsForm').addEventListener('submit', async 
 async function checkCertificateStatus() {
     const statusDiv = document.getElementById('certificateStatus');
     const certInfoGrid = document.getElementById('certInfoGrid');
-    
+
+    // This card sits near the top of the page, but the button that triggers
+    // it (e.g. after a renewal result) can be far down. Without this,
+    // clicking "Verify Certificate" appears to do nothing.
+    statusDiv.scrollIntoView({ behavior: 'smooth', block: 'start' });
     statusDiv.innerHTML = '<div class="alert alert-info"><span class="spinner-border"></span> Checking certificate status...</div>';
     certInfoGrid.style.display = 'none';
     
@@ -478,7 +482,8 @@ async function checkCertificateStatus() {
             </div>
         `;
         certInfoGrid.style.display = 'grid';
-        
+        showToast('Certificate status updated', 'success');
+
     } catch (error) {
         statusDiv.innerHTML = `
             <div class="alert alert-danger">

--- a/webapp/admin/certbot/routes_renew.py
+++ b/webapp/admin/certbot/routes_renew.py
@@ -234,7 +234,14 @@ def renew_certificate_execute():
             'sudo', 'certbot', 'renew',
             '--config-dir', str(CERTBOT_CONFIG_DIR),
             '--work-dir', str(CERTBOT_WORK_DIR),
-            '--logs-dir', str(CERTBOT_LOGS_DIR)
+            '--logs-dir', str(CERTBOT_LOGS_DIR),
+            # certbot renew applies a random.uniform(1, 480)s sleep before
+            # renewing whenever stdin isn't a tty (see certbot's renewal.py),
+            # to spread load across Let's Encrypt when many hosts share a
+            # cron schedule. Irrelevant for a single admin clicking a button
+            # here, and a draw over our 120s subprocess timeout below is what
+            # was surfacing as spurious "renewal operation timed out" errors.
+            '--no-random-sleep-on-renew',
         ]
 
         if dry_run:


### PR DESCRIPTION
## Summary
- `certbot renew` inserts a `random.uniform(1, 480)`s delay before renewing whenever stdin isn't a tty (its built-in anti-thundering-herd protection for fleets sharing a cron schedule). Every invocation from the admin panel runs via `subprocess.run` with no tty, so every click of Renew/Dry-run rolled that delay against the endpoint's 120s subprocess timeout — roughly 3 in 4 clicks failed with "Certbot renewal operation timed out" even though certbot succeeded seconds later in the background. Disabled with `--no-random-sleep-on-renew`, since a single admin click isn't the scenario the jitter protects against (the real automatic renewal via `certbot.timer` is untouched and correctly keeps the jitter).
- The "Verify Certificate" button (`checkCertificateStatus()`) only updated a status card near the top of the page with no scroll or toast, so clicking it from further down (e.g. right after a renewal result) looked like it did nothing. Now scrolls the card into view and shows a success toast.

## Test plan
- [x] Reproduced the timeout live: watched a real `certbot renew --dry-run` process sleep ~141s in `hrtimer_nanosleep` past the 120s subprocess timeout, confirmed via logs that certbot itself succeeded afterward while the web request had already errored.
- [x] Applied the fix, gracefully reloaded gunicorn (SIGHUP), re-ran the dry run from the admin panel — completed in a couple seconds with "Certificate successfully tested (dry run)".
- [ ] Click "Verify Certificate" from the bottom of the page after a renewal result and confirm it scrolls up and shows the status/toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKqXUg5imPpiJsB6Rykrj2