### PR TITLE
Add Edge Defense analytics tab for nginx-level perimeter blocks

### DIFF
--- a/app_core/analytics/security_blocks.py
+++ b/app_core/analytics/security_blocks.py
@@ -1,0 +1,262 @@
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+"""
+
+from __future__ import annotations
+
+"""Edge Defense analytics: stats for requests nginx rejected before the app
+ever saw them.
+
+Three of EAS Station's protections happen entirely inside nginx --
+scanner-bait path rejection, the Spamhaus/local bad-actor IP blocklist, and
+per-IP rate limiting (see config/nginx-eas-station.conf) -- so none of them
+show up in WebRequestLog (web_traffic.py), which only ever sees requests
+Flask actually handled. This module gives that layer its own, much smaller
+event log, fed by tailing the nginx access log rather than in-process
+recording (there is no in-process hook to record from: the app never runs).
+
+scripts/ingest_security_perimeter_log.py (run every 2 minutes via
+security-perimeter-ingest.timer) calls ingest_new_events() to do the actual
+tailing; this module also holds the query helpers the "Edge Defense" tab on
+the Security Center page (webapp/admin/security_blocks.py) uses to render
+them.
+"""
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+from app_core.extensions import db
+from app_utils import utc_now
+
+LOG_PATH = "/var/log/nginx/eas-station-access.log"
+
+# Matches log_format eas_station_combined in config/nginx-eas-station.conf:
+#   $remote_addr - $remote_user [$time_local] "$request" $status
+#   $body_bytes_sent "$http_referer" "$http_user_agent" "$security_block_reason"
+_LOG_LINE_RE = re.compile(
+    r'^(?P<ip>\S+) \S+ \S+ \[(?P<time>[^\]]+)\] '
+    r'"(?P<method>[A-Za-z]+) (?P<path>\S+)(?: \S+)?" '
+    r'(?P<status>\d{3}) \S+ '
+    r'"[^"]*" "(?P<ua>[^"]*)" "(?P<reason>[^"]*)"\s*$'
+)
+_TIME_FMT = "%d/%b/%Y:%H:%M:%S %z"
+
+BLOCK_REASON_LABELS = {
+    "scanner_bait": "Scanner Bait",
+    "bad_actor_blocklist": "Bad Actor Blocklist",
+    "rate_limited": "Rate Limited",
+    "other_444": "Other (444)",
+}
+
+
+class SecurityPerimeterEvent(db.Model):
+    """A single request nginx rejected before it reached the application.
+
+    block_reason is one of BLOCK_REASON_LABELS' keys, derived by
+    _classify() from the response status plus (for a 444) the
+    $security_block_reason field nginx tagged the line with.
+    """
+
+    __tablename__ = "security_perimeter_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    occurred_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
+    ip_address = db.Column(db.String(64), nullable=False, index=True)
+    status_code = db.Column(db.Integer, nullable=False, index=True)
+    block_reason = db.Column(db.String(32), nullable=False, index=True)
+    method = db.Column(db.String(8), nullable=True)
+    path = db.Column(db.String(512), nullable=True, index=True)
+    user_agent = db.Column(db.String(512), nullable=True)
+    created_at = db.Column(db.DateTime(timezone=True), default=utc_now, nullable=False)
+
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "occurred_at": self.occurred_at.isoformat() if self.occurred_at else None,
+            "ip_address": self.ip_address,
+            "status_code": self.status_code,
+            "block_reason": self.block_reason,
+            "block_reason_label": BLOCK_REASON_LABELS.get(self.block_reason, self.block_reason),
+            "method": self.method,
+            "path": self.path,
+            "user_agent": self.user_agent,
+        }
+
+
+class SecurityPerimeterIngestState(db.Model):
+    """Single-row (id=1) checkpoint: how far into LOG_PATH we've read.
+
+    Keyed by inode rather than just byte offset so a logrotate rotation
+    (rename + fresh file, not copytruncate) is detected and read from the
+    top instead of seeking past the new, much-shorter file.
+    """
+
+    __tablename__ = "security_perimeter_ingest_state"
+
+    id = db.Column(db.Integer, primary_key=True)
+    log_inode = db.Column(db.BigInteger, nullable=False, default=0)
+    log_offset = db.Column(db.BigInteger, nullable=False, default=0)
+    updated_at = db.Column(db.DateTime(timezone=True), default=utc_now, onupdate=utc_now, nullable=False)
+
+
+def _classify(status: int, reason: str) -> Optional[str]:
+    """Map a log line's (status, $security_block_reason) to a block_reason,
+    or None if this line isn't a perimeter-defense event at all (the
+    overwhelming majority of lines -- ordinary 200s, 404s, etc.)."""
+    if status == 429:
+        return "rate_limited"
+    if status == 444:
+        return reason if reason in BLOCK_REASON_LABELS else "other_444"
+    return None
+
+
+def _parse_line(line: str):
+    match = _LOG_LINE_RE.match(line)
+    if not match:
+        return None
+    try:
+        status = int(match.group("status"))
+    except ValueError:
+        return None
+
+    reason = _classify(status, match.group("reason"))
+    if reason is None:
+        return None
+
+    try:
+        occurred_at = datetime.strptime(match.group("time"), _TIME_FMT)
+    except ValueError:
+        occurred_at = utc_now()
+
+    return SecurityPerimeterEvent(
+        occurred_at=occurred_at,
+        ip_address=match.group("ip"),
+        status_code=status,
+        block_reason=reason,
+        method=match.group("method")[:8],
+        path=match.group("path")[:512],
+        user_agent=(match.group("ua") or "")[:512],
+    )
+
+
+def ingest_new_events(log_path: str = LOG_PATH, batch_size: int = 2000) -> int:
+    """Tail *log_path* from the last checkpoint, insert any new perimeter-
+    defense events, and advance the checkpoint. Returns the number inserted.
+
+    Safe to call repeatedly and concurrently-adjacent (each run picks up
+    exactly where the last one's checkpoint left off); a still-being-written
+    partial final line is left for the next run rather than guessed at.
+    """
+    state = SecurityPerimeterIngestState.query.get(1)
+    if not state:
+        state = SecurityPerimeterIngestState(id=1, log_inode=0, log_offset=0)
+        db.session.add(state)
+        db.session.commit()
+
+    try:
+        file_stat = os.stat(log_path)
+    except FileNotFoundError:
+        return 0
+
+    offset = state.log_offset
+    if file_stat.st_ino != state.log_inode:
+        # First run, or the file was rotated (rename + fresh file) since we
+        # last checked -- read the new file from the top.
+        offset = 0
+
+    inserted = 0
+    batch: List[SecurityPerimeterEvent] = []
+    checkpoint = offset
+    with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+        f.seek(offset)
+        while True:
+            pos = f.tell()
+            line = f.readline()
+            if not line:
+                break
+            if not line.endswith("\n"):
+                break  # partial line still being written; retry next run
+            checkpoint = f.tell()
+            event = _parse_line(line)
+            if event is not None:
+                batch.append(event)
+                inserted += 1
+            if len(batch) >= batch_size:
+                db.session.bulk_save_objects(batch)
+                db.session.commit()
+                batch = []
+
+    if batch:
+        db.session.bulk_save_objects(batch)
+
+    state.log_inode = file_stat.st_ino
+    state.log_offset = checkpoint
+    db.session.commit()
+    return inserted
+
+
+def summary_counts(hours: int = 24) -> Dict[str, int]:
+    since = utc_now() - timedelta(hours=hours)
+    rows = (
+        db.session.query(SecurityPerimeterEvent.block_reason, db.func.count(SecurityPerimeterEvent.id))
+        .filter(SecurityPerimeterEvent.occurred_at >= since)
+        .group_by(SecurityPerimeterEvent.block_reason)
+        .all()
+    )
+    counts = {key: 0 for key in BLOCK_REASON_LABELS}
+    total = 0
+    for reason, count in rows:
+        counts[reason] = count
+        total += count
+    counts["total"] = total
+    return counts
+
+
+def top_ips(hours: int = 24, limit: int = 10) -> List[Dict]:
+    since = utc_now() - timedelta(hours=hours)
+    rows = (
+        db.session.query(SecurityPerimeterEvent.ip_address, db.func.count(SecurityPerimeterEvent.id))
+        .filter(SecurityPerimeterEvent.occurred_at >= since)
+        .group_by(SecurityPerimeterEvent.ip_address)
+        .order_by(db.func.count(SecurityPerimeterEvent.id).desc())
+        .limit(limit)
+        .all()
+    )
+    return [{"ip_address": ip, "count": count} for ip, count in rows]
+
+
+def top_paths(hours: int = 24, limit: int = 10) -> List[Dict]:
+    since = utc_now() - timedelta(hours=hours)
+    rows = (
+        db.session.query(SecurityPerimeterEvent.path, db.func.count(SecurityPerimeterEvent.id))
+        .filter(SecurityPerimeterEvent.occurred_at >= since)
+        .group_by(SecurityPerimeterEvent.path)
+        .order_by(db.func.count(SecurityPerimeterEvent.id).desc())
+        .limit(limit)
+        .all()
+    )
+    return [{"path": path, "count": count} for path, count in rows]
+
+
+def recent_events(limit: int = 50) -> List[Dict]:
+    rows = (
+        SecurityPerimeterEvent.query.order_by(SecurityPerimeterEvent.occurred_at.desc()).limit(limit).all()
+    )
+    return [r.to_dict() for r in rows]

--- a/app_core/migrations/versions/20260904_add_security_perimeter_events.py
+++ b/app_core/migrations/versions/20260904_add_security_perimeter_events.py
@@ -1,0 +1,81 @@
+"""Add security_perimeter_events and security_perimeter_ingest_state tables.
+
+Revision ID: 20260904_add_security_perimeter_events
+Revises: 20260904_add_httpbl_settings
+Create Date: 2026-09-04
+
+Backs the Security Center "Edge Defense" tab (app_core/analytics/
+security_blocks.py): requests nginx rejected before they ever reached the
+app (scanner-bait paths, the Spamhaus/local bad-actor blocklist, and rate
+limiting), fed by scripts/ingest_security_perimeter_log.py tailing the
+nginx access log. security_perimeter_ingest_state is a single-row (id=1)
+checkpoint of how far into that log the ingester has read.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "20260904_add_security_perimeter_events"
+down_revision = "20260904_add_httpbl_settings"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(table_name: str) -> bool:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade():
+    if not _table_exists("security_perimeter_events"):
+        op.create_table(
+            "security_perimeter_events",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("ip_address", sa.String(length=64), nullable=False),
+            sa.Column("status_code", sa.Integer(), nullable=False),
+            sa.Column("block_reason", sa.String(length=32), nullable=False),
+            sa.Column("method", sa.String(length=8), nullable=True),
+            sa.Column("path", sa.String(length=512), nullable=True),
+            sa.Column("user_agent", sa.String(length=512), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index(
+            "ix_security_perimeter_events_occurred_at",
+            "security_perimeter_events", ["occurred_at"],
+        )
+        op.create_index(
+            "ix_security_perimeter_events_ip_address",
+            "security_perimeter_events", ["ip_address"],
+        )
+        op.create_index(
+            "ix_security_perimeter_events_status_code",
+            "security_perimeter_events", ["status_code"],
+        )
+        op.create_index(
+            "ix_security_perimeter_events_block_reason",
+            "security_perimeter_events", ["block_reason"],
+        )
+        op.create_index(
+            "ix_security_perimeter_events_path",
+            "security_perimeter_events", ["path"],
+        )
+
+    if not _table_exists("security_perimeter_ingest_state"):
+        op.create_table(
+            "security_perimeter_ingest_state",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("log_inode", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("log_offset", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        )
+
+
+def downgrade():
+    if _table_exists("security_perimeter_ingest_state"):
+        op.drop_table("security_perimeter_ingest_state")
+    if _table_exists("security_perimeter_events"):
+        op.drop_table("security_perimeter_events")

--- a/app_core/models.py
+++ b/app_core/models.py
@@ -132,6 +132,8 @@ from ._models_displays import (
 # here so they register on the shared metadata and stay importable from
 # ``app_core.models`` like every other table.
 from app_core.analytics.web_traffic import TrafficAnalyticsSettings, WebRequestLog
+# Edge Defense (nginx-level perimeter blocks) analytics -- same reasoning.
+from app_core.analytics.security_blocks import SecurityPerimeterEvent, SecurityPerimeterIngestState
 
 # Wire the alert-correlation-ID auto-populate hook onto log-shaped tables.
 # Every INSERT to one of these tables made while a logging_context alert

--- a/config/nginx-eas-station.conf
+++ b/config/nginx-eas-station.conf
@@ -17,6 +17,11 @@ upstream eas_station_backend {
 # /login gets a much tighter cap to slow credential-stuffing.
 limit_req_zone $binary_remote_addr zone=eas_api:10m rate=20r/s;
 limit_req_zone $binary_remote_addr zone=eas_login:10m rate=5r/m;
+# 429 (Too Many Requests) rather than the module's 503 default -- 503 also
+# means "backend down" elsewhere in this config, and Edge Defense stats
+# (app_core/analytics/security_blocks.py) need to tell the two apart by
+# status code alone.
+limit_req_status 429;
 
 # Known-bad-actor IP blocklist. bad-actors-local.conf is checked into git,
 # hand-curated (see that file); bad-actors-auto.conf is regenerated daily
@@ -52,6 +57,18 @@ map "$bad_actor_switch:$bad_actor:$bad_actor_allow" $bad_actor_block {
     default 0;
     "1:1:0" 1;
 }
+
+# Same as nginx's built-in `combined` format, plus one trailing field:
+# $security_block_reason, set immediately before each perimeter-defense
+# `return` (empty for ordinary requests). Lets the Security Center "Edge
+# Defense" tab (app_core/analytics/security_blocks.py) tell scanner-bait
+# blocks apart from bad-actor-blocklist blocks even though both answer with
+# the same bare 444 -- and, combined with `limit_req_status 429` below,
+# tells a rate-limited request apart from a real backend 5xx.
+log_format eas_station_combined '$remote_addr - $remote_user [$time_local] '
+                                 '"$request" $status $body_bytes_sent '
+                                 '"$http_referer" "$http_user_agent" '
+                                 '"$security_block_reason"';
 
 # HTTP server - redirect to HTTPS
 server {
@@ -98,10 +115,16 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Default for the trailing access-log field (see log_format
+    # eas_station_combined above) -- overwritten right before each
+    # perimeter-defense `return` below.
+    set $security_block_reason "";
+
     # Reject known-bad-actor IPs before any location/proxy logic runs. See
     # the `geo $bad_actor` / `$bad_actor_block` blocks above for where this
     # comes from, the on/off switch, and the allowlist bypass.
     if ($bad_actor_block) {
+        set $security_block_reason "bad_actor_blocklist";
         return 444;
     }
 
@@ -157,6 +180,7 @@ server {
     # catch-all, which was rendering a full 29KB page for every one of these).
     # 444 is nginx-specific: close the connection with no response at all.
     location ~* (wp-admin|wp-login|wp-json|wp-content|wp-includes|wordpress|xmlrpc\.php|\.env|\.git/|phpmyadmin|/\.docker/|/cgi-bin/|\.php$) {
+        set $security_block_reason "scanner_bait";
         return 444;
     }
 
@@ -177,7 +201,7 @@ server {
     # Flood control: general per-IP cap on API traffic. burst=40 absorbs a
     # normal page's simultaneous polls (broadcast_state @1s, alerts @5s, etc.)
     # and short bursts on load; nodelay lets those through immediately rather
-    # than queuing, only excess above the burst gets 503'd. More specific
+    # than queuing, only excess above the burst gets 429'd. More specific
     # /api/... locations below (streaming, audio) still take precedence.
     location /api/ {
         limit_req zone=eas_api burst=40 nodelay;
@@ -370,6 +394,6 @@ server {
     }
 
     # Access and error logs
-    access_log /var/log/nginx/eas-station-access.log;
+    access_log /var/log/nginx/eas-station-access.log eas_station_combined;
     error_log /var/log/nginx/eas-station-error.log;
 }

--- a/install.sh
+++ b/install.sh
@@ -1319,6 +1319,21 @@ else
     echo_warning "systemd-journal group not found (systemd logs may not be accessible)"
 fi
 
+# Add service user to adm group so it can read nginx's access log (mode
+# 0640 www-data:adm) -- required by the security-perimeter-ingest timer
+# (app_core/analytics/security_blocks.py), which reads
+# eas-station-access.log to populate the Security Center "Edge Defense" tab.
+# adm is the conventional read-only log-access group on Debian; logrotate's
+# `create 0640 www-data adm` preserves this group ownership across rotation,
+# so this survives without any ongoing maintenance.
+echo_progress "Adding $SERVICE_USER to adm group for nginx log access..."
+if getent group adm >/dev/null 2>&1; then
+    usermod -a -G adm "$SERVICE_USER" 2>/dev/null || true
+    echo_success "adm group access configured"
+else
+    echo_warning "adm group not found (nginx access log may not be readable)"
+fi
+
 # Create installation directory
 echo_progress "Setting up installation directory: ${BOLD}$INSTALL_DIR${NC}"
 if [ ! -d "$INSTALL_DIR" ]; then
@@ -2481,6 +2496,10 @@ systemctl enable --now bad-actors-update.timer > /dev/null 2>&1 || \
     echo_warning "bad-actors-update.timer failed to enable"
 systemctl start bad-actors-update.service > /dev/null 2>&1 || \
     echo_warning "Initial known-bad-actor blocklist fetch failed (will retry on the daily timer)"
+# Edge Defense analytics (Security Center tab): tails the nginx access log
+# for the events the blocklist/scanner-bait/rate-limit rules above produce.
+systemctl enable --now security-perimeter-ingest.timer > /dev/null 2>&1 || \
+    echo_warning "security-perimeter-ingest.timer failed to enable"
 # Hardware subsystem units (Phase 4 split). The umbrella target Wants= these,
 # but transitively-wanted units don't get [Install] symlinks created — so
 # enable each one explicitly so they auto-start at boot independent of the

--- a/scripts/ingest_security_perimeter_log.py
+++ b/scripts/ingest_security_perimeter_log.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Tails /var/log/nginx/eas-station-access.log for perimeter-defense events
+(scanner-bait blocks, bad-actor-blocklist blocks, rate limiting) and writes
+new ones to the security_perimeter_events table, powering the Security
+Center "Edge Defense" tab. Run every 2 minutes by
+security-perimeter-ingest.timer (see systemd/); safe to run by hand.
+
+SKIP_DB_INIT is set before importing app.py so this doesn't also spin up
+every background worker (schedulers, pollers, etc.) just to do one tail-
+and-insert pass -- see app.py's own comment on that flag.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ["SKIP_DB_INIT"] = "1"
+
+from app import create_app  # noqa: E402
+from app_core.analytics.security_blocks import ingest_new_events  # noqa: E402
+
+
+def main() -> int:
+    app = create_app()
+    with app.app_context():
+        count = ingest_new_events()
+        print(f"ingest_security_perimeter_log: {count} new event(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/static/js/pages/security_center.js
+++ b/static/js/pages/security_center.js
@@ -48,6 +48,7 @@
         'malicious-tab': loadAttempts,
         'bans-tab': loadIPFilters,
         'fail2ban-tab': loadFail2banStatus,
+        'edge-tab': loadEdgeDefense,
         'checkup-tab': loadCheckupStatus,
     };
     const loadedTabs = new Set();
@@ -84,6 +85,7 @@
             '#malicious': 'malicious-tab',
             '#bans': 'bans-tab',
             '#fail2ban': 'fail2ban-tab',
+            '#edge': 'edge-tab',
             '#checkup': 'checkup-tab',
         };
         const tabId = map[window.location.hash];
@@ -755,6 +757,97 @@
             .catch(error => notify('Error applying fix: ' + error, true));
     }
 
+    /* -------------------------------------------------------------- */
+    /* Edge Defense (nginx-level perimeter blocks)                     */
+    /* -------------------------------------------------------------- */
+
+    function loadEdgeDefense() {
+        fetch('/admin/security/edge-defense/summary')
+            .then(response => response.json())
+            .then(data => {
+                if (!data.success) throw new Error(data.error || 'Unknown error');
+                displayEdgeMetrics(data);
+                displayEdgeTopIps(data.top_ips_24h);
+                displayEdgeTopPaths(data.top_paths_24h);
+                displayEdgeRecentEvents(data.recent_events);
+            })
+            .catch(error => {
+                console.error('Error loading edge defense summary:', error);
+                document.getElementById('edge-metrics').innerHTML =
+                    '<span class="text-danger small">Error loading Edge Defense stats</span>';
+            });
+    }
+
+    function edgeMetricTile(label, value, badgeClass) {
+        return `
+            <div class="col-6 col-md-3">
+                <div class="p-2">
+                    <div class="h3 mb-0"><span class="admin-badge ${badgeClass}">${esc(String(value))}</span></div>
+                    <div class="small text-muted">${esc(label)}</div>
+                </div>
+            </div>`;
+    }
+
+    function displayEdgeMetrics(data) {
+        const c = data.counts_24h || {};
+        const blocklistState = data.blocklist_enabled ? 'admin-badge-success' : 'admin-badge-muted';
+        document.getElementById('edge-metrics').innerHTML =
+            edgeMetricTile('Scanner Bait Blocks', c.scanner_bait || 0, 'admin-badge-danger') +
+            edgeMetricTile('Bad Actor Blocklist Blocks', c.bad_actor_blocklist || 0, 'admin-badge-danger') +
+            edgeMetricTile('Rate Limited', c.rate_limited || 0, 'admin-badge-warning') +
+            `<div class="col-6 col-md-3">
+                <div class="p-2">
+                    <div class="h3 mb-0"><span class="admin-badge ${blocklistState}">${esc(String(data.blocklist_entry_count || 0))}</span></div>
+                    <div class="small text-muted">Blocklist Entries (${data.blocklist_enabled ? 'enabled' : 'disabled'})</div>
+                </div>
+            </div>`;
+    }
+
+    function displayEdgeTopIps(rows) {
+        const el = document.getElementById('edge-top-ips');
+        if (!rows || rows.length === 0) {
+            el.innerHTML = '<p class="text-center text-muted small mb-0">No blocked requests in the last 24 hours.</p>';
+            return;
+        }
+        el.innerHTML = '<table class="table table-sm mb-0"><tbody>' + rows.map(r => `
+            <tr>
+                <td class="admin-mono-badge">${esc(r.ip_address)}</td>
+                <td class="text-end">${esc(String(r.count))}</td>
+            </tr>`).join('') + '</tbody></table>';
+    }
+
+    function displayEdgeTopPaths(rows) {
+        const el = document.getElementById('edge-top-paths');
+        if (!rows || rows.length === 0) {
+            el.innerHTML = '<p class="text-center text-muted small mb-0">No blocked requests in the last 24 hours.</p>';
+            return;
+        }
+        el.innerHTML = '<table class="table table-sm mb-0"><tbody>' + rows.map(r => `
+            <tr>
+                <td><code>${esc(r.path)}</code></td>
+                <td class="text-end">${esc(String(r.count))}</td>
+            </tr>`).join('') + '</tbody></table>';
+    }
+
+    function displayEdgeRecentEvents(events) {
+        const el = document.getElementById('edge-recent-events');
+        if (!events || events.length === 0) {
+            el.innerHTML = '<p class="text-center text-muted small mb-0">No blocked requests recorded yet.</p>';
+            return;
+        }
+        el.innerHTML = '<div class="table-responsive"><table class="table table-sm mb-0"><thead><tr>' +
+            '<th>Time</th><th>IP</th><th>Reason</th><th>Method</th><th>Path</th></tr></thead><tbody>' +
+            events.map(e => `
+                <tr>
+                    <td data-label="Time">${esc(new Date(e.occurred_at).toLocaleString())}</td>
+                    <td data-label="IP" class="admin-mono-badge">${esc(e.ip_address)}</td>
+                    <td data-label="Reason"><span class="admin-badge admin-badge-danger">${esc(e.block_reason_label)}</span></td>
+                    <td data-label="Method">${esc(e.method || '')}</td>
+                    <td data-label="Path"><code>${esc(e.path || '')}</code></td>
+                </tr>`).join('') +
+            '</tbody></table></div>';
+    }
+
     // Export only the handlers referenced by inline onclick=.
     window.SC = {
         loadAttempts: loadAttempts,
@@ -775,5 +868,6 @@
         sshUnban: sshUnban,
         loadCheckupStatus: loadCheckupStatus,
         fixCheckupItem: fixCheckupItem,
+        loadEdgeDefense: loadEdgeDefense,
     };
 })();

--- a/systemd/security-perimeter-ingest.service
+++ b/systemd/security-perimeter-ingest.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ingest nginx perimeter-defense events into the Edge Defense dashboard
+After=network.target postgresql.service
+
+[Service]
+Type=oneshot
+User=eas-station
+Group=eas-station
+WorkingDirectory=/opt/eas-station
+Environment="PATH=/opt/eas-station/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PYTHONPATH=/opt/eas-station"
+EnvironmentFile=/opt/eas-station/.env
+ExecStart=/opt/eas-station/venv/bin/python3 /opt/eas-station/scripts/ingest_security_perimeter_log.py
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/security-perimeter-ingest.timer
+++ b/systemd/security-perimeter-ingest.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ingest nginx perimeter-defense events every 2 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=2min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/templates/security/security_center.html
+++ b/templates/security/security_center.html
@@ -135,6 +135,12 @@
             </button>
         </li>
         <li class="nav-item" role="presentation">
+            <button class="nav-link" id="edge-tab" data-bs-toggle="tab"
+                    data-bs-target="#edge-pane" type="button" role="tab">
+                <i class="fas fa-shield-halved"></i> Edge Defense
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
             <button class="nav-link" id="checkup-tab" data-bs-toggle="tab"
                     data-bs-target="#checkup-pane" type="button" role="tab">
                 <i class="fas fa-stethoscope"></i> Checkup
@@ -386,6 +392,57 @@
                         together rather than leaving a permanent entry behind.</p>
                     <div id="f2b-ssh-banned-list">
                         <p class="text-muted mb-0">No SSH bans.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ============ EDGE DEFENSE TAB ============ -->
+        <div class="tab-pane fade" id="edge-pane" role="tabpanel" aria-labelledby="edge-tab">
+            <div class="container">
+                <div class="admin-warning-box mb-3">
+                    <h3 class="mb-1 h5"><i class="fas fa-shield-halved"></i> Requests nginx rejected before the app ever saw them</h3>
+                    <p class="mb-0">Scanner-bait paths (<code>wp-admin</code>, <code>.env</code>, etc.), the
+                    Spamhaus/local <a href="/admin/application/#badActorsCard">bad-actor IP blocklist</a>, and
+                    per-IP rate limiting are all enforced by nginx itself -- these never reach the application, so
+                    they don't appear in Traffic or the Global Ban List above. Updated every ~2 minutes.</p>
+                </div>
+
+                <div class="admin-accent-card accent-danger mb-3">
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
+                        <h2 class="mb-0 h4"><i class="fas fa-chart-column"></i> Last 24 Hours</h2>
+                        <button class="btn btn-sm btn-secondary" onclick="SC.loadEdgeDefense()">
+                            <i class="fas fa-sync-alt"></i> Refresh
+                        </button>
+                    </div>
+                    <div id="edge-metrics" class="row g-2 text-center">
+                        <span class="text-muted small">Loading…</span>
+                    </div>
+                </div>
+
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <div class="admin-accent-card accent-danger h-100">
+                            <h2 class="mb-2 h5"><i class="fas fa-globe"></i> Top Blocked IPs (24h)</h2>
+                            <div id="edge-top-ips">
+                                <p class="text-center text-muted small">Loading…</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="admin-accent-card accent-danger h-100">
+                            <h2 class="mb-2 h5"><i class="fas fa-route"></i> Top Blocked Paths (24h)</h2>
+                            <div id="edge-top-paths">
+                                <p class="text-center text-muted small">Loading…</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="admin-accent-card accent-danger mb-4">
+                    <h2 class="mb-2 h4"><i class="fas fa-list"></i> Recent Events</h2>
+                    <div id="edge-recent-events">
+                        <p class="text-center text-muted small">Loading…</p>
                     </div>
                 </div>
             </div>

--- a/update.sh
+++ b/update.sh
@@ -975,6 +975,12 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
             echo_warning "Initial known-bad-actor blocklist fetch failed (will retry on the daily timer)"
     fi
 
+    # Edge Defense analytics (Security Center tab): tails the nginx access
+    # log for the events the blocklist/scanner-bait/rate-limit rules above
+    # produce. enable --now is idempotent, same as its neighbors above.
+    systemctl enable --now security-perimeter-ingest.timer >/dev/null 2>&1 || \
+        echo_warning "security-perimeter-ingest.timer failed to enable"
+
     # Give the subsystems a beat to come up before we judge the target.
     sleep 2
     if systemctl is-active --quiet eas-station-hardware.target; then
@@ -1078,6 +1084,19 @@ if [ -d "$INSTALL_DIR/systemd" ]; then
         echo_success "Hardware access groups configured (created $GROUPS_CREATED new groups)"
     else
         echo_success "Hardware access groups configured (all groups already existed)"
+    fi
+
+    # Add service user to adm group so it can read nginx's access log (mode
+    # 0640 www-data:adm) -- required by the security-perimeter-ingest timer,
+    # which reads eas-station-access.log to populate the Security Center
+    # "Edge Defense" tab. A deployment updating into this feature for the
+    # first time won't have this membership yet; usermod is idempotent.
+    echo_progress "Adding $SERVICE_USER to adm group for nginx log access..."
+    if getent group adm >/dev/null 2>&1; then
+        usermod -a -G adm "$SERVICE_USER" 2>/dev/null || true
+        echo_success "adm group access configured"
+    else
+        echo_warning "adm group not found (nginx access log may not be readable)"
     fi
 
     # Apply Argon ONE V5 config.txt settings if the Argon daemon is installed but the

--- a/webapp/admin/__init__.py
+++ b/webapp/admin/__init__.py
@@ -60,6 +60,7 @@ from .mail_server import register_mail_server_routes
 from .ntp_server import register_ntp_server_routes
 from .fail2ban import register_fail2ban_routes
 from .bad_actors import register_bad_actors_routes
+from .edge_defense import register_edge_defense_routes
 from .security_checkup import register_security_checkup_routes
 from .firewall import register_firewall_routes
 from .eas_decoder_monitor import register_blueprint as register_eas_decoder_monitor_routes
@@ -118,6 +119,7 @@ def register(app, logger):
     register_ntp_server_routes(app, logger)  # LAN NTP server (chrony allow + firewall) management
     register_fail2ban_routes(app, logger)  # fail2ban host-level intrusion banning
     register_bad_actors_routes(app, logger)  # nginx-level Spamhaus known-bad-actor blocklist
+    register_edge_defense_routes(app, logger)  # Security Center "Edge Defense" tab analytics
     register_security_checkup_routes(app, logger)  # Security Center "Checkup" tab (UFW/fail2ban gap detection)
     register_firewall_routes(app, logger)  # Consolidated firewall rule management (baseline, NTP, Icecast)
     register_eas_decoder_monitor_routes(app)  # EAS decoder audio monitor settings

--- a/webapp/admin/edge_defense.py
+++ b/webapp/admin/edge_defense.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""
+EAS Station - Emergency Alert System
+Copyright (c) 2025-2026 EAS Station, LLC (KR8MER)
+
+This file is part of EAS Station.
+
+EAS Station is dual-licensed software:
+- GNU Affero General Public License v3 (AGPL-3.0) for open-source use
+- Commercial License for proprietary use
+
+You should have received a copy of both licenses with this software.
+For more information, see LICENSE and LICENSE-COMMERCIAL files.
+
+IMPORTANT: This software cannot be rebranded or have attribution removed.
+See NOTICE file for complete terms.
+
+Repository: https://github.com/KR8MER/eas-station
+
+Edge Defense tab (Security Center): stats for requests nginx rejected
+before they ever reached the app. Read-only -- configuring these
+protections (the blocklist toggle/allowlist) lives on the "Bad Actor
+Blocklist" panel in Application Settings (webapp/admin/bad_actors.py),
+whose entry-count/last-updated helpers this reuses so the tab can show
+blocklist size without a second round trip.
+"""
+
+from flask import Blueprint, jsonify
+
+from app_core.auth.decorators import require_auth
+from app_core.auth.roles import require_permission
+from app_core.analytics.security_blocks import summary_counts, top_ips, top_paths, recent_events
+from webapp.admin.bad_actors import _list_meta, _read_switch_enabled, AUTO_LIST_PATH, LOCAL_LIST_PATH
+
+edge_defense_bp = Blueprint("edge_defense", __name__, url_prefix="/admin/security/edge-defense")
+
+
+@edge_defense_bp.route("/summary", methods=["GET"])
+@require_auth
+@require_permission("logs.view")
+def summary():
+    auto_meta = _list_meta(AUTO_LIST_PATH)
+    local_meta = _list_meta(LOCAL_LIST_PATH)
+    return jsonify({
+        "success": True,
+        "counts_24h": summary_counts(hours=24),
+        "counts_7d": summary_counts(hours=24 * 7),
+        "top_ips_24h": top_ips(hours=24, limit=10),
+        "top_paths_24h": top_paths(hours=24, limit=10),
+        "recent_events": recent_events(limit=30),
+        "blocklist_enabled": _read_switch_enabled(),
+        "blocklist_entry_count": auto_meta["entry_count"] + local_meta["entry_count"],
+    })
+
+
+def register_edge_defense_routes(app, logger_):
+    app.register_blueprint(edge_defense_bp)
+    logger_.info("Edge Defense analytics routes registered")


### PR DESCRIPTION
## Summary
- Scanner-bait blocking, the Spamhaus bad-actor blocklist, and rate limiting (all added in #2567) happen entirely inside nginx, before a request reaches Flask -- so none of it was visible anywhere in the UI, only via SSH + hand-parsing raw logs.
- nginx now tags each perimeter-defense response with a reason (`$security_block_reason`, appended to a new log format) and uses `429` instead of the ambiguous default `503` for rate-limited requests, so a lightweight tailer can classify every blocked request correctly.
- A 2-minute systemd timer ingests new log lines into a small `security_perimeter_events` table (rotation-safe checkpoint by inode+offset).
- New **Edge Defense** tab on the Security Center page: 24h counts by reason, top blocked IPs/paths, recent events, current blocklist size/state.
- `eas-station` added to the `adm` group (install.sh + update.sh) so it can read the nginx access log at all -- it wasn't previously.

## Test plan
- [x] `nginx -t` clean after the log-format/status-code changes; live-verified all three block reasons tag correctly (`scanner_bait`, `bad_actor_blocklist`, empty for normal traffic) via temporary test entries, cleaned up after
- [x] `alembic upgrade head` applied cleanly
- [x] Ran the ingester manually: correctly parsed and stored real log lines, correctly classified by reason
- [x] Re-ran the ingester: 0 new events (checkpoint advancing correctly, no duplicate ingestion)
- [x] Verified `adm` group grant gives `eas-station` read access to the log (previously denied)
- [x] `py_compile` on all changed/new Python files
- [x] Full authenticated request test (Flask test client, real admin session): `/admin/security/edge-defense/summary` returns correct JSON; `/security/center` renders the full page including the new tab
- [x] `pytest tests/test_public_route_audit.py tests/test_api_field_fixes.py tests/test_auth_input_validation.py tests/test_public_pages_authz.py` -- 33 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjhF9Jkoi5FoyFY6gqVVKt