### PR TITLE
Bump gunicorn to 26.2.0; fix stale gunicorn/gevent version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 [![Alembic](https://img.shields.io/badge/Alembic-1.19.1-6BA3BE?style=flat-square&logo=sqlalchemy&logoColor=white)](https://alembic.sqlalchemy.org/)
 [![PostgreSQL + PostGIS](https://img.shields.io/badge/PostgreSQL-17%20%2B%20PostGIS-0093D0?style=flat-square&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-8.0-DC382D?style=flat-square&logo=redis&logoColor=white)](https://redis.io/)
-[![Gunicorn](https://img.shields.io/badge/Gunicorn-26.1.0-499848?style=flat-square&logo=gunicorn&logoColor=white)](https://gunicorn.org/)
-[![gevent](https://img.shields.io/badge/gevent-25.9.1-1F8B4C?style=flat-square)](https://www.gevent.org/)
+[![Gunicorn](https://img.shields.io/badge/Gunicorn-26.2.0-499848?style=flat-square&logo=gunicorn&logoColor=white)](https://gunicorn.org/)
+[![gevent](https://img.shields.io/badge/gevent-26.8.0-1F8B4C?style=flat-square)](https://www.gevent.org/)
 [![Nginx](https://img.shields.io/badge/Nginx-system-009639?style=flat-square&logo=nginx&logoColor=white)](https://nginx.org/)
 [![Let's Encrypt](https://img.shields.io/badge/Let's%20Encrypt-Certbot-003A70?style=flat-square&logo=letsencrypt&logoColor=white)](https://letsencrypt.org/)
 [![Systemd](https://img.shields.io/badge/Systemd-Services-33A9DC?style=flat-square&logo=systemd&logoColor=white)](https://systemd.io/)
@@ -503,8 +503,8 @@ EAS Station™ stands on the shoulders of an enormous open‑source ecosystem. T
 | Redis (server) | 8.0 | RSAL/SSPL/AGPL (per upstream) | Pub/sub bus between the web app and the SDR / hardware services; cache; rate‑limit store; capture registry; live spectrum + waterfall feed. | https://redis.io/ |
 | redis (Python) | 8.1.0 | MIT | Python client for the Redis server. | https://github.com/redis/redis-py |
 | hiredis | 3.4.1 | BSD‑3‑Clause | C parser accelerator for `redis‑py` (faster pub/sub fan‑out). | https://github.com/redis/hiredis-py |
-| Gunicorn | 26.1.0 | MIT | Production WSGI server fronting the Flask app. | https://gunicorn.org/ |
-| gevent | 25.9.1+ | MIT | Async worker class for Gunicorn so Flask‑SocketIO can hold thousands of concurrent WebSocket connections. | https://www.gevent.org/ |
+| Gunicorn | 26.2.0 | MIT | Production WSGI server fronting the Flask app. | https://gunicorn.org/ |
+| gevent | 26.8.0+ | MIT | Async worker class for Gunicorn so Flask‑SocketIO can hold thousands of concurrent WebSocket connections. | https://www.gevent.org/ |
 | Nginx | system (apt) | BSD‑2‑Clause | Reverse proxy / TLS terminator / static file server in front of Gunicorn and Icecast. Installed via `install.sh`'s `apt-get install nginx` — no version pin, and no Docker/Alpine image is involved despite this table's earlier claim. | https://nginx.org/ |
 | systemd | system | LGPL‑2.1+ | Process supervisor for `eas-station`, `sdr_hardware_service`, `hardware_service`, `gps_manager`, Icecast, Redis. | https://systemd.io/ |
 | Let's Encrypt / Certbot | — | Apache‑2.0 / ISRG | Automated TLS certificate issuance and renewal for the public HTTPS endpoint. | https://letsencrypt.org/ |

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ lxml==6.1.2  # Fast C-based XML parser (5-10x faster than ElementTree)
 openpyxl==3.1.5
 
 # Production servers
-gunicorn==26.1.0  # WSGI server for Flask
+gunicorn==26.2.0  # WSGI server for Flask
 gevent>=26.8.0    # Async worker for Flask-SocketIO with Gunicorn (Python 3.13+ compatible)
 
 # Redis for state management and worker coordination

--- a/templates/partials/tech_stack_badges.html
+++ b/templates/partials/tech_stack_badges.html
@@ -88,11 +88,11 @@
     </a>
 
     {# --- Servers / deployment -------------------------------------------- #}
-    <a href="https://gunicorn.org/" target="_blank" rel="noopener noreferrer" class="tech-badge" title="Gunicorn 26.1.0 — production WSGI server fronting the Flask app.">
-        <img src="https://img.shields.io/badge/Gunicorn-26.1.0-499848?style=for-the-badge&logo=gunicorn&logoColor=white" alt="Gunicorn 26.1.0">
+    <a href="https://gunicorn.org/" target="_blank" rel="noopener noreferrer" class="tech-badge" title="Gunicorn 26.2.0 — production WSGI server fronting the Flask app.">
+        <img src="https://img.shields.io/badge/Gunicorn-26.2.0-499848?style=for-the-badge&logo=gunicorn&logoColor=white" alt="Gunicorn 26.2.0">
     </a>
-    <a href="https://www.gevent.org/" target="_blank" rel="noopener noreferrer" class="tech-badge" title="gevent 25.9.1 — async worker class for Gunicorn so Flask-SocketIO can hold thousands of concurrent WebSocket connections.">
-        <img src="https://img.shields.io/badge/gevent-25.9.1-1F8B4C?style=for-the-badge{% if gevent_logo %}&logo={{ gevent_logo | urlencode }}{% endif %}" alt="gevent 25.9.1">
+    <a href="https://www.gevent.org/" target="_blank" rel="noopener noreferrer" class="tech-badge" title="gevent 26.8.0 — async worker class for Gunicorn so Flask-SocketIO can hold thousands of concurrent WebSocket connections.">
+        <img src="https://img.shields.io/badge/gevent-26.8.0-1F8B4C?style=for-the-badge{% if gevent_logo %}&logo={{ gevent_logo | urlencode }}{% endif %}" alt="gevent 26.8.0">
     </a>
     <a href="https://nginx.org/" target="_blank" rel="noopener noreferrer" class="tech-badge" title="Nginx — reverse proxy / TLS terminator / static file server in front of Gunicorn and Icecast. Installed as a system package (apt), not the Docker/Alpine image this badge used to imply.">
         <img src="https://img.shields.io/badge/Nginx-system-009639?style=for-the-badge&logo=nginx&logoColor=white" alt="Nginx (system package)">


### PR DESCRIPTION
## Summary
Supersedes #2523 (Dependabot's gunicorn 26.1.0 → 26.2.0 PR), which failed CI because it only touched `requirements.txt` — `tests/test_tech_stack_badges.py`'s drift guard requires gunicorn's exact pin to match its badge text in README.md and the footer partial too. Applying the bump directly with the badge fix instead.

Also fixed the gevent badge while in here: it still read 25.9.1 after gevent's own bump (#2526, merged separately) took `requirements.txt` to `>=26.8.0`. The drift guard doesn't enforce gevent's badge since it's a range pin (`CURATED_UNVERSIONED`), so this went stale silently rather than failing CI.

## Test plan
- [x] `pytest tests/test_tech_stack_badges.py` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnFBDLhpnRb2nvh2jnBFLT