### PR TITLE
Document uptime diagnostics pack and dashboard status strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Every alert insert, encoder action, and operator change is recorded into the exi
 
 **Why it matters institutionally:** This is the difference between "we logged it" and "we can prove the log hasn't been edited." For incident reviews, regulator interaction, training-program documentation, or research integrity, that distinction is the whole point.
 
+### Uptime & Reliability Diagnostics — Beyond "Is the Process Running?"
+
+`Restart=always` only catches a crashed process; it says nothing about one that's still running but **deadlocked**. Both `eas-station-audio` and `eas-station-poller` are systemd `Type=notify` units that send `WATCHDOG=1` heartbeats from their own main loop, so a genuine hang now gets killed and restarted too. An **outbound heartbeat** (Settings → Uptime Heartbeat) pings an external monitor such as healthchecks.io on a schedule — the one check on the box that's designed to fail *outward* when the whole box, its power, or its network goes dark, rather than only reporting inward to a dashboard nobody's watching at 3 a.m. **Backup restore verification** (`tools/verify_backup_restore.py`, Admin → Backups) actually restores the latest backup's database dump into a throwaway scratch database and sanity-checks it — proving a backup restores, not just that a file exists — on demand or automatically after every scheduled backup. A **Clock Sync** card on `/system_health` watches chrony/NTP drift, since SAME timing and RWT scheduling both depend on correct wall-clock time. And a **combined NOAA+IPAWS feed-loss alarm** tracks each poller's staleness independently, so a live feed can never mask a dead one — the alert only fires when both feeds have stalled past a configurable threshold.
+
 ### Hardware Integration — The Things the System Actually Has to Drive
 
 The platform was designed under the assumption that an EAS station is not a pure software product — it has to flip relays and drive signs. The hardware service exposes:
