### PR TITLE
Add a minimal release tarball (no tests/CI/dev-tooling)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,35 @@ jobs:
             --output="dist/eas-station-${{ steps.version.outputs.version }}.tar.gz" \
             HEAD
 
+      - name: Build minimal source tarball
+        if: steps.guard.outputs.exists == 'false'
+        run: |
+          # A slimmer download for people who just want to run the app, not
+          # develop it. Drops dev/CI-only content: the test suite, GitHub
+          # Actions workflows and issue/PR templates, one-off dev diagnostic
+          # scripts, and repo-root tool config that nothing at runtime reads
+          # (mkdocs.yml, pyproject.toml, CodeRabbit config, editor settings).
+          #
+          # docs/ stays IN: webapp/documentation.py and webapp/public/
+          # read it straight off disk at runtime to power the in-app /docs
+          # browser and the /terms, /privacy, and other policy pages, so it
+          # is a runtime dependency, not dev-only content, despite living
+          # next to the other docs. static/ and data/ also stay -- required
+          # assets and boundary data, not optional.
+          git archive \
+            --format=tar.gz \
+            --prefix="eas-station-${{ steps.version.outputs.version }}-minimal/" \
+            --output="dist/eas-station-${{ steps.version.outputs.version }}-minimal.tar.gz" \
+            HEAD -- . \
+            ':!tests' \
+            ':!.github' \
+            ':!scripts/diagnostics' \
+            ':!.vscode' \
+            ':!.claude' \
+            ':!.coderabbit.yaml' \
+            ':!mkdocs.yml' \
+            ':!pyproject.toml'
+
       - name: Generate checksums
         if: steps.guard.outputs.exists == 'false'
         working-directory: dist

--- a/docs/process/RELEASING.md
+++ b/docs/process/RELEASING.md
@@ -22,17 +22,42 @@ signing step — but publishing the release is a deliberate, on-demand action.
    reads the current `VERSION` and releases that version.
 4. **The workflow then:**
    - re-validates the release metadata (`tests/test_release_metadata.py`);
-   - builds a reproducible source tarball
-     (`eas-station-X.Y.Z.tar.gz`) with `git archive` from the exact commit
-     being released;
-   - writes a `SHA256SUMS` checksum manifest;
-   - **signs both artifacts** with a GitHub artifact attestation (see below);
-   - creates the `vX.Y.Z` tag and publishes a GitHub Release with the
-     tarball, checksums, and the changelog section for that version as the
+   - builds two reproducible source tarballs with `git archive` from the
+     exact commit being released — a full one (`eas-station-X.Y.Z.tar.gz`)
+     and a minimal one (`eas-station-X.Y.Z-minimal.tar.gz`), see below;
+   - writes a `SHA256SUMS` checksum manifest covering both;
+   - **signs all artifacts** with a GitHub artifact attestation (see below);
+   - creates the `vX.Y.Z` tag and publishes a GitHub Release with both
+     tarballs, checksums, and the changelog section for that version as the
      release notes.
 
 The workflow is idempotent: if a release for the current `VERSION` already
 exists, it exits without doing anything, so re-running it is safe.
+
+## Full vs. minimal tarball
+
+Every release publishes two source tarballs:
+
+- **`eas-station-X.Y.Z.tar.gz`** — the complete repository at the released
+  commit: application code, the test suite, CI workflow files, and every
+  dev-tooling config. Use this if you plan to develop, test, or contribute.
+- **`eas-station-X.Y.Z-minimal.tar.gz`** — everything needed to actually
+  *run* EAS Station, with dev/CI-only content removed: `tests/`, `.github/`,
+  `scripts/diagnostics/`, `.vscode/`, `.claude/`, and repo-root tool config
+  that nothing at runtime reads (`mkdocs.yml`, `pyproject.toml`,
+  `.coderabbit.yaml`). Use this for an actual deployment.
+
+  `docs/` is **not** trimmed from the minimal tarball even though it isn't
+  needed to develop the app — `webapp/documentation.py` and
+  `webapp/public/` read it straight off disk at runtime to power the in-app
+  `/docs` browser and the `/terms`/`/privacy`/policy pages, so it is a
+  runtime dependency of the deployed app, not dev-only content. This is
+  unrelated to the GitHub Pages documentation site, which is built by a
+  separate workflow (`docs-pages.yml`) directly from the repository, not
+  from either release tarball.
+
+Both tarballs are built from the same commit, checksummed together in the
+same `SHA256SUMS`, and signed the same way — see below.
 
 ## How releases are signed
 


### PR DESCRIPTION
## Summary
- Adds a second tarball to every future GitHub Release: `eas-station-X.Y.Z-minimal.tar.gz`, built the same way as the existing full `eas-station-X.Y.Z.tar.gz` but with dev/CI-only content stripped via `git archive` pathspec excludes: `tests/`, `.github/`, `scripts/diagnostics/`, `.vscode/`, `.claude/`, `mkdocs.yml`, `pyproject.toml`, `.coderabbit.yaml`.
- `docs/` is deliberately kept in the minimal tarball — `webapp/documentation.py` and `webapp/public/` read it straight off disk at runtime to power the in-app `/docs` browser and the `/terms`/`/privacy`/policy pages, so it's a runtime dependency of the deployed app, not dev-only content. This is unrelated to (and doesn't affect) the GitHub Pages docs site, which `docs-pages.yml` builds separately, directly from the repo — never from either release tarball.
- No changes needed to the checksum, attestation, or `gh release create` steps — they already glob `dist/eas-station-*.tar.gz`, so the new file is picked up automatically.
- Documents both tarballs' purpose in `docs/process/RELEASING.md`.

## Test plan
- [x] `git archive` with the exclude pathspecs run locally against `HEAD`: confirmed `tests/`, `.github/`, `scripts/diagnostics/`, `.vscode/`, `.claude/`, `mkdocs.yml`, `pyproject.toml`, `.coderabbit.yaml` are absent from the resulting tarball, while `docs/`, `webapp/`, `static/`, and `data/` are present.
- [x] `.github/workflows/release.yml` parses as valid YAML.
- [ ] Manual verification: next time `Actions → Release → Run workflow` is run, confirm both tarballs are attached, checksummed, and signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnFBDLhpnRb2nvh2jnBFLT