### PR TITLE
Flood control, scanner blocking, and an admin-managed bad-actor blocklist

### DIFF
--- a/app_core/_models_settings.py
+++ b/app_core/_models_settings.py
@@ -1154,9 +1154,31 @@ class ApplicationSettings(db.Model):
     # Number of days before a password expires (0 = disabled)
 
     # ========================================================================
+    # Project Honeypot http:BL
+    # ========================================================================
+    httpbl_enabled = db.Column(db.Boolean, nullable=False, default=False)
+    # Whether to query Project Honeypot's http:BL reputation DNSBL for
+    # login attempts (see app_core/auth/httpbl.py). Off by default: it's an
+    # opt-in feature requiring an account at projecthoneypot.org.
+
+    httpbl_api_key = db.Column(db.String(64), nullable=True)
+    # http:BL access key. Falls back to the HTTPBL_API_KEY environment
+    # variable when unset here, so a key dropped into .env before this
+    # setting existed keeps working.
+
+    # ========================================================================
     # Metadata
     # ========================================================================
     updated_at = db.Column(db.DateTime, nullable=True, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    @property
+    def httpbl_api_key_set(self) -> bool:
+        """Whether an http:BL key is configured, without exposing the key itself.
+
+        Templates check this (not ``httpbl_api_key``) so the settings page
+        never has the secret in hand to accidentally render.
+        """
+        return bool(self.httpbl_api_key)
 
     def to_dict(self):
         """Convert model to dictionary."""
@@ -1173,6 +1195,11 @@ class ApplicationSettings(db.Model):
             "password_require_digits": self.password_require_digits,
             "password_require_special": self.password_require_special,
             "password_expiration_days": self.password_expiration_days,
+            "httpbl_enabled": self.httpbl_enabled,
+            # Never round-trip the actual key through the API -- just whether
+            # one is configured, so the settings page can show "configured"
+            # without ever displaying (or re-transmitting) the secret itself.
+            "httpbl_api_key_set": bool(self.httpbl_api_key),
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
 

--- a/app_core/auth/httpbl.py
+++ b/app_core/auth/httpbl.py
@@ -1,0 +1,236 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+"""
+Project Honeypot http:BL reputation client.
+
+http:BL is a DNS-based lookup, not a bulk-downloadable list: for a visitor
+at a.b.c.d, ask DNS for ``<api_key>.d.c.b.a.dnsbl.httpbl.org`` and decode the
+returned ``127.<days_since_activity>.<threat_score>.<visitor_type>`` A
+record. IPv4 only -- http:BL has no IPv6 lookup format. Results are cached
+in Redis (24h) both to cut repeat lookups and because free http:BL keys
+carry a daily query quota, so this is only ever queried from the login flow
+(see webapp/admin/auth.py), never on every request.
+
+Get a free key at https://www.projecthoneypot.org/
+"""
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOOKUP_SUFFIX = "dnsbl.httpbl.org"
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_CACHE_PREFIX = "httpbl:"
+_CACHE_EMPTY = "-"  # sentinel meaning "queried, not listed" (vs. cache miss)
+_DNS_TIMEOUT_SECONDS = 2.0
+
+# Visitor type bits in the response's 4th octet (may be OR'd together).
+TYPE_SEARCH_ENGINE = 0
+TYPE_SUSPICIOUS = 1
+TYPE_HARVESTER = 2
+TYPE_COMMENT_SPAMMER = 4
+
+# A harvester/comment-spammer hit is treated as bad on its own -- those bits
+# are specific enough to be low false-positive. Plain "suspicious" is the
+# noisiest bit, so it additionally needs a real threat score before acting.
+_SUSPICIOUS_THREAT_THRESHOLD = 25
+_AUTO_BAN_HOURS = 72
+
+
+def _get_settings():
+    from app_core.models import ApplicationSettings
+    try:
+        return ApplicationSettings.query.first()
+    except Exception:
+        return None
+
+
+def get_api_key() -> Optional[str]:
+    """Configured http:BL access key: DB setting first, then HTTPBL_API_KEY env."""
+    settings = _get_settings()
+    if settings and settings.httpbl_api_key:
+        return settings.httpbl_api_key
+    return os.environ.get('HTTPBL_API_KEY') or None
+
+
+def is_enabled() -> bool:
+    """Whether http:BL checks are turned on AND a key is actually configured."""
+    settings = _get_settings()
+    if not settings or not settings.httpbl_enabled:
+        return False
+    return bool(get_api_key())
+
+
+def _reverse_ipv4(ip_address: str) -> Optional[str]:
+    try:
+        ip_obj = ipaddress.ip_address(ip_address)
+    except ValueError:
+        return None
+    if ip_obj.version != 4:
+        return None
+    return ".".join(reversed(ip_address.split(".")))
+
+
+def _cache_get(ip_address: str):
+    """Returns (result_or_None, was_cached: bool)."""
+    try:
+        from app_core.redis_client import get_redis_client
+        client = get_redis_client()
+        raw = client.get(_CACHE_PREFIX + ip_address)
+        if raw is None:
+            return None, False
+        if raw == _CACHE_EMPTY:
+            return None, True
+        days, threat, vtype = (int(x) for x in raw.split(","))
+        return {"days_since_last_activity": days, "threat_score": threat, "visitor_type": vtype}, True
+    except Exception:
+        return None, False
+
+
+def _cache_set(ip_address: str, result: Optional[Dict]) -> None:
+    try:
+        from app_core.redis_client import get_redis_client
+        client = get_redis_client()
+        value = (
+            _CACHE_EMPTY if result is None
+            else f"{result['days_since_last_activity']},{result['threat_score']},{result['visitor_type']}"
+        )
+        client.setex(_CACHE_PREFIX + ip_address, _CACHE_TTL_SECONDS, value)
+    except Exception:
+        pass  # caching is purely an optimization -- never let it be fatal
+
+
+def query_httpbl(ip_address: str, api_key: Optional[str] = None) -> Optional[Dict]:
+    """Query http:BL for *ip_address*.
+
+    Returns a dict with days_since_last_activity/threat_score/visitor_type,
+    or None if not listed, IPv6, unreachable, or misconfigured. None is "no
+    signal" -- callers must never treat it as "confirmed safe". Never raises.
+    """
+    reversed_octets = _reverse_ipv4(ip_address)
+    if not reversed_octets:
+        return None
+
+    cached, hit = _cache_get(ip_address)
+    if hit:
+        return cached
+
+    key = api_key or get_api_key()
+    if not key:
+        return None
+
+    query = f"{key}.{reversed_octets}.{_LOOKUP_SUFFIX}"
+    result = None
+    old_timeout = socket.getdefaulttimeout()
+    try:
+        socket.setdefaulttimeout(_DNS_TIMEOUT_SECONDS)
+        answer = socket.gethostbyname(query)
+        octets = [int(o) for o in answer.split(".")]
+        if len(octets) == 4 and octets[0] == 127:
+            result = {
+                "days_since_last_activity": octets[1],
+                "threat_score": octets[2],
+                "visitor_type": octets[3],
+            }
+    except socket.gaierror:
+        result = None  # NXDOMAIN -- not listed, the common case
+    except Exception:
+        logger.debug("http:BL lookup failed for %s", ip_address, exc_info=True)
+        result = None
+    finally:
+        socket.setdefaulttimeout(old_timeout)
+
+    _cache_set(ip_address, result)
+    return result
+
+
+def describe_visitor_type(visitor_type: int) -> str:
+    labels = []
+    if visitor_type & TYPE_SUSPICIOUS:
+        labels.append("suspicious")
+    if visitor_type & TYPE_HARVESTER:
+        labels.append("harvester")
+    if visitor_type & TYPE_COMMENT_SPAMMER:
+        labels.append("comment spammer")
+    return ", ".join(labels) if labels else "search engine"
+
+
+def check_httpbl_and_ban(ip_address: str):
+    """Query http:BL for *ip_address* and auto-ban it if it looks malicious.
+
+    Only call this from the login flow. A per-request DNS lookup on every
+    page load would add latency everywhere and quickly burn through a free
+    key's daily query quota; login attempts are a naturally low-frequency
+    choke point that also happens to be exactly where a harvester/spammer
+    reputation signal is most actionable.
+
+    Returns the created IPFilter row if banned, else None. Never raises --
+    a lookup problem must never block or delay a real login.
+    """
+    if not ip_address or not is_enabled():
+        return None
+    if ip_address in ('127.0.0.1', '::1'):
+        return None
+
+    try:
+        result = query_httpbl(ip_address)
+        if not result:
+            return None
+
+        visitor_type = result["visitor_type"]
+        threat_score = result["threat_score"]
+        is_bad = (
+            visitor_type & (TYPE_HARVESTER | TYPE_COMMENT_SPAMMER)
+            or (visitor_type & TYPE_SUSPICIOUS and threat_score >= _SUSPICIOUS_THREAT_THRESHOLD)
+        )
+        if not is_bad:
+            return None
+
+        from app_core.auth.ip_filter import IPFilter, IPFilterReason, IPFilterSource, IPFilterType
+        existing = IPFilter.query.filter_by(
+            ip_address=ip_address,
+            filter_type=IPFilterType.BLOCKLIST.value,
+            is_active=True,
+        ).first()
+        if existing:
+            return None
+
+        logger.warning(
+            "http:BL flagged %s as %s (threat score %d) -- auto-banning for %dh",
+            ip_address, describe_visitor_type(visitor_type), threat_score, _AUTO_BAN_HOURS,
+        )
+        return IPFilter.add_to_blocklist(
+            ip_address=ip_address,
+            reason=IPFilterReason.AUTO_MALICIOUS.value,
+            description=(
+                f"Project Honeypot http:BL: {describe_visitor_type(visitor_type)}, "
+                f"threat score {threat_score}, last active "
+                f"{result['days_since_last_activity']}d ago"
+            ),
+            source=IPFilterSource.HTTPBL.value,
+            expires_in_hours=_AUTO_BAN_HOURS,
+        )
+    except Exception:
+        logger.exception("http:BL check failed for %s", ip_address)
+        return None

--- a/app_core/auth/ip_filter.py
+++ b/app_core/auth/ip_filter.py
@@ -65,6 +65,7 @@ class IPFilterSource(Enum):
     FLOOD = 'flood'                         # Request flooding
     API_ABUSE = 'api_abuse'                 # API abuse
     STREAM_ABUSE = 'stream_abuse'           # Stream abuse
+    HTTPBL = 'httpbl'                       # Project Honeypot http:BL reputation hit
 
 
 # Human-readable labels for ban sources (used by to_dict and the UI badges).
@@ -76,6 +77,7 @@ IP_FILTER_SOURCE_LABELS = {
     IPFilterSource.FLOOD.value: 'Flood',
     IPFilterSource.API_ABUSE.value: 'API Abuse',
     IPFilterSource.STREAM_ABUSE.value: 'Stream Abuse',
+    IPFilterSource.HTTPBL.value: 'Project Honeypot',
 }
 
 

--- a/app_core/migrations/versions/20260904_add_httpbl_settings.py
+++ b/app_core/migrations/versions/20260904_add_httpbl_settings.py
@@ -1,0 +1,62 @@
+"""Add httpbl_enabled and httpbl_api_key columns to application_settings.
+
+Revision ID: 20260904_add_httpbl_settings
+Revises: 20260904_web_request_log_endpoint
+Create Date: 2026-09-04
+
+Adds an admin-UI toggle for Project Honeypot http:BL reputation checks
+(see app_core/auth/httpbl.py) plus the account's http:BL access key,
+stored in the database so it can be set from Application Settings rather
+than requiring shell access to edit .env -- the same pattern already used
+for Icecast credentials configured via the admin UI. Both default to
+"off"/empty so existing deployments are unaffected until an admin opts in.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20260904_add_httpbl_settings"
+down_revision = "20260904_web_request_log_endpoint"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    try:
+        cols = {c["name"] for c in inspector.get_columns(table_name)}
+    except Exception:
+        return False
+    return column_name in cols
+
+
+def upgrade():
+    if not _column_exists("application_settings", "httpbl_enabled"):
+        op.add_column(
+            "application_settings",
+            sa.Column(
+                "httpbl_enabled",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+    if not _column_exists("application_settings", "httpbl_api_key"):
+        op.add_column(
+            "application_settings",
+            sa.Column(
+                "httpbl_api_key",
+                sa.String(length=64),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade():
+    if _column_exists("application_settings", "httpbl_api_key"):
+        op.drop_column("application_settings", "httpbl_api_key")
+    if _column_exists("application_settings", "httpbl_enabled"):
+        op.drop_column("application_settings", "httpbl_enabled")

--- a/config/bad-actors-local.conf
+++ b/config/bad-actors-local.conf
@@ -1,0 +1,15 @@
+# Locally curated, permanent additions to the nginx known-bad-actor
+# blocklist (see scripts/update_bad_actors.sh and the `geo $bad_actor`
+# block in config/nginx-eas-station.conf).
+#
+# This file is checked into git and NEVER touched by the automated
+# updater -- that script only ever rewrites bad-actors-auto.conf. Add
+# entries here for netblocks observed directly in this deployment's own
+# logs that you want blocked regardless of whether an external feed
+# lists them.
+#
+# Format: one nginx geo-map entry per line, "<ip-or-cidr> 1;".
+
+# 2026-09-04: single /24 responsible for 351 of ~700 scanner/exploit-probe
+# hits (.env, .git, wp-json SSRF probes, etc.) in one day of access logs.
+45.148.10.0/24 1;

--- a/config/nginx-eas-station.conf
+++ b/config/nginx-eas-station.conf
@@ -18,6 +18,18 @@ upstream eas_station_backend {
 limit_req_zone $binary_remote_addr zone=eas_api:10m rate=20r/s;
 limit_req_zone $binary_remote_addr zone=eas_login:10m rate=5r/m;
 
+# Known-bad-actor IP blocklist. bad-actors-local.conf is checked into git,
+# hand-curated (see that file); bad-actors-auto.conf is regenerated daily
+# from Spamhaus DROP/EDROP by scripts/update_bad_actors.sh, run via
+# bad-actors-update.timer -- see systemd/. Neither file's absence is
+# tolerated silently: both must exist (even if just a comment) for nginx to
+# start, which install.sh and the updater script both guarantee.
+geo $bad_actor {
+    default 0;
+    include /opt/eas-station/config/bad-actors-local.conf;
+    include /etc/nginx/bad-actors-auto.conf;
+}
+
 # HTTP server - redirect to HTTPS
 server {
     listen 80;
@@ -62,6 +74,12 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+
+    # Reject known-bad-actor IPs before any location/proxy logic runs. See
+    # the `geo $bad_actor` block above for where the list comes from.
+    if ($bad_actor) {
+        return 444;
+    }
 
     # Client body size. Set above the app's own MAX_CONTENT_LENGTH (100 MB,
     # app.py) so normal oversized uploads are rejected by Flask itself --

--- a/config/nginx-eas-station.conf
+++ b/config/nginx-eas-station.conf
@@ -10,6 +10,14 @@ upstream eas_station_backend {
     keepalive 32;
 }
 
+# Flood control zones (per-client-IP). General API traffic gets a generous
+# cap that only bites during a runaway client-side polling loop or a scan --
+# legitimate dashboard polling (broadcast_state at 1s, alerts at 5s, etc.,
+# see static/js/core/websocket.js FALLBACK_INTERVALS) sits well under it.
+# /login gets a much tighter cap to slow credential-stuffing.
+limit_req_zone $binary_remote_addr zone=eas_api:10m rate=20r/s;
+limit_req_zone $binary_remote_addr zone=eas_login:10m rate=5r/m;
+
 # HTTP server - redirect to HTTPS
 server {
     listen 80;
@@ -100,6 +108,16 @@ server {
     proxy_send_timeout 300s;
     proxy_read_timeout 300s;
 
+    # Known-scanner bait: EAS Station is a pure Python/Flask app, so none of
+    # these paths are ever legitimate here -- they're mass-scanner probes for
+    # WordPress admin/REST endpoints, leaked .env/.git files, PHP shells, and
+    # similar. Reject before they reach the app (and its /login redirect
+    # catch-all, which was rendering a full 29KB page for every one of these).
+    # 444 is nginx-specific: close the connection with no response at all.
+    location ~* (wp-admin|wp-login|wp-json|wp-content|wp-includes|wordpress|xmlrpc\.php|\.env|\.git/|phpmyadmin|/\.docker/|/cgi-bin/|\.php$) {
+        return 444;
+    }
+
     # Proxy to Flask application
     location / {
         proxy_pass http://eas_station_backend;
@@ -108,8 +126,43 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
-        
+
         # HTTP/1.1 for keep-alive
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # Flood control: general per-IP cap on API traffic. burst=40 absorbs a
+    # normal page's simultaneous polls (broadcast_state @1s, alerts @5s, etc.)
+    # and short bursts on load; nodelay lets those through immediately rather
+    # than queuing, only excess above the burst gets 503'd. More specific
+    # /api/... locations below (streaming, audio) still take precedence.
+    location /api/ {
+        limit_req zone=eas_api burst=40 nodelay;
+
+        proxy_pass http://eas_station_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # Flood control: strict per-IP cap on login attempts to slow
+    # credential-stuffing / brute force.
+    location = /login {
+        limit_req zone=eas_login burst=5 nodelay;
+
+        proxy_pass http://eas_station_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
     }

--- a/config/nginx-eas-station.conf
+++ b/config/nginx-eas-station.conf
@@ -30,6 +30,29 @@ geo $bad_actor {
     include /etc/nginx/bad-actors-auto.conf;
 }
 
+# Per-IP/CIDR bypass for the blocklist above (false positives, an admin's
+# own IP, etc). Written by the Admin -> Application Settings "Bad Actor
+# Blocklist" panel (webapp/admin/bad_actors.py) -- never hand-edit, changes
+# get clobbered on the next UI save.
+geo $bad_actor_allow {
+    default 0;
+    include /etc/nginx/bad-actors-allowlist.conf;
+}
+
+# Master on/off switch for the blocklist, also UI-managed. File contents are
+# exactly `map $host $bad_actor_switch { default 1; }` (on) or `... 0; }`
+# (off) -- a whole map block rather than a bare value because `set` isn't
+# valid at this (http) context, only inside server/location/if.
+include /etc/nginx/bad-actors-switch.conf;
+
+# Single decision combining switch + blocklist-hit + allowlist-bypass. The
+# string-concatenation trick is the standard nginx idiom for AND'ing
+# multiple geo/map variables together, since `if` has no boolean operators.
+map "$bad_actor_switch:$bad_actor:$bad_actor_allow" $bad_actor_block {
+    default 0;
+    "1:1:0" 1;
+}
+
 # HTTP server - redirect to HTTPS
 server {
     listen 80;
@@ -76,8 +99,9 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
 
     # Reject known-bad-actor IPs before any location/proxy logic runs. See
-    # the `geo $bad_actor` block above for where the list comes from.
-    if ($bad_actor) {
+    # the `geo $bad_actor` / `$bad_actor_block` blocks above for where this
+    # comes from, the on/off switch, and the allowlist bypass.
+    if ($bad_actor_block) {
         return 444;
     }
 

--- a/config/sudoers-eas-station
+++ b/config/sudoers-eas-station
@@ -234,3 +234,15 @@ eas-station ALL=(ALL) NOPASSWD: /usr/sbin/ufw delete allow from * to any port 12
 # rules this feature created, same as the NTP entries above.
 eas-station ALL=(ALL) NOPASSWD: /usr/sbin/ufw allow from * to any port * proto tcp comment eas-station-icecast
 eas-station ALL=(ALL) NOPASSWD: /usr/sbin/ufw delete allow from * to any port * proto tcp
+
+# Bad Actor Blocklist (Admin -> Application Settings): lets the web UI
+# manage the nginx-level Spamhaus/local IP blocklist added in
+# scripts/update_bad_actors.sh -- toggle it on/off, edit the allowlist, and
+# trigger an immediate Spamhaus DROP/EDROP refresh. See
+# webapp/admin/bad_actors.py. IPs/CIDRs are validated in Python before ever
+# reaching these commands. nginx -t / reload nginx are already granted above.
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/nginx/bad-actors-switch.conf
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/nginx/bad-actors-allowlist.conf
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/systemctl start bad-actors-update.service
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/systemctl is-active bad-actors-update.service
+eas-station ALL=(ALL) NOPASSWD: /usr/bin/systemctl show bad-actors-update.service *

--- a/install.sh
+++ b/install.sh
@@ -1931,10 +1931,20 @@ if [ ! -f /etc/nginx/sites-available/eas-station ]; then
     
     # Enable site
     ln -sf /etc/nginx/sites-available/eas-station /etc/nginx/sites-enabled/
-    
+
     # Remove default site if it exists
     rm -f /etc/nginx/sites-enabled/default
-    
+
+    # The nginx config's `geo $bad_actor` block (known-bad-actor IP
+    # blocklist, see scripts/update_bad_actors.sh) includes this file
+    # unconditionally -- nginx refuses to start if it's missing. Real
+    # content gets populated below once services are enabled; this
+    # placeholder just lets nginx come up in the meantime.
+    if [ ! -f /etc/nginx/bad-actors-auto.conf ]; then
+        echo "# placeholder -- populated by update_bad_actors.sh on first run" \
+            > /etc/nginx/bad-actors-auto.conf
+    fi
+
     # Test nginx configuration
     nginx -t && systemctl reload nginx
     echo_success "Nginx configured"
@@ -2447,6 +2457,14 @@ echo_step "Start EAS Station Services"
 echo_progress "Enabling services for automatic startup..."
 systemctl enable eas-station.target > /dev/null 2>&1
 systemctl enable nginx > /dev/null 2>&1
+# Known-bad-actor IP blocklist (Spamhaus DROP/EDROP): enable the daily
+# refresh timer, then run it once now so a fresh install is protected
+# immediately rather than starting from the placeholder and waiting for
+# the timer's first (up to ~24h-delayed) run.
+systemctl enable --now bad-actors-update.timer > /dev/null 2>&1 || \
+    echo_warning "bad-actors-update.timer failed to enable"
+systemctl start bad-actors-update.service > /dev/null 2>&1 || \
+    echo_warning "Initial known-bad-actor blocklist fetch failed (will retry on the daily timer)"
 # Hardware subsystem units (Phase 4 split). The umbrella target Wants= these,
 # but transitively-wanted units don't get [Install] symlinks created — so
 # enable each one explicitly so they auto-start at boot independent of the

--- a/install.sh
+++ b/install.sh
@@ -1945,6 +1945,22 @@ if [ ! -f /etc/nginx/sites-available/eas-station ]; then
             > /etc/nginx/bad-actors-auto.conf
     fi
 
+    # Master on/off switch and allowlist for the same blocklist, managed by
+    # the Admin -> Application Settings "Bad Actor Blocklist" panel
+    # (webapp/admin/bad_actors.py). Also included unconditionally, so also
+    # need a placeholder before nginx's first start. Default: enabled, empty
+    # allowlist.
+    if [ ! -f /etc/nginx/bad-actors-switch.conf ]; then
+        echo 'map $host $bad_actor_switch { default 1; }' \
+            > /etc/nginx/bad-actors-switch.conf
+    fi
+    if [ ! -f /etc/nginx/bad-actors-allowlist.conf ]; then
+        {
+            echo "# Managed by Admin -> Application Settings -> Bad Actor Blocklist."
+            echo "# IPs/CIDRs here bypass the Spamhaus/local blocklist entirely."
+        } > /etc/nginx/bad-actors-allowlist.conf
+    fi
+
     # Test nginx configuration
     nginx -t && systemctl reload nginx
     echo_success "Nginx configured"

--- a/scripts/update_bad_actors.sh
+++ b/scripts/update_bad_actors.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Refreshes /etc/nginx/bad-actors-auto.conf from Spamhaus DROP + EDROP --
+# professionally-curated lists of hijacked and cybercrime-controlled
+# netblocks, deliberately kept small and high-confidence (unlike Spamhaus's
+# spam-scoring lists), so it's safe to hard-block rather than just flag.
+#
+# Run daily by bad-actors-update.timer (see systemd/). Safe to run by hand.
+# Reloads nginx only after the new list passes `nginx -t`, so a bad fetch or
+# a syntax problem never takes the site down.
+set -euo pipefail
+
+OUT=/etc/nginx/bad-actors-auto.conf
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+{
+    echo "# Auto-generated $(date -u +%FT%TZ) by update_bad_actors.sh from Spamhaus DROP/EDROP."
+    echo "# Do not edit by hand -- edit config/bad-actors-local.conf instead, it is not overwritten."
+    # `|| true` per URL: a single source returning zero matching lines (e.g.
+    # Spamhaus has since folded EDROP into DROP, leaving edrop.txt an empty
+    # stub) must not abort the whole run under pipefail. The aggregate count
+    # check below is what actually guards against a real fetch failure.
+    for url in https://www.spamhaus.org/drop/drop.txt https://www.spamhaus.org/drop/edrop.txt; do
+        curl -fsS --max-time 15 "$url" \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' \
+            | awk '{print $1, "1;"}' \
+            || true
+    done
+} > "$TMP"
+
+count=$(grep -cE '^[0-9]' "$TMP" || true)
+if [ "$count" -lt 100 ]; then
+    echo "update_bad_actors: only $count entries fetched (expected hundreds+) -- refusing to replace the list, likely a fetch failure" >&2
+    exit 1
+fi
+
+install -m 644 "$TMP" "$OUT"
+
+if nginx -t 2>/tmp/bad-actors-nginx-test.log; then
+    systemctl reload nginx
+    echo "update_bad_actors: applied $count entries"
+else
+    echo "update_bad_actors: nginx -t failed after updating the list, see /tmp/bad-actors-nginx-test.log -- leaving nginx running on the previous config" >&2
+    exit 1
+fi

--- a/static/js/core/health.js
+++ b/static/js/core/health.js
@@ -17,6 +17,12 @@
     // WebSocket subscription handle
     let wsUnsubscribe = null;
 
+    // /api/system_status is restricted to local-network/authenticated callers
+    // (see app.py LOCAL_API_GET_PATHS). This module loads on every page, so
+    // an anonymous visitor gets 401 here forever if we keep polling. Stop
+    // (and tear down the WS fallback interval) after the first 401.
+    let statusEndpointGated = false;
+
     /**
      * Update system status banner
      */
@@ -69,9 +75,22 @@
      * Check system health status
      */
     async function checkSystemHealth() {
+        if (statusEndpointGated) {
+            return;
+        }
         try {
             const fetchFunc = window.cachedFetch || fetch;
             const response = await fetchFunc('/api/system_status');
+
+            if (response.status === 401) {
+                statusEndpointGated = true;
+                if (wsUnsubscribe) {
+                    wsUnsubscribe();
+                    wsUnsubscribe = null;
+                }
+                return;
+            }
+
             const data = await response.json();
 
             const healthDot = document.getElementById('system-health-dot');

--- a/static/js/pages/dashboard_status.js
+++ b/static/js/pages/dashboard_status.js
@@ -7,6 +7,13 @@
 (function () {
     const REFRESH_INTERVAL_MS = 30 * 1000;
 
+    // /api/eas-monitor/status is restricted to local-network/authenticated
+    // callers (see app.py LOCAL_API_GET_PATHS). An anonymous visitor on this
+    // public page will always get 401 here — retrying every interval forever
+    // just floods the server with calls that can never succeed. Stop after
+    // the first 401 for the rest of this page's lifetime.
+    let monitorTileGated = false;
+
     function setBadge(elementId, text, variant) {
         const el = document.getElementById(elementId);
         if (!el) {
@@ -26,7 +33,9 @@
     async function fetchJson(url) {
         const response = await fetch(url);
         if (!response.ok) {
-            throw new Error(`${url} responded with status ${response.status}`);
+            const error = new Error(`${url} responded with status ${response.status}`);
+            error.status = response.status;
+            throw error;
         }
         return response.json();
     }
@@ -43,6 +52,9 @@
     }
 
     async function refreshMonitorTile() {
+        if (monitorTileGated) {
+            return;
+        }
         try {
             const data = await fetchJson('/api/eas-monitor/status');
             if (data.running) {
@@ -56,6 +68,9 @@
             console.error('Dashboard status: failed to load EAS monitor status', error);
             setBadge('dash-stat-monitor-badge', 'Unknown', 'secondary');
             setText('dash-stat-monitor-sub', 'EAS Decoder');
+            if (error.status === 401) {
+                monitorTileGated = true;
+            }
         }
     }
 

--- a/systemd/bad-actors-update.service
+++ b/systemd/bad-actors-update.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Refresh nginx known-bad-actor IP blocklist (Spamhaus DROP/EDROP)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/eas-station/scripts/update_bad_actors.sh
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/bad-actors-update.timer
+++ b/systemd/bad-actors-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily refresh of the nginx known-bad-actor IP blocklist
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/templates/admin/application_settings.html
+++ b/templates/admin/application_settings.html
@@ -205,6 +205,79 @@
                     </div>
                 </div>
 
+                <!-- Bad Actor Blocklist (own AJAX API, not part of this <form>'s submit) -->
+                <div class="card mb-3" id="badActorsCard">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="mb-0 h5"><i class="fas fa-shield-halved"></i> Bad Actor Blocklist</h2>
+                        <div class="form-check form-switch mb-0">
+                            <input class="form-check-input" type="checkbox" role="switch" id="badActorsEnabled">
+                            <label class="form-check-label" for="badActorsEnabled">Enabled</label>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <p class="text-muted">
+                            nginx rejects requests from IPs on Spamhaus's DROP/EDROP list (hijacked and
+                            cybercrime-controlled netblocks) plus any manually added below, before they
+                            reach the application.
+                        </p>
+                        <div class="row mb-3">
+                            <div class="col-sm-6">
+                                <div class="small text-muted">Spamhaus list</div>
+                                <div><span class="badge bg-info" id="badActorsAutoCount">–</span> entries,
+                                    last updated <span id="badActorsAutoUpdated">–</span></div>
+                            </div>
+                            <div class="col-sm-6">
+                                <div class="small text-muted">Local additions</div>
+                                <div><span class="badge bg-secondary" id="badActorsLocalCount">–</span> entries
+                                    (<code>config/bad-actors-local.conf</code>)</div>
+                            </div>
+                        </div>
+                        <button type="button" class="btn btn-outline-primary btn-sm mb-3" id="badActorsRefreshBtn">
+                            <i class="fas fa-rotate"></i> Update Spamhaus list now
+                        </button>
+
+                        <label class="form-label">Allowlist (bypasses the blocklist entirely)</label>
+                        <div class="input-group mb-2">
+                            <input type="text" class="form-control" id="badActorsAllowInput"
+                                   placeholder="IP address or CIDR, e.g. 203.0.113.5 or 203.0.113.0/24">
+                            <button type="button" class="btn btn-outline-secondary" id="badActorsAllowAddBtn">
+                                <i class="fas fa-plus"></i> Add
+                            </button>
+                        </div>
+                        <ul class="list-group" id="badActorsAllowList"></ul>
+                        <div class="form-text" id="badActorsAllowEmpty">No allowlist entries.</div>
+                    </div>
+                </div>
+
+                <!-- Project Honeypot http:BL -->
+                <div class="card mb-3">
+                    <div class="card-header">
+                        <h2 class="mb-0 h5"><i class="fas fa-user-secret"></i> Project Honeypot (http:BL)</h2>
+                    </div>
+                    <div class="card-body">
+                        <p class="text-muted">
+                            On login attempts, checks the visitor's IP against Project Honeypot's http:BL
+                            reputation service and auto-bans it if flagged as a harvester or comment spammer.
+                            Requires a free access key from
+                            <a href="https://www.projecthoneypot.org/" target="_blank" rel="noopener">projecthoneypot.org</a>.
+                        </p>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="httpbl_enabled" name="httpbl_enabled"
+                                   {% if settings.httpbl_enabled %}checked{% endif %}>
+                            <label class="form-check-label" for="httpbl_enabled">Enabled</label>
+                        </div>
+                        <label for="httpbl_api_key" class="form-label">Access key</label>
+                        <input type="password" class="form-control" id="httpbl_api_key" name="httpbl_api_key"
+                               placeholder="{% if settings.httpbl_api_key_set %}Configured — leave blank to keep it{% else %}Not configured{% endif %}"
+                               autocomplete="off">
+                        <div class="form-text">
+                            Write-only: the saved key is never shown here. Leave blank when saving other
+                            settings to keep the current key.
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Bootstrap Settings Notice -->
                 <div class="card mb-3 border-warning">
                     <div class="card-header bg-warning text-dark">
@@ -510,6 +583,155 @@ document.addEventListener('DOMContentLoaded', function() {
         } finally {
             submitBtn.disabled = false;
             submitBtn.innerHTML = originalBtnText;
+        }
+    });
+
+    // ---- Bad Actor Blocklist (separate JSON API, webapp/admin/bad_actors.py) ----
+    const badActorsBase = '/admin/security/bad-actors';
+    const badActorsEnabled = document.getElementById('badActorsEnabled');
+    const badActorsRefreshBtn = document.getElementById('badActorsRefreshBtn');
+    const badActorsAllowInput = document.getElementById('badActorsAllowInput');
+    const badActorsAllowAddBtn = document.getElementById('badActorsAllowAddBtn');
+    const badActorsAllowList = document.getElementById('badActorsAllowList');
+    const badActorsAllowEmpty = document.getElementById('badActorsAllowEmpty');
+
+    function renderAllowlist(entries) {
+        badActorsAllowList.innerHTML = '';
+        badActorsAllowEmpty.style.display = entries.length ? 'none' : 'block';
+        entries.forEach(function(entry) {
+            const li = document.createElement('li');
+            li.className = 'list-group-item d-flex justify-content-between align-items-center';
+            const code = document.createElement('code');
+            code.textContent = entry;
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-sm btn-outline-danger';
+            btn.innerHTML = '<i class="fas fa-trash"></i>';
+            btn.addEventListener('click', function() { removeAllowlistEntry(entry); });
+            li.appendChild(code);
+            li.appendChild(btn);
+            badActorsAllowList.appendChild(li);
+        });
+    }
+
+    function applyBadActorsStatus(s) {
+        badActorsEnabled.checked = !!s.enabled;
+        document.getElementById('badActorsAutoCount').textContent = s.auto_entry_count;
+        document.getElementById('badActorsAutoUpdated').textContent =
+            s.auto_last_updated ? new Date(s.auto_last_updated).toLocaleString() : 'never';
+        document.getElementById('badActorsLocalCount').textContent = s.local_entry_count;
+        renderAllowlist(s.allowlist || []);
+    }
+
+    fetch(badActorsBase + '/status', { headers: { 'Accept': 'application/json' } })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                applyBadActorsStatus(data);
+            } else {
+                showToast(data.error || 'Failed to load bad actor blocklist status', 'danger');
+            }
+        })
+        .catch(function(err) {
+            console.error('Error loading bad actor blocklist status:', err);
+            showToast('Error loading bad actor blocklist status', 'danger');
+        });
+
+    badActorsEnabled.addEventListener('change', async function() {
+        const enabled = badActorsEnabled.checked;
+        badActorsEnabled.disabled = true;
+        try {
+            const response = await fetch(badActorsBase + '/toggle', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
+                body: JSON.stringify({ enabled: enabled })
+            });
+            const data = await response.json();
+            if (data.success) {
+                showToast(enabled ? 'Bad actor blocklist enabled' : 'Bad actor blocklist disabled', 'success');
+            } else {
+                badActorsEnabled.checked = !enabled;
+                showToast(data.error || 'Failed to change blocklist state', 'danger');
+            }
+        } catch (error) {
+            badActorsEnabled.checked = !enabled;
+            console.error('Error toggling bad actor blocklist:', error);
+            showToast('Error toggling bad actor blocklist', 'danger');
+        } finally {
+            badActorsEnabled.disabled = false;
+        }
+    });
+
+    badActorsRefreshBtn.addEventListener('click', async function() {
+        const originalHtml = badActorsRefreshBtn.innerHTML;
+        badActorsRefreshBtn.disabled = true;
+        badActorsRefreshBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Updating…';
+        try {
+            const response = await fetch(badActorsBase + '/update', {
+                method: 'POST',
+                headers: { 'X-CSRF-Token': window.CSRF_TOKEN }
+            });
+            const data = await response.json();
+            if (data.success) {
+                showToast(data.message || 'Blocklist updated', 'success');
+                document.getElementById('badActorsAutoCount').textContent = data.auto_entry_count;
+                document.getElementById('badActorsAutoUpdated').textContent =
+                    data.auto_last_updated ? new Date(data.auto_last_updated).toLocaleString() : 'never';
+            } else {
+                showToast(data.error || 'Blocklist update failed', 'danger');
+            }
+        } catch (error) {
+            console.error('Error updating bad actor blocklist:', error);
+            showToast('Error updating bad actor blocklist', 'danger');
+        } finally {
+            badActorsRefreshBtn.disabled = false;
+            badActorsRefreshBtn.innerHTML = originalHtml;
+        }
+    });
+
+    async function removeAllowlistEntry(entry) {
+        try {
+            const response = await fetch(badActorsBase + '/allowlist', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
+                body: JSON.stringify({ entry: entry })
+            });
+            const data = await response.json();
+            if (data.success) {
+                renderAllowlist(data.allowlist);
+                showToast('Removed from allowlist', 'success');
+            } else {
+                showToast(data.error || 'Failed to remove entry', 'danger');
+            }
+        } catch (error) {
+            console.error('Error removing allowlist entry:', error);
+            showToast('Error removing allowlist entry', 'danger');
+        }
+    }
+
+    badActorsAllowAddBtn.addEventListener('click', async function() {
+        const entry = badActorsAllowInput.value.trim();
+        if (!entry) return;
+        badActorsAllowAddBtn.disabled = true;
+        try {
+            const response = await fetch(badActorsBase + '/allowlist', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.CSRF_TOKEN },
+                body: JSON.stringify({ entry: entry })
+            });
+            const data = await response.json();
+            if (data.success) {
+                renderAllowlist(data.allowlist);
+                badActorsAllowInput.value = '';
+                showToast('Added to allowlist', 'success');
+            } else {
+                showToast(data.error || 'Failed to add entry', 'danger');
+            }
+        } catch (error) {
+            console.error('Error adding allowlist entry:', error);
+            showToast('Error adding allowlist entry', 'danger');
+        } finally {
+            badActorsAllowAddBtn.disabled = false;
         }
     });
 });

--- a/templates/system_health.html
+++ b/templates/system_health.html
@@ -5175,6 +5175,8 @@
             updateCurrentTimeDisplay();
         }
 
+        let healthEndpointGated = false;
+
         async function refreshHealthData(showSpinner = false) {
             try {
                 if (showSpinner) {
@@ -5189,6 +5191,13 @@
                 });
 
                 if (!response.ok) {
+                    if (response.status === 401) {
+                        // /api/system_health is restricted to local-network/
+                        // authenticated callers. An anonymous visitor on this
+                        // public page will always get 401 -- stop the
+                        // automatic refresh loop so it doesn't poll forever.
+                        healthEndpointGated = true;
+                    }
                     throw new Error(`Request failed with status ${response.status}`);
                 }
 
@@ -6034,6 +6043,7 @@
 
             setInterval(() => {
                 if (typeof document !== 'undefined' && document.hidden) return;
+                if (healthEndpointGated) return;
                 refreshHealthData(false);
             }, REFRESH_INTERVAL_MS);
 

--- a/update.sh
+++ b/update.sh
@@ -960,6 +960,21 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
     systemctl enable --now eas-station-hardware.target >/dev/null 2>&1 || \
         echo_warning "eas-station-hardware.target failed to enable"
 
+    # Known-bad-actor IP blocklist (Spamhaus DROP/EDROP): enable the daily
+    # refresh timer -- enable --now is idempotent, safe on every update, same
+    # as the units above. Only trigger an immediate fetch if the list is
+    # still just the placeholder from the nginx-config step above (a
+    # deployment updating into this feature for the first time), so routine
+    # updates on a deployment that already has it configured don't force an
+    # extra Spamhaus fetch every time.
+    systemctl enable --now bad-actors-update.timer >/dev/null 2>&1 || \
+        echo_warning "bad-actors-update.timer failed to enable"
+    if grep -q "^# placeholder" /etc/nginx/bad-actors-auto.conf 2>/dev/null; then
+        echo_progress "First-time known-bad-actor blocklist fetch..."
+        systemctl start bad-actors-update.service >/dev/null 2>&1 || \
+            echo_warning "Initial known-bad-actor blocklist fetch failed (will retry on the daily timer)"
+    fi
+
     # Give the subsystems a beat to come up before we judge the target.
     sleep 2
     if systemctl is-active --quiet eas-station-hardware.target; then
@@ -1086,6 +1101,28 @@ fi
 
 # Update nginx configuration (only if changed)
 echo_step "Checking Nginx Configuration"
+
+# The nginx config's known-bad-actor blocklist (`geo $bad_actor` etc., see
+# scripts/update_bad_actors.sh) `include`s these three files unconditionally
+# -- nginx refuses to start (and `nginx -t` below refuses to pass) if any is
+# missing. A deployment updating from before this feature existed won't have
+# them yet, so create placeholders unconditionally, before the config swap,
+# the same way install.sh does for a fresh install. Real Spamhaus content
+# gets populated below once services are (re)enabled.
+if [ ! -f /etc/nginx/bad-actors-auto.conf ]; then
+    echo "# placeholder -- populated by update_bad_actors.sh on first run" \
+        > /etc/nginx/bad-actors-auto.conf
+fi
+if [ ! -f /etc/nginx/bad-actors-switch.conf ]; then
+    echo 'map $host $bad_actor_switch { default 1; }' \
+        > /etc/nginx/bad-actors-switch.conf
+fi
+if [ ! -f /etc/nginx/bad-actors-allowlist.conf ]; then
+    {
+        echo "# Managed by Admin -> Application Settings -> Bad Actor Blocklist."
+        echo "# IPs/CIDRs here bypass the Spamhaus/local blocklist entirely."
+    } > /etc/nginx/bad-actors-allowlist.conf
+fi
 
 if [ -f "$INSTALL_DIR/config/nginx-eas-station.conf" ]; then
     if [ -f /etc/nginx/sites-available/eas-station ]; then

--- a/webapp/admin/__init__.py
+++ b/webapp/admin/__init__.py
@@ -59,6 +59,7 @@ from .alert_purge import alert_purge_bp
 from .mail_server import register_mail_server_routes
 from .ntp_server import register_ntp_server_routes
 from .fail2ban import register_fail2ban_routes
+from .bad_actors import register_bad_actors_routes
 from .security_checkup import register_security_checkup_routes
 from .firewall import register_firewall_routes
 from .eas_decoder_monitor import register_blueprint as register_eas_decoder_monitor_routes
@@ -116,6 +117,7 @@ def register(app, logger):
     register_mail_server_routes(app, logger)  # Local Postfix mail server management
     register_ntp_server_routes(app, logger)  # LAN NTP server (chrony allow + firewall) management
     register_fail2ban_routes(app, logger)  # fail2ban host-level intrusion banning
+    register_bad_actors_routes(app, logger)  # nginx-level Spamhaus known-bad-actor blocklist
     register_security_checkup_routes(app, logger)  # Security Center "Checkup" tab (UFW/fail2ban gap detection)
     register_firewall_routes(app, logger)  # Consolidated firewall rule management (baseline, NTP, Icecast)
     register_eas_decoder_monitor_routes(app)  # EAS decoder audio monitor settings

--- a/webapp/admin/application_settings.py
+++ b/webapp/admin/application_settings.py
@@ -56,6 +56,8 @@ def _get_or_create_settings() -> ApplicationSettings:
             password_require_digits=False,
             password_require_special=False,
             password_expiration_days=0,
+            httpbl_enabled=False,
+            httpbl_api_key=None,
         )
         db.session.add(settings)
         db.session.commit()
@@ -78,6 +80,8 @@ def _fallback_application_settings():
         password_require_digits=False,
         password_require_special=False,
         password_expiration_days=0,
+        httpbl_enabled=False,
+        httpbl_api_key_set=False,
     )
 
 
@@ -190,6 +194,15 @@ def update_application_settings():
             return jsonify({'success': False, 'error': 'Invalid password expiration days value'}), 400
         settings.password_expiration_days = expiry_days
 
+        # Project Honeypot http:BL. Key field is write-only from the UI: a
+        # blank submission means "leave the existing key alone" (the form
+        # never round-trips the actual secret, see
+        # ApplicationSettings.httpbl_api_key_set), not "clear it".
+        settings.httpbl_enabled = request.form.get('httpbl_enabled') == 'on'
+        httpbl_api_key = request.form.get('httpbl_api_key', '').strip()
+        if httpbl_api_key:
+            settings.httpbl_api_key = httpbl_api_key
+
         db.session.commit()
 
         # Apply log level change immediately to the running process
@@ -224,6 +237,8 @@ def update_application_settings():
                 'password_require_digits': settings.password_require_digits,
                 'password_require_special': settings.password_require_special,
                 'password_expiration_days': settings.password_expiration_days,
+                'httpbl_enabled': settings.httpbl_enabled,
+                'httpbl_api_key_set': settings.httpbl_api_key_set,
             },
         )
 

--- a/webapp/admin/auth.py
+++ b/webapp/admin/auth.py
@@ -138,6 +138,19 @@ def login():
     if request.method == 'POST':
         # Check IP filter first
         is_allowed, block_reason = IPFilter.is_ip_allowed(request.remote_addr)
+
+        # Project Honeypot http:BL reputation check (opt-in, see
+        # app_core.auth.httpbl -- Application Settings). A no-op when
+        # disabled/unconfigured. Folded into is_allowed/block_reason rather
+        # than its own branch so a fresh ban here is denied immediately,
+        # using the same "blocked IP" path below instead of duplicating it.
+        if is_allowed:
+            from app_core.auth.httpbl import check_httpbl_and_ban
+            httpbl_ban = check_httpbl_and_ban(request.remote_addr)
+            if httpbl_ban:
+                is_allowed = False
+                block_reason = 'Project Honeypot http:BL'
+
         if not is_allowed:
             error = 'Access denied. Your IP address has been blocked.'
             db.session.add(SystemLog(

--- a/webapp/admin/bad_actors.py
+++ b/webapp/admin/bad_actors.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Bad Actor Blocklist management routes.
+
+Backs the Admin -> Application Settings "Bad Actor Blocklist" panel, which
+controls the nginx-level known-bad-actor IP blocklist added alongside
+scripts/update_bad_actors.sh: a Spamhaus DROP/EDROP feed refreshed daily by
+bad-actors-update.timer, merged with config/bad-actors-local.conf (hand-
+curated, checked into git) via nginx's `geo $bad_actor` map, gated by a
+master on/off switch and a per-IP/CIDR allowlist bypass -- both files here.
+
+nginx enforces the block (see config/nginx-eas-station.conf); this module
+only ever edits the three small control files it reads, then asks nginx to
+reload -- exactly the same "write via sudo tee, nginx -t, reload" pattern
+webapp/admin/fail2ban.py already uses for its own config writes.
+"""
+
+import ipaddress
+import logging
+import subprocess
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
+from app_core.auth.decorators import require_auth
+from app_core.auth.roles import require_permission
+from app_core.auth.audit import AuditLogger
+
+logger = logging.getLogger(__name__)
+
+bad_actors_bp = Blueprint("bad_actors", __name__, url_prefix="/admin/security/bad-actors")
+
+SWITCH_PATH = "/etc/nginx/bad-actors-switch.conf"
+ALLOWLIST_PATH = "/etc/nginx/bad-actors-allowlist.conf"
+AUTO_LIST_PATH = "/etc/nginx/bad-actors-auto.conf"
+LOCAL_LIST_PATH = "/opt/eas-station/config/bad-actors-local.conf"
+UPDATE_SERVICE = "bad-actors-update.service"
+
+ALLOWLIST_HEADER = (
+    "# Managed by Admin -> Application Settings -> Bad Actor Blocklist.\n"
+    "# IPs/CIDRs here bypass the Spamhaus/local blocklist entirely.\n"
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _run(cmd: list[str], timeout: int = 30) -> tuple[bool, str]:
+    """Run a privileged command via sudo. Returns (success, output)."""
+    try:
+        result = subprocess.run(
+            ["sudo", "-n"] + cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        output = (result.stdout + result.stderr).strip()
+        return result.returncode == 0, output
+    except subprocess.TimeoutExpired:
+        return False, f"Command timed out after {timeout}s"
+    except Exception as exc:  # pragma: no cover - defensive
+        return False, str(exc)
+
+
+def _write_via_sudo(path: str, content: str) -> tuple[bool, str]:
+    """Write content to a root-owned path through `sudo tee`."""
+    try:
+        proc = subprocess.run(
+            ["sudo", "-n", "tee", path],
+            input=content,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if proc.returncode != 0:
+            return False, (proc.stderr.strip() or "permission denied")
+        return True, ""
+    except Exception as exc:  # pragma: no cover - defensive
+        return False, str(exc)
+
+
+def _reload_nginx() -> tuple[bool, str]:
+    ok, output = _run(["nginx", "-t"])
+    if not ok:
+        return False, f"nginx config test failed: {output}"
+    ok, output = _run(["systemctl", "reload", "nginx"])
+    if not ok:
+        return False, f"nginx reload failed: {output}"
+    return True, ""
+
+
+def _read_switch_enabled() -> bool:
+    try:
+        with open(SWITCH_PATH, "r") as f:
+            content = f.read()
+        # File is exactly: map $host $bad_actor_switch { default 1; }  (or 0)
+        return "default 1" in content
+    except Exception:
+        logger.exception("Could not read %s", SWITCH_PATH)
+        return True  # fail open on read errors -- assume protection is on
+
+
+def _normalize_entry(raw: str) -> str | None:
+    """Validate an IP or CIDR and return its canonical string, or None."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        if "/" in raw:
+            return str(ipaddress.ip_network(raw, strict=False))
+        return str(ipaddress.ip_address(raw))
+    except ValueError:
+        return None
+
+
+def _read_allowlist() -> list[str]:
+    entries = []
+    try:
+        with open(ALLOWLIST_PATH, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                # Lines look like "1.2.3.0/24 1;"
+                cidr = line.split()[0]
+                entries.append(cidr)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.exception("Could not read %s", ALLOWLIST_PATH)
+    return entries
+
+
+def _write_allowlist(entries: list[str]) -> tuple[bool, str]:
+    body = ALLOWLIST_HEADER + "".join(f"{e} 1;\n" for e in entries)
+    ok, err = _write_via_sudo(ALLOWLIST_PATH, body)
+    if not ok:
+        return False, f"Could not write allowlist: {err}"
+    return _reload_nginx()
+
+
+def _list_meta(path: str) -> dict:
+    """Entry count + mtime for a geo-map data file."""
+    import os
+    try:
+        count = 0
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    count += 1
+        mtime = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+        return {"entry_count": count, "last_updated": mtime.isoformat()}
+    except Exception:
+        return {"entry_count": 0, "last_updated": None}
+
+
+# ── Routes ───────────────────────────────────────────────────────────────
+
+@bad_actors_bp.route("/status", methods=["GET"])
+@require_auth
+@require_permission("system.configure")
+def status():
+    auto_meta = _list_meta(AUTO_LIST_PATH)
+    local_meta = _list_meta(LOCAL_LIST_PATH)
+    return jsonify({
+        "success": True,
+        "enabled": _read_switch_enabled(),
+        "auto_entry_count": auto_meta["entry_count"],
+        "auto_last_updated": auto_meta["last_updated"],
+        "local_entry_count": local_meta["entry_count"],
+        "allowlist": _read_allowlist(),
+    })
+
+
+@bad_actors_bp.route("/toggle", methods=["POST"])
+@require_auth
+@require_permission("system.configure")
+def toggle():
+    payload = request.get_json(silent=True) or {}
+    enabled = bool(payload.get("enabled"))
+
+    content = f"map $host $bad_actor_switch {{ default {1 if enabled else 0}; }}\n"
+    ok, err = _write_via_sudo(SWITCH_PATH, content)
+    if not ok:
+        return jsonify({"success": False, "error": f"Could not write switch: {err}"}), 500
+
+    ok, err = _reload_nginx()
+    if not ok:
+        return jsonify({"success": False, "error": err}), 500
+
+    logger.info("Bad actor blocklist %s", "enabled" if enabled else "disabled")
+    AuditLogger.log_config_change(
+        resource_type="bad_actor_blocklist",
+        details={"enabled": enabled},
+    )
+    return jsonify({"success": True, "enabled": enabled})
+
+
+@bad_actors_bp.route("/update", methods=["POST"])
+@require_auth
+@require_permission("system.configure")
+def update_now():
+    """Trigger an immediate Spamhaus DROP/EDROP refresh.
+
+    `systemctl start` on a oneshot unit blocks until it finishes (or fails),
+    so this call's own exit status already tells us whether the refresh --
+    including its own internal nginx -t / reload -- actually succeeded.
+    """
+    ok, output = _run(["systemctl", "start", UPDATE_SERVICE], timeout=45)
+    if not ok:
+        return jsonify({
+            "success": False,
+            "error": f"Blocklist refresh failed: {output or 'see journalctl -u ' + UPDATE_SERVICE}",
+        }), 500
+
+    auto_meta = _list_meta(AUTO_LIST_PATH)
+    logger.info("Bad actor blocklist refreshed on demand: %d entries", auto_meta["entry_count"])
+    AuditLogger.log_config_change(
+        resource_type="bad_actor_blocklist",
+        details={"action": "manual_refresh", "entry_count": auto_meta["entry_count"]},
+    )
+    return jsonify({
+        "success": True,
+        "message": f"Blocklist refreshed: {auto_meta['entry_count']} entries.",
+        "auto_entry_count": auto_meta["entry_count"],
+        "auto_last_updated": auto_meta["last_updated"],
+    })
+
+
+@bad_actors_bp.route("/allowlist", methods=["POST"])
+@require_auth
+@require_permission("system.configure")
+def add_allowlist_entry():
+    payload = request.get_json(silent=True) or {}
+    entry = _normalize_entry(payload.get("entry"))
+    if not entry:
+        return jsonify({"success": False, "error": "Enter a valid IP address or CIDR range"}), 400
+
+    entries = _read_allowlist()
+    if entry not in entries:
+        entries.append(entry)
+        ok, err = _write_allowlist(entries)
+        if not ok:
+            return jsonify({"success": False, "error": err}), 500
+
+        logger.info("Added %s to the bad-actor allowlist", entry)
+        AuditLogger.log_config_change(
+            resource_type="bad_actor_blocklist",
+            details={"action": "allowlist_add", "entry": entry},
+        )
+
+    return jsonify({"success": True, "allowlist": entries})
+
+
+@bad_actors_bp.route("/allowlist", methods=["DELETE"])
+@require_auth
+@require_permission("system.configure")
+def remove_allowlist_entry():
+    payload = request.get_json(silent=True) or {}
+    entry = _normalize_entry(payload.get("entry"))
+    if not entry:
+        return jsonify({"success": False, "error": "Enter a valid IP address or CIDR range"}), 400
+
+    entries = [e for e in _read_allowlist() if e != entry]
+    ok, err = _write_allowlist(entries)
+    if not ok:
+        return jsonify({"success": False, "error": err}), 500
+
+    logger.info("Removed %s from the bad-actor allowlist", entry)
+    AuditLogger.log_config_change(
+        resource_type="bad_actor_blocklist",
+        details={"action": "allowlist_remove", "entry": entry},
+    )
+    return jsonify({"success": True, "allowlist": entries})
+
+
+def register_bad_actors_routes(app, logger_):
+    app.register_blueprint(bad_actors_bp)
+    logger_.info("Bad actor blocklist management routes registered")


### PR DESCRIPTION
## Summary
- Root-caused and fixed a client-side polling flood: several pages retried gated endpoints (`/api/system_status`, `/api/eas-monitor/status`, `/api/system_health`) forever on 401 instead of backing off — one tab logged 7k+ requests in a few hours.
- Added nginx `limit_req` rate limiting on `/api/` and `/login` as a backstop independent of client behavior.
- Added an nginx-level reject for WordPress/`.env`/`.git`/PHP-shell scanner probes (zero legitimate use on this Flask app), which previously fell through to a full 29KB `/login` page render per hit.
- Added an updatable known-bad-actor IP blocklist sourced from Spamhaus DROP/EDROP, refreshed daily via a systemd timer, merged with a hand-curated local list.
- Added admin UI controls for that blocklist (Application Settings): enable/disable, allowlist a false positive, trigger an immediate refresh — previously only editable by hand over SSH.
- Added an opt-in Project Honeypot http:BL reputation check on login attempts, auto-banning IPs flagged as harvesters/comment-spammers through the existing `IPFilter` blocklist.

## Test plan
- [x] `nginx -t` clean; verified live traffic still 200s on `/`, `/api/alerts`, `/login`, static assets
- [x] Confirmed scanner-bait paths (`/wp-admin/`, `/.env`, `/.git/config`, etc.) get connection-closed (444), legitimate paths unaffected
- [x] Verified full blocklist chain live: blocked IP → 444; allowlisted → passes; switch off → passes (each isolated with debug response headers, then cleaned up)
- [x] Manual Spamhaus refresh via `bad-actors-update.service`: 1,709+ entries applied, nginx reloaded cleanly
- [x] `alembic upgrade head` applied cleanly (new `httpbl_enabled`/`httpbl_api_key` columns)
- [x] http:BL lookup verified against Project Honeypot's official test address (127.1.1.1) — returned their documented canned response
- [x] `py_compile` on all changed Python files; Jinja template compiles and fully renders with a real settings object
- [x] `pytest tests/test_public_route_audit.py tests/test_api_field_fixes.py tests/test_auth_input_validation.py tests/test_public_pages_authz.py` — 33 passed
- [x] sudoers additions validated with `visudo -c` before installing (scoped to exact file paths / one exact systemctl command each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjhF9Jkoi5FoyFY6gqVVKt