@@ -184,7 +188,7 @@ Day-to-day operations are made survivable by a **whiptail TUI configurator** (`s
 
 ### Web Dashboard & REST API
 
-The UI is a **responsive Bootstrap 5** application with **20 built-in themes** (every page including the Changelog viewer driven by theme CSS custom properties), **live Socket.IO push** for alert / radio / GPS updates, a full alert timeline with search and filter, an **Analytics dashboard** with Chart.js visualizations and one-click client-side PDF export of the full statistics report, an **audio monitoring** view with playback and live receive history, **operator-selectable display units** (coordinate format, altitude, speed, distance) saved per browser, and a **System Health** panel surfacing CPU/memory/disk/temperature.
+The UI is a **responsive Bootstrap 5** application with **20 built-in themes** (every page including the Changelog viewer driven by theme CSS custom properties), **live Socket.IO push** for alert / radio / GPS updates, a full alert timeline with search and filter, an **Analytics dashboard** with Chart.js visualizations and one-click client-side PDF export of the full statistics report, an **audio monitoring** view with playback and live receive history, **operator-selectable display units** (coordinate format, altitude, speed, distance) saved per browser, and a **System Health** panel surfacing CPU/memory/disk/temperature. A self-refreshing **System Status strip** on the main dashboard puts active-alert count, EAS decoder state, overall app health, and configured-receiver count above the map, so the four things an operator checks first are visible without navigating anywhere.
 
 Everything in the UI is reachable from a **REST API** namespaced under `/api/`, authenticated by the same login session as the UI (scoped `X-API-Key` authentication is planned), with a vendored JavaScript client for browser-side integrations.
 

--- a/docs/architecture/THEORY_OF_OPERATION.md
+++ b/docs/architecture/THEORY_OF_OPERATION.md
@@ -166,6 +166,7 @@ sequenceDiagram
 - **Schema Enforcement** validates XML against CAP schema and normalises polygons, circles, and SAME location codes
 - **Deduplication (`app_core/alerts.py`)** compares CAP identifiers, message types, and sent timestamps
 - **Configuration** for runtime settings (polling, EAS broadcast, notifications, application logging) lives in dedicated database tables editable from the admin UI; only boot-time infrastructure (`SECRET_KEY`, `DATABASE_URL`, hostnames, paths) is read from the persistent `/app-config/.env` file
+- **Combined feed-loss alarm** (`app_core/system_health.py`): the two pollers are tracked *independently* — each poller's last-success timestamp is compared against `poller_settings.feed_stall_threshold_sec` — precisely because they run as separate services and can fail independently. A live NOAA feed must never mask a dead IPAWS feed (or vice versa), so the Alert Feeds card on `/system_health` surfaces both staleness values, and the compliance alert only fires when *both* feeds have stalled past the threshold. This is a liveness check on top of the per-message deduplication above, not a replacement for it.
 
 ### 2. Persistence & Spatial Context
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -122,7 +122,9 @@
                             <li class="mb-2"><i class="fas fa-circle-check text-success me-2"></i>MDC1200 Selective Calling</li>
                             <li class="mb-2"><i class="fas fa-circle-check text-success me-2"></i>Received-Alert Purge &amp; Storage Reclaim</li>
                             <li class="mb-2"><i class="fas fa-circle-check text-success me-2"></i>Security Center — unified Traffic Analytics, malicious-login monitoring, application-wide IP bans (allowlist/blocklist, with country/city geolocation) &amp; fail2ban host-firewall enforcement in one tabbed page</li>
-                            <li class="mb-0"><i class="fas fa-circle-check text-success me-2"></i>Stratum 1 GPS Time Source</li>
+                            <li class="mb-2"><i class="fas fa-circle-check text-success me-2"></i>Stratum 1 GPS Time Source</li>
+                            <li class="mb-2"><i class="fas fa-circle-check text-success me-2"></i>Live Dashboard Status Strip</li>
+                            <li class="mb-0"><i class="fas fa-circle-check text-success me-2"></i>Uptime &amp; Reliability Diagnostics (watchdog, heartbeat, backup verification, clock sync, feed-loss alarm)</li>
                         </ul>
                     </div>
                 </div>
@@ -609,6 +611,57 @@
                     <div>
                         <strong>Why timing is treated as first-class infrastructure.</strong> Every EAS event is timestamped, geofenced, and audited — and every CAP message carries <code>sent</code>, <code>effective</code>, <code>expires</code> and <code>onset</code> fields whose math has to match the wall clock. A station that drifts seconds against NIST is a station whose RWT logs and compliance trail eventually cease to match the real world. EAS Station™ owns its time at the hardware level.
                         See the <a href="/docs/hardware/GPS_HAT_SETUP" class="alert-link">GPS HAT Setup guide</a> for board options, wiring, and the manual configuration steps the admin UI automates.
+                    </div>
+                </div>
+            </section>
+
+            <!-- Uptime & Reliability Diagnostics -->
+            <section class="about-card">
+                <div class="about-section-head">
+                    <span class="about-section-icon ico-danger"><i class="fas fa-heart-pulse"></i></span>
+                    <div>
+                        <h2 class="about-section-title">Uptime &amp; Reliability Diagnostics</h2>
+                        <p class="about-section-sub">Catching the failures a plain "is the process still running?" check misses.</p>
+                    </div>
+                </div>
+
+                <p class="mb-3">A life-safety appliance can't stop at restarting a crashed process. EAS Station™ layers five additional checks on top of standard systemd <code>Restart=always</code> to catch deadlocks, dead feeds, unproven backups, clock drift, and total box failure — reachable from <strong>Settings &rarr; Uptime Heartbeat</strong>, <strong>Admin &rarr; Backups</strong>, and <strong>System Health</strong>.</p>
+
+                <div class="row g-3">
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-blue h-100">
+                            <div class="feature-card-icon"><i class="fas fa-stopwatch"></i></div>
+                            <h5 class="feature-card-title">Hang Watchdog</h5>
+                            <p class="feature-card-text">The audio-processing and alert-poller services send <code>WATCHDOG=1</code> heartbeats to systemd from their main loop. A process that's still running but deadlocked — not just crashed — now gets killed and restarted automatically.</p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-purple h-100">
+                            <div class="feature-card-icon"><i class="fas fa-tower-broadcast"></i></div>
+                            <h5 class="feature-card-title">Outbound Uptime Heartbeat</h5>
+                            <p class="feature-card-text">Every other health check here is inward-facing — a page someone has to look at. This one pings an external monitor (e.g. healthchecks.io) on a schedule, so total power, network, or OS failure still raises an alarm from outside the box.</p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-green h-100">
+                            <div class="feature-card-icon"><i class="fas fa-database"></i></div>
+                            <h5 class="feature-card-title">Backup Restore Verification</h5>
+                            <p class="feature-card-text">A backup that's never been restored isn't a proven backup. This restores the latest backup into a throwaway scratch database, sanity-checks it, and always drops it afterward — run on demand or automatically after every backup.</p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-orange h-100">
+                            <div class="feature-card-icon"><i class="fas fa-clock"></i></div>
+                            <h5 class="feature-card-title">Clock/NTP Drift Monitoring</h5>
+                            <p class="feature-card-text">SAME timing and Required Weekly Test scheduling both depend on correct system time. The Clock Sync card on System Health tracks chrony/NTP offset and raises a compliance alert on drift or loss of sync.</p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="feature-card fc-pink h-100">
+                            <div class="feature-card-icon"><i class="fas fa-satellite-dish"></i></div>
+                            <h5 class="feature-card-title">Combined Feed-Loss Alarm</h5>
+                            <p class="feature-card-text">NOAA and IPAWS polling staleness are tracked independently, so a live feed never masks a dead one. An alert fires only when <em>both</em> feeds have stalled past a configurable threshold.</p>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/templates/help.html
+++ b/templates/help.html
@@ -247,6 +247,21 @@
                                 <div class="accordion-body">
                                     <p>Navigate to <code>http://&lt;host&gt;:5000</code> in a modern browser.</p>
                                     <p>Log in with administrator credentials created during initial setup.</p>
+                                    <p>
+                                        The main dashboard (<code>/</code>) opens with a <strong>System Status
+                                        strip</strong> above the map — four at-a-glance tiles so you don't have
+                                        to navigate away to know whether the station is actually working:
+                                    </p>
+                                    <ul>
+                                        <li><strong>Active Alerts</strong> &mdash; count of currently active CAP products; links to <a href="/alerts">Alerts</a>.</li>
+                                        <li><strong>EAS Decoder</strong> &mdash; whether the decoder monitor is running and audio is flowing or silent; links to <a href="/admin/eas_decoder_monitor">EAS Decoder Monitor</a>.</li>
+                                        <li><strong>System Health</strong> &mdash; overall application health from <code>/health</code>; links to <a href="/system_health">System Health</a>.</li>
+                                        <li><strong>Radio Receivers</strong> &mdash; number of configured SDR receivers; links to <a href="/admin/radio">Radio Receivers</a>.</li>
+                                    </ul>
+                                    <p class="text-muted small mb-0">
+                                        <i class="fas fa-sync-alt me-1"></i>
+                                        The strip refreshes itself every 30 seconds, independent of the map's own refresh cycle.
+                                    </p>
                                     <div class="alert alert-light">
                                         <i class="fas fa-lightbulb me-2"></i>
                                         <strong>Tip:</strong> Bookmark the dashboard for quick access during operations.


### PR DESCRIPTION
## Summary
- `templates/about.html` — new "Uptime & Reliability Diagnostics" section (watchdog, outbound heartbeat, backup restore verification, clock/NTP drift monitoring, combined feed-loss alarm) plus two new Key Features bullets
- `templates/help.html` — describes the dashboard's System Status strip (Active Alerts / EAS Decoder / System Health / Radio Receivers tiles) under "Accessing the Dashboard"
- `docs/architecture/THEORY_OF_OPERATION.md` — notes the combined NOAA+IPAWS feed-loss alarm under Ingestion & Validation, since it changes poller-liveness behavior
- `README.md` — new "Uptime & Reliability Diagnostics" section under "What the Platform Actually Does", plus a status-strip mention under "Web Dashboard & REST API"

Both features (v2.178.0 dashboard status strip, v2.179.0 uptime diagnostics pack) had CHANGELOG entries but were missing from the user-facing documentation AGENTS.md requires (`templates/help.html`, `templates/about.html`, and — for ingestion-path behavior changes — `docs/architecture/THEORY_OF_OPERATION.md`).

Documentation-only change; no behavior change, so no VERSION bump.

## Test plan
- [x] Ran the repo's template block-balance/validity check against `about.html` and `help.html` — both pass
- [ ] Visual check of the new About page section and Help accordion entry in a browser (light + dark theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNTDnUSrkNsihaR8JruQjw