### PR TITLE
Fix flaky git-history commit-count assertion for shallow CI checkouts

### DIFF
--- a/tests/test_repo_statistics.py
+++ b/tests/test_repo_statistics.py
@@ -226,13 +226,18 @@ def test_route_count_includes_named_blueprints():
 
 
 def test_git_history_reports_commits_and_contributors():
+    """Assert only >= 1, not some large threshold: CI checks out with
+    actions/checkout's default fetch-depth of 1, so `git log` there sees
+    exactly one commit regardless of the real repository's history. A
+    hardcoded '> 100' passed against a full local clone but failed CI every
+    time, silently, because nobody checked the run before merging."""
     stats = repo_stats.compute_stats()
     if stats['file_source'] != 'git':
         pytest.skip('not a git checkout in this environment')
 
     history = stats['git_history']
     assert history is not None
-    assert history['commits'] > 100
+    assert history['commits'] >= 1
     assert history['contributors'] >= 1
     assert history['last_commit_at'], 'expected an ISO-formatted commit date'
 


### PR DESCRIPTION
## Summary
- \`main\`'s CI has been failing since #2463 merged: \`test_git_history_reports_commits_and_contributors\` asserted \`commits > 100\`, which only holds against a full local clone. GitHub Actions' default \`actions/checkout\` fetch-depth is 1, so \`git log\` sees exactly one commit in CI regardless of the real repository's history.
- Weakened the assertion to \`commits >= 1\` (still catches a genuine regression where \`git_history()\` breaks and returns nothing) and documented why in the test.
- This was caught while working on an unrelated PR (#2464) whose CI inherited the same failure, and confirmed that this exact test has failed on every \`main\` CI run since #2463 merged -- that PR was squash-merged without checking its own CI status.

## Test plan
- [x] Verified against a real \`git clone --depth 1\` reproducing CI's exact checkout (not just reasoning about it) -- failed with the old assertion (\`1 > 100\`), passes with the new one
- [x] Full local test suite otherwise unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCELxq6UQ8i5w5bFMFUdBV